### PR TITLE
fix(pr71): pointercancel handler and path segment validation for OpenBao schemas

### DIFF
--- a/src/components/stacks/ComposeEditor.tsx
+++ b/src/components/stacks/ComposeEditor.tsx
@@ -72,9 +72,11 @@ export default function ComposeEditor({ stackName, content, variables: initialVa
     const onUp = () => {
       target.removeEventListener('pointermove', onMove);
       target.removeEventListener('pointerup', onUp);
+      target.removeEventListener('pointercancel', onUp);
     };
     target.addEventListener('pointermove', onMove);
     target.addEventListener('pointerup', onUp);
+    target.addEventListener('pointercancel', onUp);
   }, [panelWidth]);
 
   // Reads the current theme on each render. Theme toggles trigger re-renders

--- a/src/data/stacks.functions.tsx
+++ b/src/data/stacks.functions.tsx
@@ -139,8 +139,11 @@ export const updateStackIcon = createServerFn()
     return updateStackIconSlug(data.stackName, data.iconSlug);
   });
 
+const SAFE_PATH_SEGMENT_PATTERN = /^[a-zA-Z0-9_-]+$/;
+const safePathSegment = z.string().min(1).regex(SAFE_PATH_SEGMENT_PATTERN, 'Must contain only letters, numbers, hyphens, and underscores');
+
 const stackVariablesSchema = z.object({
-  stackName: z.string().min(1),
+  stackName: safePathSegment,
 });
 
 /**
@@ -154,8 +157,8 @@ export const getStackVariables = createServerFn({ method: 'GET' })
   });
 
 const getVariableValueSchema = z.object({
-  stackName: z.string().min(1),
-  variableName: z.string().min(1),
+  stackName: safePathSegment,
+  variableName: safePathSegment,
 });
 
 /**
@@ -169,8 +172,8 @@ export const getVariableValue = createServerFn({ method: 'GET' })
   });
 
 const setVariableValueSchema = z.object({
-  stackName: z.string().min(1),
-  variableName: z.string().min(1),
+  stackName: safePathSegment,
+  variableName: safePathSegment,
   value: z.string(),
 });
 
@@ -185,8 +188,8 @@ export const setVariableValue = createServerFn({ method: 'POST' })
   });
 
 const deleteVariableSchema = z.object({
-  stackName: z.string().min(1),
-  variableName: z.string().min(1),
+  stackName: safePathSegment,
+  variableName: safePathSegment,
 });
 
 /**
@@ -200,8 +203,8 @@ export const deleteVariable = createServerFn({ method: 'POST' })
   });
 
 const ensureVariablesExistSchema = z.object({
-  stackName: z.string().min(1),
-  variableNames: z.array(z.string().min(1)),
+  stackName: safePathSegment,
+  variableNames: z.array(safePathSegment),
 });
 
 /**


### PR DESCRIPTION
## Code Review Fixes for PR #71

Addresses 2 high severity issues in the VariablesPanel and ComposeEditor.

### Changes

1. **HIGH: Add `pointercancel` handler to drag resize** (`ComposeEditor.tsx`)
   - The drag-to-resize handle registered `pointermove` and `pointerup` listeners but not `pointercancel`
   - When the browser cancels pointer capture (system dialog, touch interruption), `pointercancel` fires instead of `pointerup` — the `onUp` cleanup never runs, leaking both listeners for the element's lifetime
   - Added `target.addEventListener('pointercancel', onUp)` and corresponding removal in `onUp`

2. **HIGH: Add `SAFE_PATH_SEGMENT_PATTERN` to OpenBao Zod schemas** (`stacks.functions.tsx`)
   - All 5 OpenBao server functions used `z.string().min(1)` for `stackName` and `variableName` fields
   - This accepted path traversal characters (`.`, `/`, `..`) that would be passed as URL path segments in OpenBao API calls
   - Created a reusable `safePathSegment` validator with `/^[a-zA-Z0-9_-]+$/`
   - Applied to `stackName`, `variableName`, and `variableNames` array items across all schemas
   - `value` field intentionally not validated (can contain arbitrary secret content)

### Note on Middleware Duplication (not fixed here)
The Tier 2 review identified that the new OpenBao functions duplicate existing functions in `openbao-server-functions.ts`, bypassing the established middleware pattern. This architectural refactor is tracked separately as it requires moving functions between modules and updating all callers.

### Testing
- All 1438 tests pass
- Typecheck passes (pre-existing errors in `StackDetail.tsx` unrelated to these changes)

https://claude.ai/code/session_01P1jTZeX2EZuHxze6V2AhrR