### PR TITLE
fix(pr72): distinct query cache keys, throw on missing deployId, create error feedback

### DIFF
--- a/src/components/stacks/CreateStackDialog.tsx
+++ b/src/components/stacks/CreateStackDialog.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import {
+  Alert,
   Button,
   Dialog,
   DialogActions,
@@ -30,6 +31,7 @@ interface CreateStackDialogProps {
   onSubmit: (input: CreateStackInput) => void;
   hosts: string[];
   isLoading: boolean;
+  error?: string | null;
 }
 
 export default function CreateStackDialog({
@@ -38,6 +40,7 @@ export default function CreateStackDialog({
   onSubmit,
   hosts,
   isLoading,
+  error,
 }: CreateStackDialogProps) {
   const [stackName, setStackName] = useState('');
   const [host, setHost] = useState(hosts[0] ?? '');
@@ -65,6 +68,7 @@ export default function CreateStackDialog({
     <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
       <DialogTitle>Create Stack</DialogTitle>
       <DialogContent className="flex flex-col gap-4 !pt-4">
+        {error && <Alert severity="error">{error}</Alert>}
         <TextField
           label="Stack Name"
           value={stackName}

--- a/src/components/stacks/__tests__/CreateStackDialog.test.tsx
+++ b/src/components/stacks/__tests__/CreateStackDialog.test.tsx
@@ -123,4 +123,14 @@ describe('CreateStackDialog', () => {
     render(<CreateStackDialog {...defaultProps} open={false} />);
     expect(screen.queryByLabelText('Stack Name')).toBeNull();
   });
+
+  it('displays error message when error prop is provided', () => {
+    render(<CreateStackDialog {...defaultProps} error="Something went wrong" />);
+    expect(screen.getByText('Something went wrong')).toBeDefined();
+  });
+
+  it('does not display error alert when error prop is null', () => {
+    render(<CreateStackDialog {...defaultProps} error={null} />);
+    expect(screen.queryByRole('alert')).toBeNull();
+  });
 });

--- a/src/lib/stacks/__tests__/stack-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-service.test.ts
@@ -173,12 +173,13 @@ describe('handleTriggerDeploy', () => {
     expect(result.deployId).toBe(42);
   });
 
-  test('returns 0 when pipeline returns no deployId', async () => {
+  test('throws when pipeline returns no deployId', async () => {
     const deps = mockDeps({
       executePipeline: mock(() => Promise.resolve({})),
     });
-    const result = await handleTriggerDeploy(deps, { stack: 'myapp', host: 'server1', action: 'deploy' });
-    expect(result.deployId).toBe(0);
+    await expect(
+      handleTriggerDeploy(deps, { stack: 'myapp', host: 'server1', action: 'deploy' })
+    ).rejects.toThrow(/Deploy could not be queued/);
   });
 
   test('passes compose content and commit SHA to buildRequest', async () => {

--- a/src/lib/stacks/stack-mappers.ts
+++ b/src/lib/stacks/stack-mappers.ts
@@ -86,7 +86,7 @@ export interface DeployDeps {
   readCompose: (stack: string) => Promise<string>;
   getCommitSha: () => Promise<string>;
   buildRequest: (input: { stack: string; host: string; composeContent: string; commitSha: string; action: 'deploy' | 'teardown' | 'restart' }) => DeployRequest;
-  executePipeline: (request: DeployRequest) => Promise<{ deployId?: number }>;
+  executePipeline: (request: DeployRequest) => Promise<{ deployId?: number; logs?: string }>;
 }
 
 /** Testable deploy handler — takes deps instead of importing them. */
@@ -114,5 +114,8 @@ export async function handleTriggerDeploy(
   });
 
   const result = await deps.executePipeline(request);
-  return { deployId: result.deployId ?? 0 };
+  if (result.deployId === undefined) {
+    throw new Error(`Deploy could not be queued: ${result.logs}`);
+  }
+  return { deployId: result.deployId };
 }

--- a/src/routes/stacks.tsx
+++ b/src/routes/stacks.tsx
@@ -29,11 +29,12 @@ function StacksPageContent() {
   return <StacksPage />
 }
 
-const HOSTS_QUERY_KEY = ['managed-hosts']
+const HOST_NAMES_QUERY_KEY = ['managed-host-names']
 
 function StacksPage() {
   const queryClient = useQueryClient()
   const [dialogOpen, setDialogOpen] = useState(false)
+  const [createError, setCreateError] = useState<string | null>(null)
 
   const { data: stacks, isLoading, error } = useQuery({
     queryKey: STACKS_QUERY_KEY,
@@ -42,7 +43,7 @@ function StacksPage() {
   })
 
   const { data: hosts = [] } = useQuery({
-    queryKey: HOSTS_QUERY_KEY,
+    queryKey: HOST_NAMES_QUERY_KEY,
     queryFn: () => listManagedHostNames(),
   })
 
@@ -55,6 +56,9 @@ function StacksPage() {
       void queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY })
       setDialogOpen(false)
     },
+    onError: (err) => {
+      setCreateError(err instanceof Error ? err.message : String(err))
+    },
   })
 
   return (
@@ -64,7 +68,7 @@ function StacksPage() {
           <Button
             variant="contained"
             startIcon={<Plus size={16} />}
-            onClick={() => setDialogOpen(true)}
+            onClick={() => { setCreateError(null); setDialogOpen(true) }}
           >
             Create Stack
           </Button>
@@ -82,6 +86,7 @@ function StacksPage() {
         onSubmit={(input) => createMutation.mutate(input)}
         hosts={hosts}
         isLoading={createMutation.isPending}
+        error={createError}
       />
     </div>
   )


### PR DESCRIPTION
## Code Review Fixes for PR #72

Addresses 2 critical and 1 high severity issue in stack CRUD and settings.

### Changes

1. **CRITICAL: Fix TanStack Query cache key collision** (`stacks.tsx`)
   - Both `stacks.tsx` and `ManagedHostsCard.tsx` defined `HOSTS_QUERY_KEY = ['managed-hosts']` but fetched different data types (`string[]` vs `HostListItem[]`)
   - If both pages were visited in the same session, TanStack Query would serve the wrong cached type to whichever page rendered second — causing silent data corruption or runtime errors
   - Renamed to `HOST_NAMES_QUERY_KEY = ['managed-host-names']` in `stacks.tsx`
   - `ManagedHostsCard.tsx` keeps `['managed-hosts']` for its `HostListItem[]` data

2. **CRITICAL: Throw on missing `deployId` instead of `?? 0` sentinel** (`stack-mappers.ts`)
   - `handleTriggerDeploy` returned `{ deployId: result.deployId ?? 0 }` — when `deployId` was undefined (e.g., deploy blocked by concurrency), it returned 0
   - `deleteStackFromRepo` called `deployRepo.getById(0)` which always returns `null`, so the teardown failure check was silently bypassed — stack was deleted from the repo even though containers were still running
   - Now throws `Error('Deploy could not be queued: ...')` with the pipeline's logs message
   - Updated corresponding test to expect rejection

3. **HIGH: Add error feedback to `createStack` mutation** (`stacks.tsx`, `CreateStackDialog.tsx`)
   - `createMutation` had no `onError` handler — if stack creation failed (name conflict, git error, host not found), the dialog showed no feedback
   - Added `createError` state, `onError` handler, and error clearing on dialog open
   - Added `error` prop to `CreateStackDialog` rendered as MUI `Alert` with `severity="error"`
   - Added 2 new tests for error display

### Testing
- Typecheck passes
- Tests pass

https://claude.ai/code/session_01P1jTZeX2EZuHxze6V2AhrR