### PR TITLE
refactor: extract helpers from handleLogStream to reduce nesting

### DIFF
--- a/agent/src/routes/logs.ts
+++ b/agent/src/routes/logs.ts
@@ -1,6 +1,86 @@
 import type { Readable } from 'node:stream';
 import type Dockerode from 'dockerode';
 
+/** Shared mutable state for a single SSE log session. */
+interface LogStreamContext {
+  closed: boolean;
+  readonly encoder: TextEncoder;
+  logStream: Readable | null;
+  readonly controller: ReadableStreamDefaultController<Uint8Array>;
+}
+
+/** Enqueue an SSE message, silently swallowing enqueue-after-close TypeError. */
+function sendLogSSE(ctx: LogStreamContext, data: string, event?: string): void {
+  if (ctx.closed) return;
+  try {
+    const prefix = event ? `event: ${event}\n` : '';
+    ctx.controller.enqueue(ctx.encoder.encode(`${prefix}data: ${data}\n\n`));
+  } catch (err) {
+    if (!(err instanceof TypeError)) console.error('Unexpected error enqueuing log line:', err);
+  }
+}
+
+/** Enqueue a JSON error payload as an SSE error event. */
+function sendLogErrorSSE(ctx: LogStreamContext, error: string): void {
+  sendLogSSE(ctx, JSON.stringify({ error }), 'error');
+}
+
+/**
+ * Wire up `data`, `end`, and `error` event listeners on a Docker log stream.
+ *
+ * Parses incoming chunks using the appropriate parser (TTY vs multiplexed) and
+ * forwards parsed log lines as SSE data events. Closes the stream on end or error.
+ *
+ * @param ctx - The shared log stream context
+ * @param logStream - The Node.js Readable stream from Docker's log API
+ * @param isTty - Whether the container is running in TTY mode
+ * @param containerId - Container ID used for error messages
+ */
+function wireLogStreamEvents(
+  ctx: LogStreamContext,
+  logStream: Readable,
+  isTty: boolean,
+  containerId: string,
+): void {
+  let muxedRemainder: Buffer = Buffer.alloc(0);
+
+  logStream.on('data', (chunk: Buffer) => {
+    if (ctx.closed) return;
+
+    let lines: LogLine[];
+    if (isTty) {
+      lines = parseTtyChunk(chunk);
+    } else {
+      const input = muxedRemainder.length > 0
+        ? Buffer.concat([muxedRemainder, chunk])
+        : chunk;
+      const result = parseMuxedChunk(input);
+      lines = result.lines;
+      muxedRemainder = result.remainder;
+    }
+
+    for (const line of lines) {
+      sendLogSSE(ctx, JSON.stringify(line));
+    }
+  });
+
+  logStream.on('end', () => {
+    if (!ctx.closed) {
+      ctx.closed = true;
+      ctx.controller.close();
+    }
+  });
+
+  logStream.on('error', (error: Error) => {
+    console.error(`Log stream error for container ${containerId}:`, error);
+    if (!ctx.closed) {
+      sendLogErrorSSE(ctx, error.message);
+      ctx.closed = true;
+      ctx.controller.close();
+    }
+  });
+}
+
 /**
  * Stream a Docker container's logs to the client over a Server-Sent Events (SSE) connection.
  *
@@ -21,16 +101,19 @@ export function handleLogStream(
   containerId: string,
   request: Request
 ): Response {
-  let closed = false;
-  let logStream: Readable | null = null;
-  const encoder = new TextEncoder();
-
   const stream = new ReadableStream({
     async start(controller) {
+      const ctx: LogStreamContext = {
+        closed: false,
+        encoder: new TextEncoder(),
+        logStream: null,
+        controller,
+      };
+
       request.signal.addEventListener('abort', () => {
-        closed = true;
-        if (typeof logStream?.destroy === 'function') {
-          logStream.destroy();
+        ctx.closed = true;
+        if (typeof ctx.logStream?.destroy === 'function') {
+          ctx.logStream.destroy();
         }
         try {
           controller.close();
@@ -44,7 +127,7 @@ export function handleLogStream(
         const info = await container.inspect();
         const isTty = info.Config?.Tty ?? false;
 
-        logStream = (await container.logs({
+        ctx.logStream = (await container.logs({
           follow: true,
           stdout: true,
           stderr: true,
@@ -52,63 +135,13 @@ export function handleLogStream(
           timestamps: true,
         })) as unknown as Readable;
 
-        let muxedRemainder: Buffer = Buffer.alloc(0);
-
-        logStream.on('data', (chunk: Buffer) => {
-          if (closed) return;
-
-          let lines: LogLine[];
-          if (isTty) {
-            lines = parseTtyChunk(chunk);
-          } else {
-            const input = muxedRemainder.length > 0
-              ? Buffer.concat([muxedRemainder, chunk])
-              : chunk;
-            const result = parseMuxedChunk(input);
-            lines = result.lines;
-            muxedRemainder = result.remainder;
-          }
-
-          try {
-            for (const line of lines) {
-              controller.enqueue(
-                encoder.encode(`data: ${JSON.stringify(line)}\n\n`)
-              );
-            }
-          } catch (err) {
-            if (!(err instanceof TypeError)) console.error('Unexpected error enqueuing log line:', err);
-          }
-        });
-
-        logStream.on('end', () => {
-          if (!closed) {
-            closed = true;
-            controller.close();
-          }
-        });
-
-        logStream.on('error', (error: Error) => {
-          console.error(`Log stream error for container ${containerId}:`, error);
-          if (!closed) {
-            controller.enqueue(
-              encoder.encode(
-                `event: error\ndata: ${JSON.stringify({ error: error.message })}\n\n`
-              )
-            );
-            closed = true;
-            controller.close();
-          }
-        });
+        wireLogStreamEvents(ctx, ctx.logStream, isTty, containerId);
       } catch (error) {
         console.error(`Failed to start log stream for container ${containerId}:`, error);
         const msg = error instanceof Error ? error.message : String(error);
+        sendLogErrorSSE(ctx, msg);
+        ctx.closed = true;
         try {
-          controller.enqueue(
-            encoder.encode(
-              `event: error\ndata: ${JSON.stringify({ error: msg })}\n\n`
-            )
-          );
-          closed = true;
           controller.close();
         } catch {
           // controller already closed


### PR DESCRIPTION
## Summary
- Added `LogStreamContext` interface matching the pattern from stats.ts
- Extracted `sendLogSSE()` and `sendLogErrorSSE()` helpers (same pattern as stats.ts)
- Extracted `wireLogStreamEvents()` — sets up `data`/`end`/`error` listeners with TTY vs muxed parsing
- `handleLogStream()` start() body is now flat: create context → setup abort → inspect → open stream → wire events → handle errors
- Both agent SSE handlers now share the same structural pattern

## Test plan
- [x] `cd agent && bun run typecheck` passes
- [x] `cd agent && bun test` passes (all 75 tests)
- [ ] Verify log streaming works for both TTY and non-TTY containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)