### PR TITLE
fix(pr48): code review fixes — imports, draft filter, logging, race guard, cache key

### DIFF
--- a/src/data/update.functions.tsx
+++ b/src/data/update.functions.tsx
@@ -113,6 +113,7 @@ export const updateContainer = createServerFn()
     if (currentStatus && currentStatus !== 'idle') {
       return { success: false, error: 'Another update is already in progress' };
     }
+    await settingsRepo.set(SETTINGS_KEYS.update.status, 'starting');
 
     let containerName = data.containerId.substring(0, 12);
     let currentStep = 'initializing';

--- a/src/lib/clients/portainer-client.ts
+++ b/src/lib/clients/portainer-client.ts
@@ -1,5 +1,5 @@
 import { Agent } from 'undici';
-import type { PortainerEndpoint, PortainerStack } from '../../types/portainer';
+import type { PortainerEndpoint, PortainerStack } from '@/types/portainer';
 
 // Covers both Bun's native fetch (`tls`) and Node.js-compat/undici fetch (`dispatcher`)
 interface CrossRuntimeRequestInit extends RequestInit {
@@ -141,7 +141,7 @@ export class PortainerConnectionManager {
   private clients = new Map<string, PortainerClient>();
 
   getClient(config: PortainerConfig): PortainerClient {
-    const key = config.url;
+    const key = `${config.url}|${config.token}`;
 
     let client = this.clients.get(key);
     if (!client) {

--- a/src/lib/utils/github-api.ts
+++ b/src/lib/utils/github-api.ts
@@ -62,7 +62,7 @@ export async function fetchGitHubReleases(
 
   const data = await response.json();
   const releases: GitHubRelease[] = data
-    .filter((r: any) => !r.prerelease)
+    .filter((r: any) => !r.prerelease && !r.draft)
     .map((r: any) => ({
       tag: r.tag_name,
       name: r.name || r.tag_name,

--- a/src/worker/collectors/version-check-collector.ts
+++ b/src/worker/collectors/version-check-collector.ts
@@ -69,13 +69,13 @@ export class VersionCheckCollector extends BaseCollector {
   }
 
   private async runVersionCheck(): Promise<void> {
-    console.log('[VersionCheck] Starting version check');
+    console.info('[VersionCheck] Starting version check');
     await this.updateStatus('running', '0/0');
 
     try {
       const images = await this.repository.getUniqueDockerImages();
       if (images.length === 0) {
-        console.log('[VersionCheck] No Docker images found, skipping');
+        console.info('[VersionCheck] No Docker images found, skipping');
         await this.updateStatus('idle');
         return;
       }
@@ -90,11 +90,11 @@ export class VersionCheckCollector extends BaseCollector {
       const total = uniqueImages.size;
       let checked = 0;
 
-      console.log(`[VersionCheck] Checking ${total} unique images`);
+      console.info(`[VersionCheck] Checking ${total} unique images`);
 
       for (const [image, entity] of uniqueImages) {
         if (this.signal.aborted || this._cancelCheck) {
-          console.log('[VersionCheck] Cancelled');
+          console.info('[VersionCheck] Cancelled');
           await this.updateStatus('idle');
           return;
         }
@@ -113,7 +113,7 @@ export class VersionCheckCollector extends BaseCollector {
 
       await this.updateStatus('idle', `${total}/${total}`);
       await this.settingsRepo.set(SETTINGS_KEYS.versionCheck.lastRun, new Date().toISOString());
-      console.log(`[VersionCheck] Completed, checked ${total} images`);
+      console.info(`[VersionCheck] Completed, checked ${total} images`);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       console.error(`[VersionCheck] Failed: ${errMsg}`);
@@ -153,7 +153,7 @@ export class VersionCheckCollector extends BaseCollector {
     const result = await fetchGitHubReleases(githubRepo, this.githubToken, this.signal);
 
     if (result.rateLimited) {
-      console.log('[VersionCheck] Rate limited, waiting for reset');
+      console.info('[VersionCheck] Rate limited, waiting for reset');
       await this.updateStatus('rate_limited');
 
       if (result.rateLimit?.resetAt) {


### PR DESCRIPTION
## Code Review Fixes for PR #48

Addresses critical and high severity issues found during automated code review.

### Changes

1. **Fix relative import** (`src/lib/clients/portainer-client.ts`)
   - Changed `../../types/portainer` → `@/types/portainer` (CLAUDE.md Rule 2 violation)

2. **Filter draft releases** (`src/lib/utils/github-api.ts`)
   - Added `&& !r.draft` to release filter — draft releases are not publicly visible and should never trigger update badges

3. **Replace console.log with console.info** (`src/worker/collectors/version-check-collector.ts`)
   - All 6 `console.log` calls replaced with `console.info` for operational messages (CLAUDE.md Rule 8)
   - `console.error` calls left unchanged

4. **Fix TOCTOU race in concurrent update guard** (`src/data/update.functions.tsx`)
   - Set status to `'starting'` immediately after the idle check, before calling `performUpdate()`
   - Prevents two concurrent requests from both reading `'idle'` and proceeding

5. **Include token in Portainer cache key** (`src/lib/clients/portainer-client.ts`)
   - Changed cache key from `config.url` to `${config.url}|${config.token}`
   - Ensures rotated API tokens take effect without process restart

### Testing
- All 851 tests pass
- Typecheck passes

https://claude.ai/code/session_01P1jTZeX2EZuHxze6V2AhrR