### PR TITLE
fix(pr65): path segment validation on stack schemas, theme border colors

### DIFF
--- a/src/components/stacks/StacksTable.tsx
+++ b/src/components/stacks/StacksTable.tsx
@@ -81,7 +81,7 @@ export default function StacksTable({ stacks, isLoading, error }: StacksTablePro
       <Paper variant="outlined" className="rounded-sm overflow-x-auto">
         <div className="min-w-[600px]">
           {/* Column headers */}
-          <div className={`${STACKS_GRID} border-b border-neutral-200 dark:border-neutral-700`}>
+          <div className={`${STACKS_GRID} border-b border-[var(--mui-palette-divider)]`}>
             <div className="px-3 py-2 font-semibold text-sm whitespace-nowrap">Stack</div>
             <div className="px-3 py-2 font-semibold text-sm whitespace-nowrap">Host</div>
             <div className="px-3 py-2 font-semibold text-sm whitespace-nowrap">Status</div>

--- a/src/data/stacks.functions.tsx
+++ b/src/data/stacks.functions.tsx
@@ -12,8 +12,10 @@ export const listStacks = createServerFn()
     return getStackSummaries();
   });
 
+const pathSegment = z.string().min(1).regex(/^[a-zA-Z0-9_-]+$/, 'Must contain only letters, numbers, hyphens, and underscores');
+
 const getStackDetailSchema = z.object({
-  stackName: z.string().min(1),
+  stackName: pathSegment,
 });
 
 /**
@@ -27,8 +29,8 @@ export const getStackDetail = createServerFn()
   });
 
 const triggerDeploySchema = z.object({
-  stack: z.string().min(1),
-  host: z.string().min(1),
+  stack: pathSegment,
+  host: pathSegment,
   action: z.enum(['deploy', 'teardown', 'restart']),
 });
 
@@ -43,7 +45,7 @@ export const triggerDeploy = createServerFn()
   });
 
 const getDeployHistorySchema = z.object({
-  stackName: z.string().min(1),
+  stackName: pathSegment,
   limit: z.number().min(1).max(100).optional().default(20),
 });
 
@@ -58,7 +60,7 @@ export const getDeployHistory = createServerFn()
   });
 
 const saveComposeFileSchema = z.object({
-  stackName: z.string().min(1),
+  stackName: pathSegment,
   content: z.string(),
 });
 
@@ -73,7 +75,7 @@ export const saveComposeFile = createServerFn()
   });
 
 const updateStackIconSchema = z.object({
-  stackName: z.string().min(1),
+  stackName: pathSegment,
   iconSlug: z.string().min(1),
 });
 


### PR DESCRIPTION
## Code Review Fixes for PR #65

Addresses 1 critical and 1 high severity issue.

### Changes

1. **CRITICAL: Add path segment validation to stackName schemas** (`stacks.functions.tsx`)
   - All `stackName` and `host` fields in Zod schemas now validate against `/^[a-zA-Z0-9_-]+$/`
   - Created a reusable `pathSegment` Zod schema applied to: `getStackDetailSchema`, `getDeployHistorySchema`, `saveComposeFileSchema`, `updateStackIconSchema`, and `triggerDeploySchema`
   - **Without this fix**, values like `../../../etc/passwd` would pass Zod validation — while isomorphic-git's object store prevents direct filesystem writes, the unvalidated input could cause entity metadata issues and would widen as the stacks feature grows

2. **HIGH: Replace hardcoded border colors with theme variable** (`StacksTable.tsx`)
   - Changed `border-neutral-200 dark:border-neutral-700` → `border-[var(--mui-palette-divider)]`
   - Consistent with the rest of the codebase (CLAUDE.md Rule 1)

### Testing
- All 1338 tests pass
- Typecheck passes

https://claude.ai/code/session_01P1jTZeX2EZuHxze6V2AhrR