### PR TITLE
fix(pr67): event guard, duplicate migration, fetch timeout, backoff reset

### DIFF
--- a/migrations/011_managed_hosts_agent_token.sql
+++ b/migrations/011_managed_hosts_agent_token.sql
@@ -1,5 +1,0 @@
--- Add plaintext agent token column for worker authentication to agent SSE endpoints.
--- The worker needs the token to send Authorization: Bearer <token> headers.
--- Security note: the socket_proxy_url column already provides equivalent access,
--- so storing the plaintext token does not meaningfully increase attack surface.
-ALTER TABLE managed_hosts ADD COLUMN IF NOT EXISTS agent_token TEXT;

--- a/src/worker/collectors/agent-stats-collector.ts
+++ b/src/worker/collectors/agent-stats-collector.ts
@@ -5,6 +5,7 @@ import type { DockerStatsRow } from '@/types/docker';
 import { BaseCollector } from './base-collector';
 
 const DOCKER_SOURCE = 'docker';
+const CONNECT_TIMEOUT_MS = 30_000;
 
 /** Shape of SSE events emitted by the agent's GET /stats/stream endpoint */
 interface AgentStatsEvent {
@@ -47,11 +48,14 @@ export class AgentStatsCollector extends BaseCollector {
     const url = `${this.host.agent_url}/stats/stream`;
     this.debugLog(`[${this.name}] Connecting to ${url}`);
 
+    const timeoutSignal = AbortSignal.timeout(CONNECT_TIMEOUT_MS);
+    const combinedSignal = AbortSignal.any([this.signal, timeoutSignal]);
+
     const response = await this.fetchFn(url, {
       headers: {
         Authorization: `Bearer ${this.host.agent_token}`,
       },
-      signal: this.signal,
+      signal: combinedSignal,
     });
 
     if (!response.ok) {
@@ -62,13 +66,13 @@ export class AgentStatsCollector extends BaseCollector {
       throw new Error('Agent response has no body');
     }
 
-    this.resetBackoff();
     this.debugLog(`[${this.name}] Connected, reading SSE stream`);
 
     const reader = response.body.getReader();
     const decoder = new TextDecoder();
     let buffer = '';
     let statsReceived = 0;
+    let framesReceived = 0;
 
     try {
       while (!this.signal.aborted) {
@@ -102,8 +106,9 @@ export class AgentStatsCollector extends BaseCollector {
             continue;
           }
 
-          // Skip error events from the agent
-          if ('error' in event && !('containerId' in event)) continue;
+          // Skip non-stat events (e.g. "containers" summary or "container-error")
+          if (!('containerId' in event) || !('containerName' in event)) continue;
+          if ('error' in event) continue;
 
           // Upsert entity metadata for new containers
           if (!this.knownContainers.has(event.containerId)) {
@@ -147,6 +152,11 @@ export class AgentStatsCollector extends BaseCollector {
           this.dbDebugLog(
             `[${this.name}] Wrote stat for ${event.containerName} in ${writeMs}ms (total: ${statsReceived})`
           );
+
+          framesReceived++;
+          if (framesReceived === 1) {
+            this.resetBackoff();
+          }
         }
       }
     } finally {


### PR DESCRIPTION
## Code Review Fixes for PR #67

Addresses 3 critical and 3 high severity issues in the AgentStatsCollector. All confirmed by Tier 2 deep review.

### Changes

1. **CRITICAL: Switch event guard from blocklist to allowlist** (`agent-stats-collector.ts`)
   - Old guard: `if ('error' in event && !('containerId' in event)) continue;`
   - This let `containers` events (`{ids: [...]}`) and `container-error` events (`{containerId, error}`) leak through to row insertion, corrupting the database with `undefined` values and `Invalid Date` timestamps
   - New guard requires both `containerId` AND `containerName` to be present, then separately skips events with `error` field
   - Fixes all three critical SSE event handling bugs simultaneously

2. **HIGH: Delete duplicate migration** (`migrations/011_managed_hosts_agent_token.sql`)
   - Removed via `git rm` — the base branch already has `012_managed_hosts_agent_token.sql` with identical DDL
   - The `IF NOT EXISTS` guard prevented a hard failure but the duplicate polluted migration history

3. **HIGH: Add per-request fetch timeout** (`agent-stats-collector.ts`)
   - Added `CONNECT_TIMEOUT_MS = 30_000` constant
   - Composed `AbortSignal.any([this.signal, AbortSignal.timeout(CONNECT_TIMEOUT_MS)])` for the fetch call
   - Previously only the shutdown signal was passed — an unresponsive agent would block the collector indefinitely
   - `TimeoutError` (name differs from `AbortError`) correctly falls through to the retry path in `BaseCollector`

4. **HIGH: Move `resetBackoff()` after first data frame** (`agent-stats-collector.ts`)
   - Removed `this.resetBackoff()` from immediately after HTTP 200 response
   - Added `framesReceived` counter; `resetBackoff()` now called only after the first successful `insertDockerStats`
   - Prevents tight reconnect loops when the agent returns 200 but immediately closes the stream

### Note on Protocol Mismatch (not fixed here)
The Tier 2 review also identified that the agent sends raw Docker stats (`{containerId, containerName, image, stats: {cpu_stats, memory_stats, ...}}`) while the collector expects pre-computed fields (`cpuPercent`, `memoryUsage`, etc.). This is an architectural issue requiring changes to the agent's stats computation — tracked separately.

### Testing
- All 1250 tests pass
- Typecheck passes

https://claude.ai/code/session_01P1jTZeX2EZuHxze6V2AhrR