### PR TITLE
fix(pr70): queryClient hook, dead import, rollback change detection, rollback feedback

### DIFF
--- a/src/components/stacks/DeployHistoryList.tsx
+++ b/src/components/stacks/DeployHistoryList.tsx
@@ -35,6 +35,8 @@ interface DeployHistoryListProps {
   isLoading: boolean;
   stackName?: string;
   host?: string;
+  onRollbackSuccess?: () => void;
+  onRollbackError?: (err: Error) => void;
 }
 
 export default function DeployHistoryList({
@@ -42,6 +44,8 @@ export default function DeployHistoryList({
   isLoading,
   stackName,
   host,
+  onRollbackSuccess,
+  onRollbackError,
 }: DeployHistoryListProps) {
   if (isLoading) {
     return (
@@ -69,6 +73,8 @@ export default function DeployHistoryList({
           record={record}
           stackName={stackName}
           host={host}
+          onRollbackSuccess={onRollbackSuccess}
+          onRollbackError={onRollbackError}
         />
       ))}
     </div>
@@ -79,9 +85,11 @@ interface DeployHistoryRowProps {
   record: StackDeployRecord;
   stackName?: string;
   host?: string;
+  onRollbackSuccess?: () => void;
+  onRollbackError?: (err: Error) => void;
 }
 
-function DeployHistoryRow({ record, stackName, host }: DeployHistoryRowProps) {
+function DeployHistoryRow({ record, stackName, host, onRollbackSuccess, onRollbackError }: DeployHistoryRowProps) {
   const [expanded, setExpanded] = useState(false);
   const [rollbackOpen, setRollbackOpen] = useState(false);
   const statusColor = STATUS_COLOR[record.status];
@@ -91,6 +99,8 @@ function DeployHistoryRow({ record, stackName, host }: DeployHistoryRowProps) {
   const rollbackMutation = useMutation({
     mutationFn: () =>
       triggerDeploy({ data: { stack: stackName!, host: host!, action: 'deploy', commitSha: record.commitSha } }),
+    onSuccess: () => { onRollbackSuccess?.(); },
+    onError: (err) => { onRollbackError?.(err instanceof Error ? err : new Error(String(err))); },
   });
 
   function handleRollbackConfirm() {

--- a/src/components/stacks/StackDetail.tsx
+++ b/src/components/stacks/StackDetail.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { Alert, CircularProgress, Snackbar, Typography } from '@mui/material';
-import { getStackDetail, getDeployHistory, triggerDeploy, deleteStack } from '@/data/stacks.functions';
+import { getStackDetail, getDeployHistory, triggerDeploy } from '@/data/stacks.functions';
 import ComposeEditorLoader from '@/components/stacks/ComposeEditorLoader';
 import DeployHistoryList from '@/components/stacks/DeployHistoryList';
 import ContainerList from '@/components/stacks/ContainerList';
@@ -15,6 +15,8 @@ interface StackDetailProps {
 }
 
 export default function StackDetail({ stackName, host, containers }: Readonly<StackDetailProps>) {
+  const queryClient = useQueryClient();
+
   const { data: detail, isLoading, error } = useQuery({
     queryKey: ['stack-detail', stackName],
     queryFn: () => getStackDetail({ data: { stackName } }),
@@ -79,6 +81,14 @@ export default function StackDetail({ stackName, host, containers }: Readonly<St
               isLoading={historyLoading}
               stackName={stackName}
               host={host}
+              onRollbackSuccess={() => {
+                setDeployMessage({ type: 'success', text: 'Rollback triggered successfully' });
+                void queryClient.invalidateQueries({ queryKey: ['deploy-history', stackName] });
+                void queryClient.invalidateQueries({ queryKey: ['stacks-list'] });
+              }}
+              onRollbackError={(err) => {
+                setDeployMessage({ type: 'error', text: err.message });
+              }}
             />
           </div>
         </div>

--- a/src/lib/deploy/pipeline.ts
+++ b/src/lib/deploy/pipeline.ts
@@ -51,7 +51,7 @@ export class DeployPipeline {
     let envHash = '';
     const resolvedEnvContent = await this.resolveEnv(request);
 
-    if (request.action === 'deploy') {
+    if (request.action === 'deploy' && request.trigger !== 'manual_rollback') {
       const previousDeploy = await this.deployRepo.getLatestSuccessful(request.stack, request.host);
       const changeResult = detectChanges(request.composeContent, resolvedEnvContent, previousDeploy);
       composeHash = changeResult.composeHash;


### PR DESCRIPTION
## Code Review Fixes for PR #70

Addresses 2 critical and 2 high severity issues in the stack detail and rollback UI.

### Changes

1. **CRITICAL: Add missing `useQueryClient()` call** (`StackDetail.tsx`)
   - `useQueryClient` was imported but never called in the component body
   - `queryClient.invalidateQueries(...)` in `deployMutation.onSuccess` would throw `ReferenceError: queryClient is not defined` at runtime on every successful deploy action
   - Added `const queryClient = useQueryClient();` at the top of the component

2. **CRITICAL: Remove nonexistent `deleteStack` import** (`StackDetail.tsx`)
   - `deleteStack` was imported from `@/data/stacks.functions` but that module does not export it
   - This is a TypeScript error and a forward-reference to a not-yet-implemented function (Task 13)
   - Removed from the import statement

3. **HIGH: Bypass change detection for manual rollbacks** (`pipeline.ts`)
   - Changed the condition from `request.action === 'deploy'` to `request.action === 'deploy' && request.trigger !== 'manual_rollback'`
   - **Without this fix**, rolling back to a commit whose compose content matches the current state would silently return `no_change` — the user sees 'deploy triggered successfully' but nothing actually happens
   - Rollbacks are explicitly user-requested and should always proceed

4. **HIGH: Add rollback success/error feedback** (`DeployHistoryList.tsx`, `StackDetail.tsx`)
   - `rollbackMutation` had no `onSuccess`/`onError` handlers — rollback failures were silently swallowed
   - Added `onRollbackSuccess` and `onRollbackError` callback props to `DeployHistoryList` and `DeployHistoryRow`
   - Wired them in `StackDetail.tsx` to show Snackbar feedback and invalidate the deploy history query

### Testing
- Typecheck passes
- Tests pass (2 pre-existing failures in `ComposeEditor.test.tsx` unrelated to these changes)

https://claude.ai/code/session_01P1jTZeX2EZuHxze6V2AhrR