### PR TITLE
fix: Docker container icons not applying from frontend

### DIFF
--- a/src/components/docker/ContainerRow.tsx
+++ b/src/components/docker/ContainerRow.tsx
@@ -1,6 +1,7 @@
 import { memo, useMemo, useRef, useState, useEffect } from 'react';
 import { ChevronRight, Settings } from 'lucide-react';
 import Tooltip from '@mui/joy/Tooltip';
+import { useQueryClient } from '@tanstack/react-query';
 import type { DockerStatsFromDB, DockerStatsRow } from '@/types/docker';
 import { formatAsPercentParts, formatBytesParts, formatBitsSIUnitsParts } from '../../formatters/metrics';
 import { MetricValue } from '../shared-table';
@@ -10,7 +11,7 @@ import SparklineChart from './SparklineChart';
 import IconPickerDialog from './IconPickerDialog';
 import { getIconUrl, FALLBACK_ICON_URL } from '@/lib/utils/icon-resolver';
 import { updateContainerIcon } from '@/data/docker.functions';
-import { DOCKER_GRID } from './ContainerTable';
+import { DOCKER_GRID, DOCKER_ENTITY_ICONS_QUERY_KEY } from './ContainerTable';
 
 /** Chart data point derived from wide rows */
 interface ChartDataPoint {
@@ -35,6 +36,7 @@ export default memo(function ContainerRow({ container, chartData }: ContainerRow
   const { showSparklines } = general;
   const expanded = isContainerExpanded(container.id);
 
+  const queryClient = useQueryClient();
   const [iconPickerOpen, setIconPickerOpen] = useState(false);
   const [iconError, setIconError] = useState(false);
   const [isPulsing, setIsPulsing] = useState(false);
@@ -44,6 +46,7 @@ export default memo(function ContainerRow({ container, chartData }: ContainerRow
 
   const handleIconSelect = async (iconSlug: string) => {
     await updateContainerIcon({ data: { entityId: container.id, iconSlug } });
+    await queryClient.invalidateQueries({ queryKey: DOCKER_ENTITY_ICONS_QUERY_KEY });
   };
 
   // Get last update timestamp from most recent chart data

--- a/src/components/docker/ContainerTable.tsx
+++ b/src/components/docker/ContainerTable.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { useWindowVirtualizer } from '@tanstack/react-virtual';
 import { useSettings } from '@/hooks/useSettings';
 import { Box, Chip, CircularProgress, Sheet, Typography } from '@mui/joy';
@@ -9,6 +10,9 @@ import { buildDockerHierarchy, rowToDockerStats } from '@/lib/utils/docker-hiera
 import { formatAsPercentParts, formatBytesParts, formatBitsSIUnitsParts } from '@/formatters/metrics';
 import { MetricValue, MetricHeader } from '../shared-table';
 import ContainerRow from './ContainerRow';
+import { getDockerEntityIcons } from '@/data/docker.functions';
+
+export const DOCKER_ENTITY_ICONS_QUERY_KEY = ['docker-entity-icons'] as const;
 
 type FlatRow =
   | { type: 'host'; host: HostStats; totalHosts: number }
@@ -39,14 +43,22 @@ export default function ContainerTable({
 }: ContainerTableProps) {
   const { docker, isHostExpanded, isContainerExpanded } = useSettings();
 
+  const { data: entityIcons } = useQuery({
+    queryKey: DOCKER_ENTITY_ICONS_QUERY_KEY,
+    queryFn: () => getDockerEntityIcons(),
+    staleTime: Infinity,
+  });
+
   // Convert latest rows to DockerStatsFromDB and build hierarchy
   const hierarchy = useMemo<DockerHierarchy>(() => {
     const stats: DockerStatsFromDB[] = [];
     for (const row of latestByEntity.values()) {
-      stats.push(rowToDockerStats(row));
+      const entityId = `${row.host}/${row.container_id}`;
+      const icon = entityIcons?.[entityId] ?? null;
+      stats.push(rowToDockerStats(row, icon));
     }
     return buildDockerHierarchy(stats);
-  }, [latestByEntity]);
+  }, [latestByEntity, entityIcons]);
 
   // Build per-entity chart data index
   const chartDataByEntity = useMemo(() => {

--- a/src/data/docker.functions.tsx
+++ b/src/data/docker.functions.tsx
@@ -33,6 +33,29 @@ export const getHistoricalDockerStats = createServerFn()
     }
   });
 
+/**
+ * Get all persisted icon slugs for Docker containers.
+ * Returns a plain object mapping entity ID → icon slug.
+ */
+export const getDockerEntityIcons = createServerFn()
+  .handler(async (): Promise<Record<string, string>> => {
+    try {
+      const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+      const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+      const { StatsRepository } = await import('@/lib/database/repositories/stats-repository');
+
+      const config = loadDatabaseConfig();
+      const dbClient = await databaseConnectionManager.getClient(config);
+      const repo = new StatsRepository(dbClient.getPool());
+
+      const iconsMap = await repo.getSourceIcons('docker');
+      return Object.fromEntries(iconsMap);
+    } catch (err) {
+      console.error('[getDockerEntityIcons] Failed to fetch entity icons:', err);
+      return {};
+    }
+  });
+
 const updateContainerIconSchema = z.object({
   entityId: z.string().min(1),
   iconSlug: z.string().min(1),

--- a/src/lib/database/repositories/stats-repository.ts
+++ b/src/lib/database/repositories/stats-repository.ts
@@ -177,6 +177,20 @@ export class StatsRepository {
     );
   }
 
+  async getSourceIcons(source: string): Promise<Map<string, string>> {
+    const result = await this.pool.query(
+      `SELECT entity, value
+       FROM entity_metadata
+       WHERE source = $1 AND key = 'icon'`,
+      [source]
+    );
+    const icons = new Map<string, string>();
+    for (const row of result.rows as { entity: string; value: string }[]) {
+      icons.set(row.entity, row.value);
+    }
+    return icons;
+  }
+
   async getEntityMetadata(
     source: string,
     entities: string[]


### PR DESCRIPTION
## Summary

- Icons were being saved to `entity_metadata` correctly but **never loaded back** — `rowToDockerStats()` always received `null` for the icon parameter, so user-set icons had no effect
- Added `getSourceIcons(source)` to `StatsRepository` — fetches all `icon` keys for a source in one query
- Added `getDockerEntityIcons` server function returning `Record<entityId, iconSlug>`
- `ContainerTable` now fetches icons via `useQuery(['docker-entity-icons'])` with `staleTime: Infinity` and passes them into `rowToDockerStats()` during hierarchy build
- `ContainerRow` invalidates the query after a successful `updateContainerIcon` call so the new icon renders immediately without a page reload

## Test plan

- [ ] Set an icon on a container — verify it appears immediately after the picker closes
- [ ] Reload the page — verify the icon persists
- [ ] Set icons on multiple containers across multiple hosts — verify each container shows its correct icon
- [ ] Container with no custom icon — verify auto-detection by image name still works as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker containers now display custom icons for enhanced visual identification.
  * Icons are dynamically fetched and efficiently cached for improved performance.
  * Icon data automatically syncs when container changes are made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->