### PR TITLE
refactor: extract generic bulkInsert helper for StatsRepository

### DIFF
--- a/src/lib/database/repositories/stats-repository.ts
+++ b/src/lib/database/repositories/stats-repository.ts
@@ -3,9 +3,11 @@ import type { DockerStatsRow } from '@/types/docker';
 import type { ProxmoxStatsRow } from '@/types/proxmox';
 import type { ZFSStatsRow } from '@/types/zfs';
 
+type PgArrayType = 'timestamptz' | 'text' | 'int' | 'bigint' | 'float8' | 'boolean';
+
 interface ColumnSpec {
   name: string;
-  sqlType: string;
+  sqlType: PgArrayType;
 }
 
 /**
@@ -35,6 +37,11 @@ async function bulkInsert<T>(
   const paramArrays: unknown[][] = columns.map(() => []);
   for (const row of rows) {
     const values = mapper(row);
+    if (values.length !== columns.length) {
+      throw new Error(
+        `[StatsRepository] Column/value mismatch for ${table}: expected ${columns.length} values, got ${values.length}`,
+      );
+    }
     for (let i = 0; i < columns.length; i++) {
       paramArrays[i].push(values[i]);
     }


### PR DESCRIPTION
## Summary
- Replaced 3 repetitive insert methods (`insertDockerStats` 56 lines, `insertZFSStats` 60 lines, `insertProxmoxStats` 78 lines) with a single generic `bulkInsert()` helper + column spec constants
- Each insert method reduced from 50-78 lines to ~6 lines
- Net -67 lines of boilerplate

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` passes (all 1078 tests)
- [ ] Verify Docker/ZFS/Proxmox stats ingestion still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)