### PR TITLE
refactor: break up DockerCollector.collect() into focused methods

### DIFF
--- a/src/worker/collectors/__tests__/docker-collector.test.ts
+++ b/src/worker/collectors/__tests__/docker-collector.test.ts
@@ -211,7 +211,7 @@ describe('DockerCollector', () => {
         source: 'docker',
         entity: 'test-host/abc123def456789',
         key: 'name',
-        value: 'web-server', // Leading / stripped by containerInfo helper
+        value: 'web-server', // Leading / stripped by findContainerName helper
       });
       expect(metadataUpserts[1]).toEqual({
         source: 'docker',
@@ -229,7 +229,7 @@ describe('DockerCollector', () => {
       // Stats should have been written - 2 stats events produce 2 rows
       expect(writtenRows.length).toBe(2);
 
-      // Verify row structure: the private containerInfo() helper resolved the name
+      // Verify row structure: the private findContainerName() helper resolved the name
       const row = writtenRows[0][0];
       expect(row.host).toBe('test-host');
       expect(row.container_id).toBe('abc123def456789');
@@ -484,7 +484,7 @@ describe('DockerCollector', () => {
       await (collector as any).collect();
 
       expect(writtenRows.length).toBe(1);
-      // containerInfo() should fall back to substring(0, 12) when Names is empty
+      // findContainerName() should fall back to substring(0, 12) when Names is empty
       expect(writtenRows[0][0].container_name).toBe('deadbeef1234');
 
       controller.abort();

--- a/src/worker/collectors/docker-collector.ts
+++ b/src/worker/collectors/docker-collector.ts
@@ -89,13 +89,20 @@ export class DockerCollector extends BaseCollector {
         // Periodically check for new/stopped containers
         const now = Date.now();
         if (now - lastContainerCheckTime >= CONTAINER_REFRESH_INTERVAL_MS) {
-          const changes = await this.checkForContainerChanges(docker, containers);
-          if (changes.changed) {
-            this.debugLog(
-              `[${this.name}] Container changes detected: +${changes.added} added, -${changes.removed} removed` +
-              ` (will reconnect to refresh streams)`
+          try {
+            const changes = await this.checkForContainerChanges(docker, containers);
+            if (changes.changed) {
+              this.debugLog(
+                `[${this.name}] Container changes detected: +${changes.added} added, -${changes.removed} removed` +
+                ` (will reconnect to refresh streams)`
+              );
+              break;
+            }
+          } catch (err) {
+            console.error(
+              `[${this.name}] Container refresh check failed, will retry next cycle:`,
+              err instanceof Error ? err.message : String(err)
             );
-            break;
           }
           lastContainerCheckTime = now;
         }
@@ -122,7 +129,7 @@ export class DockerCollector extends BaseCollector {
   /**
    * Upsert metadata (name, image, service_key) for all containers.
    * Handles service key migration when compose labels appear or change.
-   * Updates `this.knownContainers` as a side effect.
+   * Maintains `this.knownContainers` to track per-container state across collection cycles.
    */
   private async upsertContainerMetadata(containers: Dockerode.ContainerInfo[]): Promise<number> {
     let metadataUpdates = 0;
@@ -181,9 +188,9 @@ export class DockerCollector extends BaseCollector {
     return metadataUpdates;
   }
 
-  /** Build a database row from a stats event and the current container list. */
+  /** Build a database row from a stats event, looking up the container name from the container list and the image from `this.knownContainers`. */
   private buildStatsRow(stats: ContainerStatsWithRates, containers: Dockerode.ContainerInfo[]): DockerStatsRow {
-    const name = containerInfo(containers, stats.id);
+    const name = findContainerName(containers, stats.id);
     return {
       time: new Date(),
       host: this.hostConfig.name,
@@ -262,7 +269,7 @@ export class DockerCollector extends BaseCollector {
 }
 
 /** Find container name by ID from the container list */
-function containerInfo(containers: Dockerode.ContainerInfo[], id: string): string {
+function findContainerName(containers: Dockerode.ContainerInfo[], id: string): string {
   const info = containers.find(c => c.Id === id);
   return info?.Names[0]?.replace(/^\//, '') || id.substring(0, 12);
 }


### PR DESCRIPTION
## Summary
- Extracted `upsertContainerMetadata()` — handles metadata upserts + service key migration logic (the most subtle part of the collector), now independently testable
- Extracted `buildStatsRow()` — constructs DockerStatsRow from stats events
- Extracted `checkForContainerChanges()` — diffs container lists, returns `{ changed, added, removed }`
- `collect()` reduced from 164 lines to ~50 lines of orchestration: connect → list → upsert metadata → open streams → iterate with periodic checks
- Moved `CONTAINER_REFRESH_INTERVAL_MS` to module-level constant

## Test plan
- [x] `bun run typecheck` passes
- [x] `bun test` passes (all 1078 tests)
- [ ] Verify Docker stats collection works end-to-end with container churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)