### PR TITLE
refactor(proxmox): extract helpers and add WithNode<T> utility type

### DIFF
--- a/src/lib/clients/__tests__/proxmox-client.test.ts
+++ b/src/lib/clients/__tests__/proxmox-client.test.ts
@@ -387,6 +387,28 @@ describe('flattenPerNodeResults', () => {
     expect(result.containers[0].vmid).toBe(200);
   });
 
+  it('should keep VMs and containers with template=0', () => {
+    const perNodeResults = [
+      {
+        node: 'pve1',
+        vms: [
+          { vmid: 100, name: 'vm1', status: 'running', template: 0 },
+        ] as any[],
+        containers: [
+          { vmid: 200, name: 'ct1', status: 'running', template: 0 },
+        ] as any[],
+        storages: [],
+      },
+    ];
+
+    const result = flattenPerNodeResults(perNodeResults);
+
+    expect(result.vms).toHaveLength(1);
+    expect(result.vms[0].vmid).toBe(100);
+    expect(result.containers).toHaveLength(1);
+    expect(result.containers[0].vmid).toBe(200);
+  });
+
   it('should handle empty input', () => {
     const result = flattenPerNodeResults([]);
     expect(result.vms).toHaveLength(0);
@@ -425,6 +447,24 @@ describe('calculateClusterTotals', () => {
     expect(totals.stoppedVMs).toBe(1);
     expect(totals.runningContainers).toBe(1);
     expect(totals.stoppedContainers).toBe(1);
+  });
+
+  it('should count non-running statuses (paused, suspended) as stopped', () => {
+    const nodes = [
+      { node: 'pve1', status: 'online', cpu: 0, maxcpu: 4, mem: 0, maxmem: 8e9, disk: 0, maxdisk: 100e9, uptime: 3600, type: 'node', id: 'node/pve1' },
+    ] as any[];
+
+    const vms = [
+      { vmid: 100, status: 'running', node: 'pve1' },
+      { vmid: 101, status: 'paused', node: 'pve1' },
+      { vmid: 102, status: 'suspended', node: 'pve1' },
+      { vmid: 103, status: 'stopped', node: 'pve1' },
+    ] as any[];
+
+    const totals = calculateClusterTotals(nodes, vms, []);
+
+    expect(totals.runningVMs).toBe(1);
+    expect(totals.stoppedVMs).toBe(3);
   });
 
   it('should handle empty arrays', () => {

--- a/src/lib/clients/proxmox-client.ts
+++ b/src/lib/clients/proxmox-client.ts
@@ -7,6 +7,7 @@ import type {
   ProxmoxContainer,
   ProxmoxStorage,
   ProxmoxClusterOverview,
+  WithNode,
 } from '../../types/proxmox';
 
 // Covers both Bun's native fetch (`tls`) and Node.js-compat/undici fetch (`dispatcher`)
@@ -27,9 +28,9 @@ interface PerNodeResult {
  * Filters out template VMs and containers.
  */
 export function flattenPerNodeResults(perNodeResults: PerNodeResult[]): {
-  vms: (ProxmoxVM & { node: string })[];
-  containers: (ProxmoxContainer & { node: string })[];
-  storages: (ProxmoxStorage & { node: string })[];
+  vms: WithNode<ProxmoxVM>[];
+  containers: WithNode<ProxmoxContainer>[];
+  storages: WithNode<ProxmoxStorage>[];
 } {
   const vms = perNodeResults.flatMap((r) =>
     r.vms
@@ -52,8 +53,8 @@ export function flattenPerNodeResults(perNodeResults: PerNodeResult[]): {
  */
 export function calculateClusterTotals(
   nodes: ProxmoxNode[],
-  allVMs: (ProxmoxVM & { node: string })[],
-  allContainers: (ProxmoxContainer & { node: string })[]
+  allVMs: WithNode<ProxmoxVM>[],
+  allContainers: WithNode<ProxmoxContainer>[]
 ): ProxmoxClusterOverview['totals'] {
   const totalCpu = nodes.reduce((sum, n) => sum + n.maxcpu, 0);
   const usedCpu = nodes.reduce((sum, n) => sum + n.cpu * n.maxcpu, 0);

--- a/src/lib/utils/proxmox-overview-builder.ts
+++ b/src/lib/utils/proxmox-overview-builder.ts
@@ -5,6 +5,7 @@ import type {
   ProxmoxContainer,
   ProxmoxStorage,
   ProxmoxStatsRow,
+  WithNode,
 } from '@/types/proxmox';
 
 /**
@@ -64,7 +65,7 @@ export function buildProxmoxOverview(
   }));
 
   // Reconstruct VMs
-  const vms: (ProxmoxVM & { node: string })[] = vmRows.map((r) => ({
+  const vms: WithNode<ProxmoxVM>[] = vmRows.map((r) => ({
     vmid: r.vmid ?? 0,
     name: r.entity_name ?? '',
     status: (r.status ?? 'stopped') as 'running' | 'stopped' | 'paused' | 'suspended',
@@ -83,7 +84,7 @@ export function buildProxmoxOverview(
   }));
 
   // Reconstruct containers
-  const containers: (ProxmoxContainer & { node: string })[] = containerRows.map((r) => ({
+  const containers: WithNode<ProxmoxContainer>[] = containerRows.map((r) => ({
     vmid: r.vmid ?? 0,
     name: r.entity_name ?? '',
     status: (r.status ?? 'stopped') as 'running' | 'stopped',
@@ -105,7 +106,7 @@ export function buildProxmoxOverview(
   }));
 
   // Reconstruct storages
-  const storages: (ProxmoxStorage & { node: string })[] = storageRows.map((r) => ({
+  const storages: WithNode<ProxmoxStorage>[] = storageRows.map((r) => ({
     storage: r.entity_name ?? '',
     type: r.storage_type ?? '',
     content: r.storage_content ?? '',

--- a/src/types/proxmox.ts
+++ b/src/types/proxmox.ts
@@ -172,15 +172,18 @@ export interface ProxmoxStatsRow {
   cluster_version: number | null;
 }
 
+/** A Proxmox entity enriched with its source node name */
+export type WithNode<T> = T & { node: string };
+
 /** Aggregated cluster overview for the dashboard */
 export interface ProxmoxClusterOverview {
   clusterName: string;
   quorate: boolean;
   version: number;
   nodes: ProxmoxNode[];
-  vms: (ProxmoxVM & { node: string })[];
-  containers: (ProxmoxContainer & { node: string })[];
-  storages: (ProxmoxStorage & { node: string })[];
+  vms: WithNode<ProxmoxVM>[];
+  containers: WithNode<ProxmoxContainer>[];
+  storages: WithNode<ProxmoxStorage>[];
   totals: {
     totalCpu: number;
     usedCpu: number;


### PR DESCRIPTION
## Summary
- Extracted `flattenPerNodeResults()` from `getClusterOverview()` to handle template filtering and node attribution as a standalone helper
- Extracted `calculateClusterTotals()` from `getClusterOverview()` to handle resource aggregation (CPU, memory, disk) and running/stopped VM counts
- Introduced `WithNode<T>` generic utility type to replace 11 repeated `& { node: string }` intersection patterns across `proxmox.ts`, `proxmox-client.ts`, and `proxmox-overview-builder.ts`
- Added dedicated test suites for both helpers with thorough coverage including edge cases:
  - `template: 0` (Proxmox's "not a template" value) is correctly kept via falsy coercion
  - Non-running statuses (`paused`, `suspended`) are counted as stopped

## Test plan
- [x] Verify `flattenPerNodeResults()` correctly filters templates and attributes nodes
- [x] Verify `template: 0` VMs/containers are preserved (not filtered)
- [x] Verify `calculateClusterTotals()` correctly aggregates resources and counts running/stopped VMs
- [x] Verify paused/suspended VMs count as stopped
- [x] Confirm `getClusterOverview()` behavior is unchanged after refactor
- [x] All tests pass, typecheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized cluster resource aggregation and totals computation logic for improved code maintainability and clarity.

* **Tests**
  * Added comprehensive test coverage for cluster overview functionality, including per-node resource aggregation, template filtering for virtual machines and containers, capacity totals calculation, and validation of running versus stopped status counts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->