### PR TITLE
fix(docker): restore natural-height detail panel layout

### DIFF
--- a/src/components/docker/ContainerDetailPanel.tsx
+++ b/src/components/docker/ContainerDetailPanel.tsx
@@ -62,8 +62,8 @@ export default memo(function ContainerDetailPanel({
   return (
     <div className="bg-[var(--mui-palette-action-hover)] pb-4 border-b border-[var(--mui-palette-divider)]">
       <Divider />
-      <div className="grid lg:grid-cols-2 lg:h-100 lg:overflow-hidden gap-4 px-4 pt-4">
-        <div className="flex flex-col gap-3 min-h-0 h-[400px] lg:h-auto">
+      <div className="grid lg:grid-cols-2 gap-4 px-4 pt-4">
+        <div className="flex flex-col gap-3">
           <DualSeriesChart
             title="CPU & Memory"
             series={cpuMemSeries}
@@ -77,7 +77,7 @@ export default memo(function ContainerDetailPanel({
             formatValue={formatNetwork}
           />
         </div>
-        <div className="h-64 lg:h-full">
+        <div className="h-[300px] lg:h-full">
           <ContainerLogViewer containerId={containerId} host={host} />
         </div>
       </div>

--- a/src/components/docker/DualSeriesChart.tsx
+++ b/src/components/docker/DualSeriesChart.tsx
@@ -185,8 +185,8 @@ export default memo(function DualSeriesChart({
   useEChartTimeScroll(chartRef, windowMs);
 
   return (
-    <Paper elevation={0} className="flex-1 min-h-0 flex flex-col rounded-sm p-2 !bg-[var(--mui-palette-background-chartBg)]">
-      <div className="flex items-center justify-between mb-0.5 shrink-0">
+    <Paper elevation={0} className="rounded-sm p-2 !bg-[var(--mui-palette-background-chartBg)]">
+      <div className="flex items-center justify-between mb-0.5">
         <Typography variant="body2" className="font-medium">{title}</Typography>
         <div className="flex gap-3">
           {series.map((s) => {
@@ -200,14 +200,16 @@ export default memo(function DualSeriesChart({
           })}
         </div>
       </div>
+      <div className="h-40">
         <ReactECharts
           ref={chartRef}
           option={option}
           opts={{ renderer: 'canvas' }}
           notMerge={false}
           lazyUpdate={true}
-          style={{ height: '100%', minHeight: 0 }}
+          className="!h-full !w-full"
         />
+      </div>
     </Paper>
   );
 });


### PR DESCRIPTION
## Summary

Followup to #97. The `flex-1 min-h-0` approach in `DualSeriesChart` required a constrained parent height (`h-100 + overflow-hidden`), which clipped the charts and log viewer on most screens.

- **`DualSeriesChart`**: revert chart area to a fixed-height `<div class="h-40">` wrapper so charts have intrinsic size and the panel grows naturally to fit them
- **`ContainerDetailPanel`**: remove `lg:h-100 lg:overflow-hidden` and the `h-[400px]` chart-column wrapper. Log viewer wrapper is now `h-[300px] lg:h-full`:
  - Mobile: explicit 300px so the log viewer's `h-full` Paper has a defined parent
  - Desktop: `h-full` resolves against the grid cell stretched to the chart column height (~424px), without participating in intrinsic row sizing — so the log viewer always matches the chart column and never drives the row taller

## Test plan

- [ ] `bun run typecheck`
- [ ] Expand a Docker container row on desktop: charts and log viewer should be visible end-to-end with no clipping; log viewer should be the same height as the two stacked charts
- [ ] Expand on mobile (<lg): charts stack vertically, log viewer is 300px tall below them

🤖 Generated with [Claude Code](https://claude.com/claude-code)