### PR TITLE
fix(pr66): hostname validation and OpenBao secrets engine initialization

### DIFF
--- a/src/data/__tests__/hosts.functions.test.ts
+++ b/src/data/__tests__/hosts.functions.test.ts
@@ -36,7 +36,7 @@ const socketProxyUrlSchema = z.string().min(1).refine(
 );
 
 const addHostSchema = z.object({
-  name: z.string().min(1).max(100),
+  name: z.string().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, 'Must contain only letters, numbers, hyphens, and underscores'),
   socketProxyUrl: socketProxyUrlSchema,
   agentPort: z.number().int().min(1).max(65535).optional().default(9090),
 });
@@ -228,6 +228,32 @@ describe('hosts.functions module', () => {
         socketProxyUrl: 'tcp://192.168.1.10:2375',
       });
       expect(result.name).toBe('x');
+    });
+
+    it('rejects name with dots', () => {
+      expect(() =>
+        addHostSchema.parse({ name: 'server.local', socketProxyUrl: 'tcp://192.168.1.10:2375' })
+      ).toThrow(/letters, numbers, hyphens, and underscores/);
+    });
+
+    it('rejects name with IP-like format', () => {
+      expect(() =>
+        addHostSchema.parse({ name: '192.168.1.10', socketProxyUrl: 'tcp://192.168.1.10:2375' })
+      ).toThrow(/letters, numbers, hyphens, and underscores/);
+    });
+
+    it('rejects name with spaces', () => {
+      expect(() =>
+        addHostSchema.parse({ name: 'my server', socketProxyUrl: 'tcp://192.168.1.10:2375' })
+      ).toThrow(/letters, numbers, hyphens, and underscores/);
+    });
+
+    it('accepts name with hyphens and underscores', () => {
+      const result = addHostSchema.parse({
+        name: 'my-server_01',
+        socketProxyUrl: 'tcp://192.168.1.10:2375',
+      });
+      expect(result.name).toBe('my-server_01');
     });
 
     it('rejects empty socketProxyUrl', () => {

--- a/src/data/hosts.functions.tsx
+++ b/src/data/hosts.functions.tsx
@@ -17,7 +17,7 @@ const socketProxyUrlSchema = z.string().min(1).refine(
 );
 
 const addHostSchema = z.object({
-  name: z.string().min(1).max(100),
+  name: z.string().min(1).max(100).regex(/^[a-zA-Z0-9_-]+$/, 'Must contain only letters, numbers, hyphens, and underscores'),
   socketProxyUrl: socketProxyUrlSchema,
   agentPort: z.number().int().min(1).max(65535).optional().default(9090),
 });
@@ -276,6 +276,7 @@ export const addHost = createServerFn()
     const { OpenBaoClient } = await import('@/lib/clients/openbao-client');
     const { loadOpenBaoConfig } = await import('@/lib/config/openbao-config');
     const baoClient = new OpenBaoClient(loadOpenBaoConfig());
+    await baoClient.ensureSecretsEngine();
     const provService = new AgentProvisioningService();
     return handleAddHost({
       ...baseDeps,


### PR DESCRIPTION
## Code Review Fixes for PR #66

Addresses 2 high severity issues in the OpenBao token migration.

### Changes

1. **HIGH: Add hostname regex validation to `addHostSchema`** (`hosts.functions.tsx`)
   - Added `.regex(/^[a-zA-Z0-9_-]+$/)` to the `name` field
   - **Without this fix**, hostnames like `192.168.1.10` or `server.local` would pass Zod validation but crash deep inside the OpenBao client at `validatePathSegment()` — after the agent container was already provisioned
   - The error message was confusing: `Invalid hostname: must contain only letters, numbers, hyphens, and underscores` from an internal function, not from input validation
   - Added 4 new test cases: rejects dots, rejects IP format, rejects spaces, accepts valid names

2. **HIGH: Call `ensureSecretsEngine()` before `setHostSecret`** (`hosts.functions.tsx`)
   - Added `await baoClient.ensureSecretsEngine()` in the `addHost` server function before `handleAddHost`
   - **Without this fix**, adding a host on a fresh OpenBao instance (where the worker hadn't run yet) would fail because the `secret/` KV v2 engine wasn't mounted
   - The worker and web server run in separate processes with no startup ordering guarantee

### Testing
- All 1350 tests pass (including 4 new validation tests)
- Typecheck passes

https://claude.ai/code/session_01P1jTZeX2EZuHxze6V2AhrR