### PR TITLE
Refactor streaming architecture to use PostgreSQL LISTEN/NOTIFY with shared cache

### DIFF
--- a/src/components/docker/ContainerRow.tsx
+++ b/src/components/docker/ContainerRow.tsx
@@ -1,9 +1,9 @@
-import type { ContainerStatsWithRates } from '../../types/docker';
+import type { ContainerStatsDisplay } from '../../types/docker';
 import { formatAsPercent, formatBytes, formatBitsSIUnits } from '../../formatters/metrics';
 import { MetricCell } from '../shared-table';
 
 interface ContainerRowProps {
-  container: ContainerStatsWithRates;
+  container: ContainerStatsDisplay;
 }
 
 export default function ContainerRow({ container }: ContainerRowProps) {

--- a/src/components/docker/ContainerTable.tsx
+++ b/src/components/docker/ContainerTable.tsx
@@ -1,7 +1,7 @@
 import { useCallback } from 'react';
 import ContainerRow from './ContainerRow';
-import { streamAllDockerContainerStats } from '@/data/docker.functions';
-import type { ContainerStatsWithRates } from '@/types/docker';
+import { streamDockerStatsFromDB } from '@/data/docker.functions';
+import type { ContainerStatsDisplay, DockerStatsFromDB } from '@/types/docker';
 import StreamingTable, { type ColumnDef } from '../shared-table/StreamingTable';
 
 const columns: ColumnDef[] = [
@@ -14,11 +14,11 @@ const columns: ColumnDef[] = [
   { label: 'Network TX (Mbps)', align: 'right' },
 ];
 
-type DockerState = Map<string, ContainerStatsWithRates>;
+type DockerState = Map<string, ContainerStatsDisplay>;
 
 export default function ContainerTable() {
   const onData = useCallback(
-    (prev: DockerState, stat: ContainerStatsWithRates): DockerState => {
+    (prev: DockerState, stat: DockerStatsFromDB): DockerState => {
       const next = new Map(prev);
       next.set(stat.id, stat);
       return next;
@@ -35,11 +35,11 @@ export default function ContainerTable() {
   );
 
   return (
-    <StreamingTable<ContainerStatsWithRates, DockerState>
+    <StreamingTable<DockerStatsFromDB, DockerState>
       title="Docker Containers Dashboard"
       ariaLabel="docker containers table"
       columns={columns}
-      streamFn={streamAllDockerContainerStats}
+      streamFn={streamDockerStatsFromDB}
       initialState={new Map()}
       onData={onData}
       renderRows={renderRows}

--- a/src/components/zfs/ZFSPoolsTable.tsx
+++ b/src/components/zfs/ZFSPoolsTable.tsx
@@ -1,9 +1,10 @@
 import { useCallback } from 'react';
-import { streamZFSIOStat } from '@/data/zfs.functions';
-import type { ZFSHierarchy, ZFSIOStatWithRates } from '@/types/zfs';
+import { streamZFSStatsFromDB } from '@/data/zfs.functions';
+import type { ZFSHierarchy } from '@/types/zfs';
 import { buildHierarchy } from '@/lib/utils/zfs-hierarchy-builder';
 import ZFSPoolAccordion from './ZFSPoolAccordion';
 import StreamingTable, { type ColumnDef } from '../shared-table/StreamingTable';
+import type { ZFSStatsFromDB } from '@/lib/transformers/zfs-transformer';
 
 const columns: ColumnDef[] = [
   { label: 'Pool / Device', width: '30%' },
@@ -16,8 +17,9 @@ const columns: ColumnDef[] = [
 ];
 
 export default function ZFSPoolsTable() {
+
   const onData = useCallback(
-    (_prev: ZFSHierarchy, cycleStats: ZFSIOStatWithRates[]): ZFSHierarchy => {
+    (_prev: ZFSHierarchy, cycleStats: ZFSStatsFromDB[]): ZFSHierarchy => {
       return buildHierarchy(cycleStats);
     },
     [],
@@ -32,11 +34,11 @@ export default function ZFSPoolsTable() {
   );
 
   return (
-    <StreamingTable<ZFSIOStatWithRates[], ZFSHierarchy>
+    <StreamingTable<ZFSStatsFromDB[], ZFSHierarchy>
       title="ZFS Pools Dashboard"
       ariaLabel="zfs pools table"
       columns={columns}
-      streamFn={streamZFSIOStat}
+      streamFn={streamZFSStatsFromDB}
       initialState={new Map()}
       onData={onData}
       renderRows={renderRows}

--- a/src/data/docker.functions.tsx
+++ b/src/data/docker.functions.tsx
@@ -1,73 +1,64 @@
-import { createServerFn } from '@tanstack/react-start'
-import Dockerode from 'dockerode';
-import { streamToAsyncIterator, mergeAsyncIterables } from '../lib/stream-utils';
-import { DockerRateCalculator } from '../lib/rate-calculator';
-import { dockerMiddleware } from '../middleware/docker-middleware';
+import { createServerFn } from '@tanstack/react-start';
+import type { DockerStatsFromDB } from '@/lib/transformers/docker-transformer';
 
-const rateCalculator = new DockerRateCalculator();
+/**
+ * Stream Docker stats from the database via PostgreSQL LISTEN/NOTIFY.
+ * Uses the shared stats cache updated by the subscription service.
+ */
+export const streamDockerStatsFromDB = createServerFn()
+  .handler(async function* (): AsyncGenerator<DockerStatsFromDB> {
+    // Dynamic imports to avoid bundling server-only code into client
+    // Also initializes server-side shutdown handlers
+    await import('@/lib/server-init');
+    const { subscriptionService } = await import('@/lib/database/subscription-service');
+    const { statsCache } = await import('@/lib/cache/stats-cache');
 
-export const getServerTime = createServerFn().handler(async () => {
-  return new Date().toISOString();
-});
+    // Ensure subscription service is running
+    await subscriptionService.start();
 
-export const getDockerContainers = createServerFn().middleware([dockerMiddleware]).handler(async ({ context }) => {
-  const containers = await context.docker.listContainers({ all: true });
-  return containers;
-})
+    // Yield initial state from cache
+    const initialStats = statsCache.getDocker();
+    for (const stat of initialStats) {
+      yield stat;
+    }
 
-export const streamAllDockerContainerStats = createServerFn()
-  .middleware([dockerMiddleware])
-  .handler(async function* ({ context }) {
-    const docker = context.docker;
-    const streams: any[] = [];
+    // Wait for updates and yield new stats
+    while (true) {
+      await new Promise<void>(resolve => {
+        const handler = (source: string) => {
+          if (source === 'docker') {
+            subscriptionService.removeListener('stats_update', handler);
+            resolve();
+          }
+        };
+        subscriptionService.on('stats_update', handler);
+      });
 
-    try {
-      const containers = await docker.listContainers({ all: false });
-
-      if (containers.length === 0) {
-        return;
+      // Yield all stats from the updated cache
+      const stats = statsCache.getDocker();
+      for (const stat of stats) {
+        yield stat;
       }
-
-      const containerStreams = containers.map(async function* (containerInfo) {
-        const containerName = containerInfo.Names[0]?.replace(/^\//, '') || containerInfo.Id.substring(0, 12);
-
-        const container = docker.getContainer(containerInfo.Id);
-        const statsStream = await container.stats({ stream: true });
-        streams.push(statsStream);
-
-        try {
-          for await (const stats of streamToAsyncIterator<Dockerode.ContainerStats>(statsStream)) {
-            const statsWithRates = rateCalculator.calculate(
-              containerInfo.Id,
-              {
-                containerId: containerInfo.Id,
-                containerName,
-                stats,
-              }
-            );
-            yield statsWithRates;
-          }
-        } finally {
-          if (statsStream && typeof (statsStream as any).destroy === 'function') {
-            (statsStream as any).destroy();
-          }
-        }
-      });
-
-      yield* mergeAsyncIterables(containerStreams);
-    } finally {
-      streams.forEach(stream => {
-        if (stream && typeof stream.destroy === 'function') {
-          stream.destroy();
-        }
-      });
-      rateCalculator.clear();
     }
   });
 
-export const getDockerContainerStats = createServerFn().middleware([dockerMiddleware])
-  .inputValidator((data: { containerId: string }) => data)
-  .handler(async ({ data, context }) => {
-    const container = context.docker.getContainer(data.containerId);
-    return await container.stats({ stream: false });
+/**
+ * Get list of active Docker containers from the database.
+ */
+export const getActiveDockerContainers = createServerFn()
+  .handler(async (): Promise<string[]> => {
+    const { subscriptionService } = await import('@/lib/database/subscription-service');
+    const { statsCache } = await import('@/lib/cache/stats-cache');
+
+    await subscriptionService.start();
+    return Array.from(statsCache.getAllDocker().keys());
+  });
+
+/**
+ * Check if Docker data in cache is stale (no updates for 30+ seconds)
+ */
+export const isDockerDataStale = createServerFn()
+  .handler(async (): Promise<boolean> => {
+    const { statsCache } = await import('@/lib/cache/stats-cache');
+    return statsCache.isDockerStale();
   });

--- a/src/lib/cache/stats-cache.ts
+++ b/src/lib/cache/stats-cache.ts
@@ -1,0 +1,123 @@
+import type { DockerStatsFromDB } from '@/lib/transformers/docker-transformer';
+import type { ZFSStatsFromDB } from '@/lib/transformers/zfs-transformer';
+import { filterVisibleZFSStats, sortZFSStats } from '@/lib/transformers/zfs-transformer';
+
+/**
+ * Server-side cache for stats from the database.
+ * Shared across all frontend connections to avoid duplicate DB queries.
+ *
+ * Updated by the SubscriptionService when NOTIFY is received.
+ * Read by server functions to yield data to frontends.
+ */
+class StatsCache {
+  private docker: Map<string, DockerStatsFromDB> = new Map();
+  private zfs: Map<string, ZFSStatsFromDB> = new Map();
+  private lastDockerUpdate: Date | null = null;
+  private lastZFSUpdate: Date | null = null;
+
+  /**
+   * Update Docker stats in the cache
+   */
+  updateDocker(stats: Map<string, DockerStatsFromDB>): void {
+    this.docker = stats;
+    this.lastDockerUpdate = new Date();
+  }
+
+  /**
+   * Update ZFS stats in the cache
+   */
+  updateZFS(stats: Map<string, ZFSStatsFromDB>): void {
+    this.zfs = stats;
+    this.lastZFSUpdate = new Date();
+  }
+
+  /**
+   * Get all Docker stats, optionally filtered by entity IDs
+   */
+  getDocker(entities?: string[]): DockerStatsFromDB[] {
+    if (!entities || entities.length === 0) {
+      return Array.from(this.docker.values());
+    }
+
+    const entitySet = new Set(entities);
+    return Array.from(this.docker.values()).filter(s => entitySet.has(s.id));
+  }
+
+  /**
+   * Get ZFS stats filtered by visibility state.
+   * All pools are always returned; vdevs/disks are filtered based on expansion state.
+   * Results are sorted in hierarchy order for buildHierarchy().
+   */
+  getZFS(expandedPools?: string[], expandedVdevs?: string[]): ZFSStatsFromDB[] {
+    // If no expansion state provided, return all stats sorted
+    if (!expandedPools && !expandedVdevs) {
+      return sortZFSStats(Array.from(this.zfs.values()));
+    }
+
+    // filterVisibleZFSStats already sorts the results
+    return filterVisibleZFSStats(this.zfs, expandedPools, expandedVdevs);
+  }
+
+  /**
+   * Get the full ZFS stats map (for internal use by subscription service)
+   */
+  getAllZFS(): Map<string, ZFSStatsFromDB> {
+    return this.zfs;
+  }
+
+  /**
+   * Get the full Docker stats map (for internal use by subscription service)
+   */
+  getAllDocker(): Map<string, DockerStatsFromDB> {
+    return this.docker;
+  }
+
+  /**
+   * Check if Docker data is stale (no update for more than 30 seconds)
+   */
+  isDockerStale(): boolean {
+    if (!this.lastDockerUpdate) return true;
+    return Date.now() - this.lastDockerUpdate.getTime() > 30000;
+  }
+
+  /**
+   * Check if ZFS data is stale (no update for more than 30 seconds)
+   */
+  isZFSStale(): boolean {
+    if (!this.lastZFSUpdate) return true;
+    return Date.now() - this.lastZFSUpdate.getTime() > 30000;
+  }
+
+  /**
+   * Check if any data is stale
+   */
+  isStale(): boolean {
+    return this.isDockerStale() || this.isZFSStale();
+  }
+
+  /**
+   * Get last update timestamps
+   */
+  getLastUpdateTimes(): { docker: Date | null; zfs: Date | null } {
+    return {
+      docker: this.lastDockerUpdate,
+      zfs: this.lastZFSUpdate,
+    };
+  }
+
+  /**
+   * Clear all cached data
+   */
+  clear(): void {
+    this.docker.clear();
+    this.zfs.clear();
+    this.lastDockerUpdate = null;
+    this.lastZFSUpdate = null;
+  }
+}
+
+/**
+ * Singleton instance of the stats cache.
+ * Shared across all server function invocations.
+ */
+export const statsCache = new StatsCache();

--- a/src/lib/database/subscription-service.ts
+++ b/src/lib/database/subscription-service.ts
@@ -1,0 +1,255 @@
+import { Client, type ClientConfig } from 'pg';
+import { EventEmitter } from 'events';
+import { loadDatabaseConfig } from '@/lib/config/database-config';
+import { StatsRepository } from '@/lib/database/repositories/stats-repository';
+import { statsCache } from '@/lib/cache/stats-cache';
+import { transformDockerStats } from '@/lib/transformers/docker-transformer';
+import { transformZFSStats } from '@/lib/transformers/zfs-transformer';
+import { databaseConnectionManager, type DatabaseConfig } from '@/lib/clients/database-client';
+
+/** Events emitted by the subscription service */
+export interface SubscriptionServiceEvents {
+  stats_update: (source: 'docker' | 'zfs') => void;
+  error: (error: Error) => void;
+  connected: () => void;
+  disconnected: () => void;
+}
+
+/**
+ * Singleton service that maintains a LISTEN connection to PostgreSQL
+ * and updates the stats cache when NOTIFY is received.
+ *
+ * Usage:
+ *   await subscriptionService.start();
+ *   subscriptionService.on('stats_update', (source) => { ... });
+ */
+class SubscriptionService extends EventEmitter {
+  private client: Client | null = null;
+  private repository: StatsRepository | null = null;
+  private config: DatabaseConfig | null = null;
+  private isRunning = false;
+  private startPromise: Promise<void> | null = null;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+  private reconnectAttempts = 0;
+  private readonly maxReconnectAttempts = 10;
+  private readonly baseReconnectDelay = 1000; // 1 second
+
+  /**
+   * Start the subscription service.
+   * Connects to PostgreSQL, sets up LISTEN, and begins processing notifications.
+   * Safe to call concurrently - subsequent calls await the first startup.
+   */
+  async start(): Promise<void> {
+    if (this.isRunning) {
+      return;
+    }
+
+    // If startup is in progress, await it
+    if (this.startPromise) {
+      return this.startPromise;
+    }
+
+    // Start and store the promise so concurrent calls can await it
+    this.startPromise = this.doStart();
+
+    try {
+      await this.startPromise;
+    } finally {
+      this.startPromise = null;
+    }
+  }
+
+  private async doStart(): Promise<void> {
+    try {
+      this.config = loadDatabaseConfig();
+      await this.connect();
+      this.isRunning = true;
+      this.reconnectAttempts = 0;
+    } catch (err) {
+      console.error('[SubscriptionService] Failed to start:', err);
+      throw err;
+    }
+  }
+
+  private async connect(): Promise<void> {
+    if (!this.config) {
+      throw new Error('Config not loaded');
+    }
+
+    // Create a dedicated client for LISTEN (not from the pool)
+    const clientConfig: ClientConfig = {
+      host: this.config.host,
+      port: this.config.port,
+      database: this.config.database,
+      user: this.config.user,
+      password: this.config.password,
+    };
+
+    if (this.config.ssl) {
+      clientConfig.ssl = { rejectUnauthorized: false };
+    }
+
+    this.client = new Client(clientConfig);
+
+    // Handle errors on the connection
+    this.client.on('error', err => {
+      console.error('[SubscriptionService] Client error:', err);
+      this.emit('error', err);
+      this.scheduleReconnect();
+    });
+
+    // Handle connection end
+    this.client.on('end', () => {
+      console.log('[SubscriptionService] Connection ended');
+      this.emit('disconnected');
+      if (this.isRunning) {
+        this.scheduleReconnect();
+      }
+    });
+
+    // Handle notifications
+    this.client.on('notification', async msg => {
+      if (msg.channel === 'stats_update') {
+        const source = msg.payload as 'docker' | 'zfs';
+        await this.handleNotification(source);
+      }
+    });
+
+    // Connect
+    await this.client.connect();
+    console.log('[SubscriptionService] Connected to PostgreSQL');
+
+    // Subscribe to notifications
+    await this.client.query('LISTEN stats_update');
+    console.log('[SubscriptionService] Listening for stats_update notifications');
+
+    // Get a repository for querying
+    const dbClient = await databaseConnectionManager.getClient(this.config);
+    this.repository = new StatsRepository(dbClient.getPool());
+
+    // Load initial data into cache
+    await this.loadInitialData();
+
+    this.emit('connected');
+  }
+
+  private async loadInitialData(): Promise<void> {
+    if (!this.repository) return;
+
+    try {
+      // Load Docker stats
+      const dockerRows = await this.repository.getLatestStats({ sourceName: 'docker' });
+      statsCache.updateDocker(transformDockerStats(dockerRows));
+      console.log(`[SubscriptionService] Loaded ${dockerRows.length} Docker stat rows into cache`);
+
+      // Load ZFS stats
+      const zfsRows = await this.repository.getLatestStats({ sourceName: 'zfs' });
+      statsCache.updateZFS(transformZFSStats(zfsRows));
+      console.log(`[SubscriptionService] Loaded ${zfsRows.length} ZFS stat rows into cache`);
+    } catch (err) {
+      console.error('[SubscriptionService] Failed to load initial data:', err);
+    }
+  }
+
+  private async handleNotification(source: 'docker' | 'zfs'): Promise<void> {
+    if (!this.repository) return;
+
+    try {
+      const rows = await this.repository.getLatestStats({ sourceName: source });
+
+      if (source === 'docker') {
+        statsCache.updateDocker(transformDockerStats(rows));
+      } else if (source === 'zfs') {
+        statsCache.updateZFS(transformZFSStats(rows));
+      }
+
+      // Emit event for server functions to yield to frontends
+      this.emit('stats_update', source);
+    } catch (err) {
+      console.error(`[SubscriptionService] Failed to handle notification for ${source}:`, err);
+      this.emit('error', err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (this.reconnectTimer) {
+      return; // Already scheduled
+    }
+
+    if (this.reconnectAttempts >= this.maxReconnectAttempts) {
+      console.error('[SubscriptionService] Max reconnect attempts reached, giving up');
+      this.isRunning = false;
+      return;
+    }
+
+    const delay = Math.min(
+      this.baseReconnectDelay * Math.pow(2, this.reconnectAttempts),
+      30000 // Max 30 seconds
+    );
+
+    console.log(
+      `[SubscriptionService] Scheduling reconnect in ${delay}ms (attempt ${this.reconnectAttempts + 1})`
+    );
+
+    this.reconnectTimer = setTimeout(async () => {
+      this.reconnectTimer = null;
+      this.reconnectAttempts++;
+
+      try {
+        await this.cleanup();
+        await this.connect();
+        this.reconnectAttempts = 0; // Reset on successful connect
+      } catch (err) {
+        console.error('[SubscriptionService] Reconnect failed:', err);
+        this.scheduleReconnect();
+      }
+    }, delay);
+  }
+
+  private async cleanup(): Promise<void> {
+    if (this.client) {
+      try {
+        await this.client.end();
+      } catch {
+        // Ignore errors during cleanup
+      }
+      this.client = null;
+    }
+  }
+
+  /**
+   * Stop the subscription service.
+   * Closes the connection and cleans up resources.
+   */
+  async stop(): Promise<void> {
+    this.isRunning = false;
+
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
+    await this.cleanup();
+    console.log('[SubscriptionService] Stopped');
+  }
+
+  /**
+   * Check if the service is currently running and connected
+   */
+  isConnected(): boolean {
+    return this.isRunning && this.client !== null;
+  }
+
+  /**
+   * Get the stats cache (for access from server functions)
+   */
+  getCache(): typeof statsCache {
+    return statsCache;
+  }
+}
+
+/**
+ * Singleton instance of the subscription service.
+ * Use this to subscribe to stats updates from anywhere in the server.
+ */
+export const subscriptionService = new SubscriptionService();

--- a/src/lib/server-init.ts
+++ b/src/lib/server-init.ts
@@ -1,0 +1,41 @@
+import { subscriptionService } from '@/lib/database/subscription-service';
+import { databaseConnectionManager } from '@/lib/clients/database-client';
+
+let initialized = false;
+
+/**
+ * Initialize server-side resources and set up shutdown handlers.
+ * This is idempotent - safe to call multiple times.
+ */
+export function initServer(): void {
+  if (initialized) return;
+  initialized = true;
+
+  const shutdown = async () => {
+    console.log('[Server] Shutdown signal received, cleaning up...');
+
+    try {
+      // Stop the subscription service (closes LISTEN connection)
+      await subscriptionService.stop();
+
+      // Close database connection pool
+      await databaseConnectionManager.closeAll();
+
+      console.log('[Server] Cleanup complete');
+      process.exit(0);
+    } catch (err) {
+      console.error('[Server] Error during cleanup:', err);
+      process.exit(1);
+    }
+  };
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+
+  console.log('[Server] Shutdown handlers registered');
+}
+
+// Auto-initialize when this module is imported on the server
+if (typeof window === 'undefined') {
+  initServer();
+}

--- a/src/lib/transformers/docker-transformer.ts
+++ b/src/lib/transformers/docker-transformer.ts
@@ -1,0 +1,90 @@
+import type { LatestStatRow } from '@/lib/database/repositories/stats-repository';
+
+/**
+ * Docker stats reconstructed from database rows.
+ * Contains only the fields stored in DB that the frontend needs.
+ */
+export interface DockerStatsFromDB {
+  id: string;
+  name: string;
+  timestamp: Date;
+  rates: {
+    cpuPercent: number;
+    memoryPercent: number;
+    networkRxBytesPerSec: number;
+    networkTxBytesPerSec: number;
+    blockIoReadBytesPerSec: number;
+    blockIoWriteBytesPerSec: number;
+  };
+  memory_stats: {
+    usage: number;
+    limit: number;
+  };
+}
+
+/** Map of stat type name to the field path in DockerStatsFromDB */
+const DOCKER_TYPE_MAP: Record<string, (stats: DockerStatsFromDB, value: number) => void> = {
+  cpu_percent: (s, v) => (s.rates.cpuPercent = v),
+  memory_usage: (s, v) => (s.memory_stats.usage = v),
+  memory_limit: (s, v) => (s.memory_stats.limit = v),
+  memory_percent: (s, v) => (s.rates.memoryPercent = v),
+  network_rx_bytes_per_sec: (s, v) => (s.rates.networkRxBytesPerSec = v),
+  network_tx_bytes_per_sec: (s, v) => (s.rates.networkTxBytesPerSec = v),
+  block_io_read_bytes_per_sec: (s, v) => (s.rates.blockIoReadBytesPerSec = v),
+  block_io_write_bytes_per_sec: (s, v) => (s.rates.blockIoWriteBytesPerSec = v),
+};
+
+/**
+ * Creates an empty DockerStatsFromDB object with default values
+ */
+function createEmptyDockerStats(entityId: string): DockerStatsFromDB {
+  return {
+    id: entityId,
+    name: entityId.substring(0, 12), // Docker short ID format
+    timestamp: new Date(),
+    rates: {
+      cpuPercent: 0,
+      memoryPercent: 0,
+      networkRxBytesPerSec: 0,
+      networkTxBytesPerSec: 0,
+      blockIoReadBytesPerSec: 0,
+      blockIoWriteBytesPerSec: 0,
+    },
+    memory_stats: {
+      usage: 0,
+      limit: 0,
+    },
+  };
+}
+
+/**
+ * Transform flat database rows into DockerStatsFromDB objects.
+ * Groups rows by entity (container ID) and maps type names to object fields.
+ *
+ * @param rows - Latest stat rows from the database
+ * @returns Map of container ID to stats object
+ */
+export function transformDockerStats(rows: LatestStatRow[]): Map<string, DockerStatsFromDB> {
+  const result = new Map<string, DockerStatsFromDB>();
+
+  for (const row of rows) {
+    let stats = result.get(row.entity);
+    if (!stats) {
+      stats = createEmptyDockerStats(row.entity);
+      result.set(row.entity, stats);
+    }
+
+    // Update timestamp to the most recent
+    if (row.timestamp > stats.timestamp) {
+      stats.timestamp = row.timestamp;
+    }
+
+    // Apply the value to the appropriate field
+    const setter = DOCKER_TYPE_MAP[row.type];
+    if (setter) {
+      setter(stats, row.value);
+    }
+  }
+
+  return result;
+}

--- a/src/lib/transformers/zfs-transformer.ts
+++ b/src/lib/transformers/zfs-transformer.ts
@@ -1,0 +1,177 @@
+import type { LatestStatRow } from '@/lib/database/repositories/stats-repository';
+import type { ZFSIOStatWithRates } from '@/types/zfs';
+
+/**
+ * ZFS stats reconstructed from database rows.
+ * Uses the same type as direct streaming since we store all needed fields.
+ */
+export type ZFSStatsFromDB = ZFSIOStatWithRates;
+
+/** Map of stat type name to the field setter in ZFSStatsFromDB */
+const ZFS_TYPE_MAP: Record<string, (stats: ZFSStatsFromDB, value: number) => void> = {
+  capacity_alloc: (s, v) => (s.capacity.alloc = v),
+  capacity_free: (s, v) => (s.capacity.free = v),
+  read_ops_per_sec: (s, v) => (s.rates.readOpsPerSec = v),
+  write_ops_per_sec: (s, v) => (s.rates.writeOpsPerSec = v),
+  read_bytes_per_sec: (s, v) => (s.rates.readBytesPerSec = v),
+  write_bytes_per_sec: (s, v) => (s.rates.writeBytesPerSec = v),
+  utilization_percent: (s, v) => (s.rates.utilizationPercent = v),
+};
+
+/**
+ * Determines the hierarchy level and indent from an entity path.
+ * - "poolname" → pool, indent 0
+ * - "poolname/vdevname" → vdev, indent 2
+ * - "poolname/vdevname/diskname" → disk, indent 4
+ */
+function parseEntityPath(entityPath: string): { name: string; indent: number } {
+  const parts = entityPath.split('/');
+
+  if (parts.length === 1) {
+    // Pool: just the pool name
+    return { name: parts[0], indent: 0 };
+  } else if (parts.length === 2) {
+    // Vdev: pool/vdev
+    return { name: parts[1], indent: 2 };
+  } else {
+    // Disk: pool/vdev/disk (or deeper)
+    return { name: parts[parts.length - 1], indent: 4 };
+  }
+}
+
+/**
+ * Creates an empty ZFSStatsFromDB object with default values
+ */
+function createEmptyZFSStats(entityPath: string): ZFSStatsFromDB {
+  const { name, indent } = parseEntityPath(entityPath);
+
+  return {
+    id: entityPath,
+    name,
+    indent,
+    timestamp: Date.now(),
+    capacity: { alloc: 0, free: 0 },
+    operations: { read: 0, write: 0 },
+    bandwidth: { read: 0, write: 0 },
+    total: { readOps: 0, writeOps: 0, readBytes: 0, writeBytes: 0 },
+    rates: {
+      readOpsPerSec: 0,
+      writeOpsPerSec: 0,
+      readBytesPerSec: 0,
+      writeBytesPerSec: 0,
+      utilizationPercent: 0,
+    },
+  };
+}
+
+/**
+ * Compare function to sort ZFS stats in hierarchy order for buildHierarchy().
+ * Sorts by full entity path to keep parent-child relationships together:
+ *   "backup", "backup/raidz1-0", "backup/raidz1-0/sda", "tank", "tank/mirror-0", etc.
+ *
+ * This is critical because buildHierarchy() processes items sequentially and
+ * expects children to immediately follow their parents.
+ */
+function compareZFSStats(a: ZFSStatsFromDB, b: ZFSStatsFromDB): number {
+  return a.id.localeCompare(b.id);
+}
+
+/**
+ * Sort ZFS stats array in hierarchy order for buildHierarchy().
+ * Returns a new sorted array.
+ */
+export function sortZFSStats(stats: ZFSStatsFromDB[]): ZFSStatsFromDB[] {
+  return [...stats].sort(compareZFSStats);
+}
+
+/**
+ * Transform flat database rows into ZFSStatsFromDB objects.
+ * Reconstructs hierarchy from entity paths and orders correctly for buildHierarchy().
+ *
+ * @param rows - Latest stat rows from the database
+ * @returns Map of entity path to stats object
+ */
+export function transformZFSStats(rows: LatestStatRow[]): Map<string, ZFSStatsFromDB> {
+  const result = new Map<string, ZFSStatsFromDB>();
+
+  for (const row of rows) {
+    let stats = result.get(row.entity);
+    if (!stats) {
+      stats = createEmptyZFSStats(row.entity);
+      result.set(row.entity, stats);
+    }
+
+    // Update timestamp to the most recent
+    const rowTimestamp = row.timestamp.getTime();
+    if (rowTimestamp > stats.timestamp) {
+      stats.timestamp = rowTimestamp;
+    }
+
+    // Apply the value to the appropriate field
+    const setter = ZFS_TYPE_MAP[row.type];
+    if (setter) {
+      setter(stats, row.value);
+    }
+
+    // Also set operations to match rates (they're the same for rate-based stats)
+    stats.operations.read = stats.rates.readOpsPerSec;
+    stats.operations.write = stats.rates.writeOpsPerSec;
+    stats.bandwidth.read = stats.rates.readBytesPerSec;
+    stats.bandwidth.write = stats.rates.writeBytesPerSec;
+  }
+
+  return result;
+}
+
+/**
+ * Transform and return as array sorted in hierarchy order.
+ * This is the format expected by buildHierarchy().
+ *
+ * @param rows - Latest stat rows from the database
+ * @returns Array of stats sorted by hierarchy (pools, then vdevs, then disks)
+ */
+export function transformZFSStatsToArray(rows: LatestStatRow[]): ZFSStatsFromDB[] {
+  const statsMap = transformZFSStats(rows);
+  return Array.from(statsMap.values()).sort(compareZFSStats);
+}
+
+/**
+ * Filters ZFS stats based on visibility state.
+ *
+ * @param allStats - All ZFS stats from the cache
+ * @param expandedPools - Set of pool names that are expanded
+ * @param expandedVdevs - Set of vdev paths (pool/vdev) that are expanded
+ * @returns Filtered stats that should be visible to the client
+ */
+export function filterVisibleZFSStats(
+  allStats: Map<string, ZFSStatsFromDB>,
+  expandedPools?: string[],
+  expandedVdevs?: string[]
+): ZFSStatsFromDB[] {
+  const expandedPoolsSet = new Set(expandedPools ?? []);
+  const expandedVdevsSet = new Set(expandedVdevs ?? []);
+  const visible: ZFSStatsFromDB[] = [];
+
+  for (const [entityPath, stats] of allStats) {
+    const parts = entityPath.split('/');
+
+    if (parts.length === 1) {
+      // Pool: always visible
+      visible.push(stats);
+    } else if (parts.length === 2) {
+      // Vdev: visible if parent pool is expanded
+      const poolName = parts[0];
+      if (expandedPoolsSet.has(poolName)) {
+        visible.push(stats);
+      }
+    } else {
+      // Disk: visible if parent vdev is expanded
+      const vdevPath = parts.slice(0, 2).join('/');
+      if (expandedVdevsSet.has(vdevPath)) {
+        visible.push(stats);
+      }
+    }
+  }
+
+  return visible.sort(compareZFSStats);
+}

--- a/src/types/docker.ts
+++ b/src/types/docker.ts
@@ -10,3 +10,23 @@ export interface DockerContainer {
 }
 
 export type { ContainerStatsWithRates } from '../lib/rate-calculator';
+
+/**
+ * Common interface for container stats that works with both
+ * direct streaming (ContainerStatsWithRates) and database-backed streaming (DockerStatsFromDB)
+ */
+export interface ContainerStatsDisplay {
+  id: string;
+  name: string;
+  rates: {
+    cpuPercent: number;
+    memoryPercent: number;
+    networkRxBytesPerSec: number;
+    networkTxBytesPerSec: number;
+    blockIoReadBytesPerSec: number;
+    blockIoWriteBytesPerSec: number;
+  };
+}
+
+// Re-export the DB type for convenience
+export type { DockerStatsFromDB } from '../lib/transformers/docker-transformer';

--- a/src/worker/collectors/base-collector.ts
+++ b/src/worker/collectors/base-collector.ts
@@ -135,7 +135,6 @@ export abstract class BaseCollector implements AsyncDisposable {
 
     try {
       await this.repository.insertRawStats(this.batch);
-      console.log(`[${this.name}] Flushed ${this.batch.length} stats to database`);
       this.batch = [];
     } catch (err) {
       console.error(`[${this.name}] Failed to flush batch:`, err);


### PR DESCRIPTION
## Summary

This PR refactors the streaming architecture to eliminate duplicate database connections and improve scalability. Instead of each frontend connection making its own queries to the database, the system now uses a single PostgreSQL LISTEN connection with a shared server-side cache.

## Architecture Changes

### New Components

- **Stats Cache** (`src/lib/cache/stats-cache.ts`): Singleton cache shared across all frontend connections, stores latest Docker and ZFS stats in memory
- **Subscription Service** (`src/lib/database/subscription-service.ts`): Maintains a single LISTEN connection to PostgreSQL, updates cache on NOTIFY events, handles automatic reconnection with exponential backoff
- **Transformers** (`src/lib/transformers/`): Convert flat database rows (EAV model) into domain objects
  - `docker-transformer.ts`: Transforms Docker stats from DB rows to `DockerStatsFromDB` objects
  - `zfs-transformer.ts`: Transforms ZFS stats from DB rows to `ZFSStatsFromDB` objects, handles hierarchical entity paths
- **Server Init** (`src/lib/server-init.ts`): Graceful shutdown handlers for LISTEN connection and database pools

### Modified Components

- **Data Functions** (`src/data/*.functions.tsx`): Simplified to read from cache instead of direct DB queries
  - `streamDockerStatsFromDB()`: Yields from cache on NOTIFY
  - `streamZFSStatsFromDB()`: Yields from cache on NOTIFY
  - Uses dynamic imports to avoid bundling server-only modules into client
- **Worker Collectors**: Enhanced ZFS collector to write hierarchical entity paths
- **Stats Repository**: Added NOTIFY trigger after INSERT to stats_raw table
- **Streaming Components**: Added stale data warnings when no NOTIFY received for 30+ seconds

## Data Flow
