### PR TITLE
fix(deploy): recover stuck deploys on startup + watchdog timeout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,8 +43,7 @@ WORKER_COLLECTION_INTERVAL_MS="1000"
 GIT_REPOS_DIR="./data/repos"
 GIT_SERVER_TOKEN="dev-git-token"
 
-# Deploy Watchdog — fails any deploy stuck in "in_progress" longer than the threshold.
-# Server startup separately flips pending/in_progress rows to "failed" to recover from crashes.
+# Deploy watchdog — fails deploys stuck in "in_progress" past the threshold.
 # DEPLOY_WATCHDOG_INTERVAL_MS="120000"
 # DEPLOY_WATCHDOG_TIMEOUT_MINUTES="10"
 

--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,11 @@ WORKER_COLLECTION_INTERVAL_MS="1000"
 GIT_REPOS_DIR="./data/repos"
 GIT_SERVER_TOKEN="dev-git-token"
 
+# Deploy Watchdog — fails any deploy stuck in "in_progress" longer than the threshold.
+# Server startup separately flips pending/in_progress rows to "failed" to recover from crashes.
+# DEPLOY_WATCHDOG_INTERVAL_MS="120000"
+# DEPLOY_WATCHDOG_TIMEOUT_MINUTES="30"
+
 # Dev Agent (auto-seeded when DEV_AGENT_TOKEN is set)
 # DEV_HOST_NAME defaults to "localhost"; uncomment to override.
 # DEV_HOST_NAME="localhost"

--- a/.env.example
+++ b/.env.example
@@ -46,7 +46,7 @@ GIT_SERVER_TOKEN="dev-git-token"
 # Deploy Watchdog — fails any deploy stuck in "in_progress" longer than the threshold.
 # Server startup separately flips pending/in_progress rows to "failed" to recover from crashes.
 # DEPLOY_WATCHDOG_INTERVAL_MS="120000"
-# DEPLOY_WATCHDOG_TIMEOUT_MINUTES="30"
+# DEPLOY_WATCHDOG_TIMEOUT_MINUTES="10"
 
 # Dev Agent (auto-seeded when DEV_AGENT_TOKEN is set)
 # DEV_HOST_NAME defaults to "localhost"; uncomment to override.

--- a/src/lib/database/repositories/__tests__/deploy-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/deploy-repository.test.ts
@@ -275,4 +275,47 @@ describe('DeployRepository', () => {
       expect(mock.queries[0].params).toEqual([JSON.stringify({ type: 'deploy_changed', stack: 'plex', host: 'homeserver' })]);
     });
   });
+
+  describe('recoverStuckDeploys', () => {
+    it('returns an empty array when no deploys are stuck', async () => {
+      mock.pushResult([]);
+      const rows = await repo.recoverStuckDeploys('boom');
+      expect(rows).toHaveLength(0);
+      expect(mock.queries[0].sql).toContain("status IN ('pending', 'in_progress')");
+      expect(mock.queries[0].params).toEqual(['boom']);
+    });
+
+    it('returns the recovered rows with Number-coerced ids', async () => {
+      mock.pushResult([
+        { id: '7', stack: 'plex', host: 'homeserver' },
+        { id: '8', stack: 'traefik', host: 'other' },
+      ]);
+      const rows = await repo.recoverStuckDeploys('crashed');
+      expect(rows).toEqual([
+        { id: 7, stack: 'plex', host: 'homeserver' },
+        { id: 8, stack: 'traefik', host: 'other' },
+      ]);
+    });
+  });
+
+  describe('timeoutStuckDeploys', () => {
+    it('returns an empty array when no deploys are overdue', async () => {
+      mock.pushResult([]);
+      const rows = await repo.timeoutStuckDeploys(30, 'timed out');
+      expect(rows).toHaveLength(0);
+      expect(mock.queries[0].sql).toContain("status = 'in_progress'");
+      expect(mock.queries[0].sql).toContain('make_interval(mins => $1)');
+      expect(mock.queries[0].params).toEqual([30, 'timed out']);
+    });
+
+    it('returns the timed-out rows with Number-coerced ids', async () => {
+      mock.pushResult([
+        { id: '42', stack: 'plex', host: 'homeserver' },
+      ]);
+      const rows = await repo.timeoutStuckDeploys(15, 'slow');
+      expect(rows).toEqual([
+        { id: 42, stack: 'plex', host: 'homeserver' },
+      ]);
+    });
+  });
 });

--- a/src/lib/database/repositories/__tests__/deploy-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/deploy-repository.test.ts
@@ -281,7 +281,12 @@ describe('DeployRepository', () => {
       mock.pushResult([]);
       const rows = await repo.recoverStuckDeploys('boom');
       expect(rows).toHaveLength(0);
-      expect(mock.queries[0].sql).toContain("status IN ('pending', 'in_progress')");
+      const sql = mock.queries[0].sql;
+      expect(sql).toContain('UPDATE deploy_history');
+      expect(sql).toContain("SET status = 'failed'");
+      expect(sql).toContain('logs = $1');
+      expect(sql).toContain("status IN ('pending', 'in_progress')");
+      expect(sql).toContain('RETURNING id, stack, host');
       expect(mock.queries[0].params).toEqual(['boom']);
     });
 
@@ -303,8 +308,13 @@ describe('DeployRepository', () => {
       mock.pushResult([]);
       const rows = await repo.timeoutStuckDeploys(30, 'timed out');
       expect(rows).toHaveLength(0);
-      expect(mock.queries[0].sql).toContain("status = 'in_progress'");
-      expect(mock.queries[0].sql).toContain('make_interval(mins => $1)');
+      const sql = mock.queries[0].sql;
+      expect(sql).toContain('UPDATE deploy_history');
+      expect(sql).toContain("SET status = 'failed'");
+      expect(sql).toContain('logs = $2');
+      expect(sql).toContain("status = 'in_progress'");
+      expect(sql).toContain('make_interval(mins => $1)');
+      expect(sql).toContain('RETURNING id, stack, host');
       expect(mock.queries[0].params).toEqual([30, 'timed out']);
     });
 

--- a/src/lib/database/repositories/deploy-repository.ts
+++ b/src/lib/database/repositories/deploy-repository.ts
@@ -125,6 +125,49 @@ export class DeployRepository {
     const payload = JSON.stringify({ type: 'deploy_changed', stack, host });
     await this.pool.query("SELECT pg_notify('deploy_change', $1)", [payload]);
   }
+
+  /**
+   * Mark all pending/in_progress deploys as failed. Used on server startup to recover
+   * from crashes that left a deploy row active. Returns the recovered rows so the caller
+   * can notify subscribers.
+   */
+  async recoverStuckDeploys(logMessage: string): Promise<Array<{ id: number; stack: string; host: string }>> {
+    const result = await this.pool.query(
+      `UPDATE deploy_history
+       SET status = 'failed', logs = $1
+       WHERE status IN ('pending', 'in_progress')
+       RETURNING id, stack, host`,
+      [logMessage],
+    );
+    return result.rows.map((r: Record<string, unknown>) => ({
+      id: Number(r.id),
+      stack: r.stack as string,
+      host: r.host as string,
+    }));
+  }
+
+  /**
+   * Mark in_progress deploys older than thresholdMinutes as failed.
+   * Returns the timed-out rows so the caller can notify subscribers.
+   */
+  async timeoutStuckDeploys(
+    thresholdMinutes: number,
+    logMessage: string,
+  ): Promise<Array<{ id: number; stack: string; host: string }>> {
+    const result = await this.pool.query(
+      `UPDATE deploy_history
+       SET status = 'failed', logs = $2
+       WHERE status = 'in_progress'
+         AND created_at < NOW() - make_interval(mins => $1)
+       RETURNING id, stack, host`,
+      [thresholdMinutes, logMessage],
+    );
+    return result.rows.map((r: Record<string, unknown>) => ({
+      id: Number(r.id),
+      stack: r.stack as string,
+      host: r.host as string,
+    }));
+  }
 }
 
 /** Check for the specific active-deploy unique constraint violation. */

--- a/src/lib/database/repositories/deploy-repository.ts
+++ b/src/lib/database/repositories/deploy-repository.ts
@@ -1,6 +1,12 @@
 import type { Pool } from 'pg';
 import type { DeployAction, DeployRecord, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
 
+export interface StuckDeployRow {
+  id: number;
+  stack: string;
+  host: string;
+}
+
 interface InsertDeployParams {
   stack: string;
   host: string;
@@ -127,7 +133,7 @@ export class DeployRepository {
   }
 
   /** Fails any active deploy rows that survived a crash. Returns the recovered rows. */
-  async recoverStuckDeploys(logMessage: string): Promise<Array<{ id: number; stack: string; host: string }>> {
+  async recoverStuckDeploys(logMessage: string): Promise<StuckDeployRow[]> {
     const result = await this.pool.query(
       `UPDATE deploy_history
        SET status = 'failed', logs = $1
@@ -135,18 +141,14 @@ export class DeployRepository {
        RETURNING id, stack, host`,
       [logMessage],
     );
-    return result.rows.map((r: Record<string, unknown>) => ({
-      id: Number(r.id),
-      stack: r.stack as string,
-      host: r.host as string,
-    }));
+    return result.rows.map(toStuckDeployRow);
   }
 
   /** Fails in_progress deploys older than thresholdMinutes. Returns the timed-out rows. */
   async timeoutStuckDeploys(
     thresholdMinutes: number,
     logMessage: string,
-  ): Promise<Array<{ id: number; stack: string; host: string }>> {
+  ): Promise<StuckDeployRow[]> {
     const result = await this.pool.query(
       `UPDATE deploy_history
        SET status = 'failed', logs = $2
@@ -155,12 +157,16 @@ export class DeployRepository {
        RETURNING id, stack, host`,
       [thresholdMinutes, logMessage],
     );
-    return result.rows.map((r: Record<string, unknown>) => ({
-      id: Number(r.id),
-      stack: r.stack as string,
-      host: r.host as string,
-    }));
+    return result.rows.map(toStuckDeployRow);
   }
+}
+
+function toStuckDeployRow(row: Record<string, unknown>): StuckDeployRow {
+  return {
+    id: Number(row.id),
+    stack: row.stack as string,
+    host: row.host as string,
+  };
 }
 
 /** Check for the specific active-deploy unique constraint violation. */

--- a/src/lib/database/repositories/deploy-repository.ts
+++ b/src/lib/database/repositories/deploy-repository.ts
@@ -126,11 +126,7 @@ export class DeployRepository {
     await this.pool.query("SELECT pg_notify('deploy_change', $1)", [payload]);
   }
 
-  /**
-   * Mark all pending/in_progress deploys as failed. Used on server startup to recover
-   * from crashes that left a deploy row active. Returns the recovered rows so the caller
-   * can notify subscribers.
-   */
+  /** Fails any active deploy rows that survived a crash. Returns the recovered rows. */
   async recoverStuckDeploys(logMessage: string): Promise<Array<{ id: number; stack: string; host: string }>> {
     const result = await this.pool.query(
       `UPDATE deploy_history
@@ -146,10 +142,7 @@ export class DeployRepository {
     }));
   }
 
-  /**
-   * Mark in_progress deploys older than thresholdMinutes as failed.
-   * Returns the timed-out rows so the caller can notify subscribers.
-   */
+  /** Fails in_progress deploys older than thresholdMinutes. Returns the timed-out rows. */
   async timeoutStuckDeploys(
     thresholdMinutes: number,
     logMessage: string,

--- a/src/lib/database/repositories/deploy-repository.ts
+++ b/src/lib/database/repositories/deploy-repository.ts
@@ -132,7 +132,12 @@ export class DeployRepository {
     await this.pool.query("SELECT pg_notify('deploy_change', $1)", [payload]);
   }
 
-  /** Fails any active deploy rows that survived a crash. Returns the recovered rows. */
+  /**
+   * Fails ALL pending/in_progress deploy_history rows unconditionally, overwriting
+   * `logs` with `logMessage` (any partial agent output is lost). Safe only for
+   * single-instance/single-worker startup recovery — do not call in multi-process
+   * deployments where another instance may own active rows. Returns the recovered rows.
+   */
   async recoverStuckDeploys(logMessage: string): Promise<StuckDeployRow[]> {
     const result = await this.pool.query(
       `UPDATE deploy_history
@@ -144,7 +149,10 @@ export class DeployRepository {
     return result.rows.map(toStuckDeployRow);
   }
 
-  /** Fails in_progress deploys older than thresholdMinutes. Returns the timed-out rows. */
+  /**
+   * Fails in_progress deploys older than thresholdMinutes, overwriting `logs`
+   * with `logMessage`. Returns the timed-out rows.
+   */
   async timeoutStuckDeploys(
     thresholdMinutes: number,
     logMessage: string,

--- a/src/lib/deploy/__tests__/deploy-watchdog.test.ts
+++ b/src/lib/deploy/__tests__/deploy-watchdog.test.ts
@@ -156,6 +156,8 @@ describe('DeployWatchdog', () => {
       const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
       await expect(w.tick(repo)).resolves.toBeUndefined();
       expect(notifyStackChange).toHaveBeenCalledTimes(2);
+      expect(notifyStackChange.mock.calls[0]).toEqual(['a', 'h']);
+      expect(notifyStackChange.mock.calls[1]).toEqual(['b', 'h']);
       expect(errSpy).toHaveBeenCalled();
       errSpy.mockRestore();
     });
@@ -188,6 +190,55 @@ describe('DeployWatchdog', () => {
 
       resolveFirst([]);
       await firstTick;
+    });
+
+    it('releases the reentrancy guard after the first tick completes', async () => {
+      const timeoutStuckDeploys = mock().mockResolvedValue([]);
+      const repo = createRepoMock({ timeoutStuckDeploys } as Partial<WatchdogRepo>);
+      const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
+
+      await w.tick(repo);
+      await w.tick(repo);
+      expect(timeoutStuckDeploys).toHaveBeenCalledTimes(2);
+    });
+
+    it('tracks consecutive failures and escalates the log prefix past the threshold', async () => {
+      const repo = createRepoMock({
+        timeoutStuckDeploys: mock().mockRejectedValue(new Error('db is sad')),
+      } as Partial<WatchdogRepo>);
+      const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+      const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
+      await w.tick(repo);
+      await w.tick(repo);
+      expect(w.getConsecutiveFailures()).toBe(2);
+      expect(errSpy.mock.calls.at(-1)?.[0]).not.toContain('consecutive failures');
+
+      await w.tick(repo);
+      expect(w.getConsecutiveFailures()).toBe(3);
+      expect(errSpy.mock.calls.at(-1)?.[0]).toContain('3 consecutive failures');
+      expect(errSpy.mock.calls.at(-1)?.[0]).toContain('degraded');
+
+      errSpy.mockRestore();
+    });
+
+    it('resets the consecutive failure counter after a successful tick', async () => {
+      const timeoutStuckDeploys = mock()
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockRejectedValueOnce(new Error('fail'))
+        .mockResolvedValueOnce([]);
+      const repo = createRepoMock({ timeoutStuckDeploys } as Partial<WatchdogRepo>);
+      const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+      const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
+      await w.tick(repo);
+      await w.tick(repo);
+      expect(w.getConsecutiveFailures()).toBe(2);
+
+      await w.tick(repo);
+      expect(w.getConsecutiveFailures()).toBe(0);
+
+      errSpy.mockRestore();
     });
   });
 
@@ -249,12 +300,37 @@ describe('DeployWatchdog', () => {
       expect(cfg.thresholdMinutes).toBe(10);
     });
 
+    it('treats 0 as invalid and falls back to defaults', () => {
+      process.env.DEPLOY_WATCHDOG_INTERVAL_MS = '0';
+      process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES = '0';
+      const cfg = loadDeployWatchdogConfig();
+      expect(cfg.intervalMs).toBe(2 * 60 * 1000);
+      expect(cfg.thresholdMinutes).toBe(10);
+    });
+
     it('floors fractional values', () => {
       process.env.DEPLOY_WATCHDOG_INTERVAL_MS = '1234.9';
       process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES = '10.7';
       const cfg = loadDeployWatchdogConfig();
       expect(cfg.intervalMs).toBe(1234);
       expect(cfg.thresholdMinutes).toBe(10);
+    });
+  });
+
+  describe('constructor guards', () => {
+    it('throws when intervalMs is 0 or negative', () => {
+      expect(() => new DeployWatchdog({ intervalMs: 0, thresholdMinutes: 10 })).toThrow(/intervalMs/);
+      expect(() => new DeployWatchdog({ intervalMs: -1, thresholdMinutes: 10 })).toThrow(/intervalMs/);
+    });
+
+    it('throws when thresholdMinutes is 0 or negative', () => {
+      expect(() => new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 0 })).toThrow(/thresholdMinutes/);
+      expect(() => new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: -5 })).toThrow(/thresholdMinutes/);
+    });
+
+    it('throws when values are non-finite', () => {
+      expect(() => new DeployWatchdog({ intervalMs: Number.POSITIVE_INFINITY, thresholdMinutes: 10 })).toThrow();
+      expect(() => new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: Number.NaN })).toThrow();
     });
   });
 });

--- a/src/lib/deploy/__tests__/deploy-watchdog.test.ts
+++ b/src/lib/deploy/__tests__/deploy-watchdog.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
-import { DeployWatchdog, loadDeployWatchdogConfig } from '../deploy-watchdog';
-import type { DeployRepository } from '@/lib/database/repositories/deploy-repository';
+import { DeployWatchdog, loadDeployWatchdogConfig, type WatchdogRepo } from '../deploy-watchdog';
 
 interface IntervalHandle {
   cb: () => void;
@@ -30,18 +29,12 @@ function createIntervalHarness() {
   };
 }
 
-type RepoMock = Pick<DeployRepository, 'timeoutStuckDeploys' | 'notifyStackChange'>;
-
-function createRepoMock(overrides: Partial<RepoMock> = {}): RepoMock {
+function createRepoMock(overrides: Partial<WatchdogRepo> = {}): WatchdogRepo {
   return {
-    timeoutStuckDeploys: mock().mockResolvedValue([]) as unknown as DeployRepository['timeoutStuckDeploys'],
-    notifyStackChange: mock().mockResolvedValue(undefined) as unknown as DeployRepository['notifyStackChange'],
+    timeoutStuckDeploys: mock().mockResolvedValue([]) as unknown as WatchdogRepo['timeoutStuckDeploys'],
+    notifyStackChange: mock().mockResolvedValue(undefined) as unknown as WatchdogRepo['notifyStackChange'],
     ...overrides,
   };
-}
-
-function asRepo(mock: RepoMock): DeployRepository {
-  return mock as unknown as DeployRepository;
 }
 
 describe('DeployWatchdog', () => {
@@ -59,7 +52,7 @@ describe('DeployWatchdog', () => {
     it('registers a setInterval with the configured interval', () => {
       const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
       const repo = createRepoMock();
-      w.start(asRepo(repo));
+      w.start(repo);
       expect(harness.intervals).toHaveLength(1);
       expect(harness.intervals[0].ms).toBe(500);
       w.stop();
@@ -67,7 +60,7 @@ describe('DeployWatchdog', () => {
 
     it('is a no-op when start is called twice', () => {
       const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
-      const repo = asRepo(createRepoMock());
+      const repo = createRepoMock();
       w.start(repo);
       w.start(repo);
       expect(harness.intervals).toHaveLength(1);
@@ -77,7 +70,7 @@ describe('DeployWatchdog', () => {
     it('clears the interval on stop', () => {
       const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
       const repo = createRepoMock();
-      w.start(asRepo(repo));
+      w.start(repo);
       w.stop();
       expect(harness.intervals[0].cleared).toBe(true);
     });
@@ -90,7 +83,7 @@ describe('DeployWatchdog', () => {
 
     it('can be restarted after stop', () => {
       const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
-      const repo = asRepo(createRepoMock());
+      const repo = createRepoMock();
       w.start(repo);
       w.stop();
       w.start(repo);
@@ -105,7 +98,7 @@ describe('DeployWatchdog', () => {
       const repo = createRepoMock({ timeoutStuckDeploys });
       const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 45 });
 
-      await w.tick(asRepo(repo));
+      await w.tick(repo);
 
       expect(timeoutStuckDeploys).toHaveBeenCalledTimes(1);
       const [threshold, message] = timeoutStuckDeploys.mock.calls[0] as [number, string];
@@ -124,7 +117,7 @@ describe('DeployWatchdog', () => {
       const repo = createRepoMock({
         timeoutStuckDeploys,
         notifyStackChange,
-      } as unknown as Partial<DeployRepository>);
+      } as Partial<WatchdogRepo>);
 
       const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
       await w.tick(repo);
@@ -139,7 +132,7 @@ describe('DeployWatchdog', () => {
       const repo = createRepoMock({
         timeoutStuckDeploys: mock().mockResolvedValue([]),
         notifyStackChange,
-      } as unknown as Partial<DeployRepository>);
+      } as Partial<WatchdogRepo>);
 
       const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
       await w.tick(repo);
@@ -157,7 +150,7 @@ describe('DeployWatchdog', () => {
       const repo = createRepoMock({
         timeoutStuckDeploys: mock().mockResolvedValue(rows),
         notifyStackChange,
-      } as unknown as Partial<DeployRepository>);
+      } as Partial<WatchdogRepo>);
       const errSpy = spyOn(console, 'error').mockImplementation(() => {});
 
       const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
@@ -170,7 +163,7 @@ describe('DeployWatchdog', () => {
     it('logs and swallows timeoutStuckDeploys errors', async () => {
       const repo = createRepoMock({
         timeoutStuckDeploys: mock().mockRejectedValue(new Error('db is sad')),
-      } as unknown as Partial<DeployRepository>);
+      } as Partial<WatchdogRepo>);
       const errSpy = spyOn(console, 'error').mockImplementation(() => {});
 
       const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
@@ -186,7 +179,7 @@ describe('DeployWatchdog', () => {
       );
       const repo = createRepoMock({
         timeoutStuckDeploys,
-      } as unknown as Partial<DeployRepository>);
+      } as Partial<WatchdogRepo>);
       const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
 
       const firstTick = w.tick(repo);
@@ -206,7 +199,7 @@ describe('DeployWatchdog', () => {
       const repo = createRepoMock({
         timeoutStuckDeploys,
         notifyStackChange,
-      } as unknown as Partial<DeployRepository>);
+      } as Partial<WatchdogRepo>);
 
       const w = new DeployWatchdog({ intervalMs: 100, thresholdMinutes: 5 });
       w.start(repo);

--- a/src/lib/deploy/__tests__/deploy-watchdog.test.ts
+++ b/src/lib/deploy/__tests__/deploy-watchdog.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { DeployWatchdog, loadDeployWatchdogConfig } from '../deploy-watchdog';
+import type { DeployRepository } from '@/lib/database/repositories/deploy-repository';
+
+interface IntervalHandle {
+  cb: () => void;
+  ms: number;
+  cleared: boolean;
+}
+
+function createIntervalHarness() {
+  const intervals: IntervalHandle[] = [];
+  const setSpy = spyOn(globalThis, 'setInterval').mockImplementation(((cb: () => void, ms: number) => {
+    const handle: IntervalHandle = { cb, ms, cleared: false };
+    intervals.push(handle);
+    return handle as unknown as ReturnType<typeof setInterval>;
+  }) as typeof setInterval);
+  const clearSpy = spyOn(globalThis, 'clearInterval').mockImplementation(((h: unknown) => {
+    const handle = h as IntervalHandle;
+    if (handle) handle.cleared = true;
+  }) as typeof clearInterval);
+  return {
+    intervals,
+    setSpy,
+    clearSpy,
+    restore() {
+      setSpy.mockRestore();
+      clearSpy.mockRestore();
+    },
+  };
+}
+
+function createRepoMock(overrides: Partial<DeployRepository> = {}): DeployRepository {
+  return {
+    timeoutStuckDeploys: mock().mockResolvedValue([]),
+    notifyStackChange: mock().mockResolvedValue(undefined),
+    ...overrides,
+  } as unknown as DeployRepository;
+}
+
+describe('DeployWatchdog', () => {
+  let harness: ReturnType<typeof createIntervalHarness>;
+
+  beforeEach(() => {
+    harness = createIntervalHarness();
+  });
+
+  afterEach(() => {
+    harness.restore();
+  });
+
+  describe('start / stop', () => {
+    it('registers a setInterval with the configured interval', () => {
+      const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
+      const repo = createRepoMock();
+      w.start(repo);
+      expect(harness.intervals).toHaveLength(1);
+      expect(harness.intervals[0].ms).toBe(500);
+      w.stop();
+    });
+
+    it('is a no-op when start is called twice', () => {
+      const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
+      const repo = createRepoMock();
+      w.start(repo);
+      w.start(repo);
+      expect(harness.intervals).toHaveLength(1);
+      w.stop();
+    });
+
+    it('clears the interval on stop', () => {
+      const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
+      const repo = createRepoMock();
+      w.start(repo);
+      w.stop();
+      expect(harness.intervals[0].cleared).toBe(true);
+    });
+
+    it('is a no-op when stop is called before start', () => {
+      const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
+      expect(() => w.stop()).not.toThrow();
+      expect(harness.clearSpy).not.toHaveBeenCalled();
+    });
+
+    it('can be restarted after stop', () => {
+      const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
+      const repo = createRepoMock();
+      w.start(repo);
+      w.stop();
+      w.start(repo);
+      expect(harness.intervals).toHaveLength(2);
+      w.stop();
+    });
+  });
+
+  describe('tick', () => {
+    it('calls timeoutStuckDeploys with the configured threshold and formatted message', async () => {
+      const timeoutStuckDeploys = mock().mockResolvedValue([]);
+      const repo = createRepoMock({ timeoutStuckDeploys } as unknown as Partial<DeployRepository>);
+      const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 45 });
+
+      await w.tick(repo);
+
+      expect(timeoutStuckDeploys).toHaveBeenCalledTimes(1);
+      const [threshold, message] = timeoutStuckDeploys.mock.calls[0] as [number, string];
+      expect(threshold).toBe(45);
+      expect(message).toContain('45 minutes');
+      expect(message).toContain('watchdog');
+    });
+
+    it('notifies each timed-out row on stack_change', async () => {
+      const rows = [
+        { id: 1, stack: 'plex', host: 'homeserver' },
+        { id: 2, stack: 'traefik', host: 'homeserver' },
+      ];
+      const timeoutStuckDeploys = mock().mockResolvedValue(rows);
+      const notifyStackChange = mock().mockResolvedValue(undefined);
+      const repo = createRepoMock({
+        timeoutStuckDeploys,
+        notifyStackChange,
+      } as unknown as Partial<DeployRepository>);
+
+      const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
+      await w.tick(repo);
+
+      expect(notifyStackChange).toHaveBeenCalledTimes(2);
+      expect(notifyStackChange.mock.calls[0]).toEqual(['plex', 'homeserver']);
+      expect(notifyStackChange.mock.calls[1]).toEqual(['traefik', 'homeserver']);
+    });
+
+    it('does not call notifyStackChange when no deploys are stuck', async () => {
+      const notifyStackChange = mock().mockResolvedValue(undefined);
+      const repo = createRepoMock({
+        timeoutStuckDeploys: mock().mockResolvedValue([]),
+        notifyStackChange,
+      } as unknown as Partial<DeployRepository>);
+
+      const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
+      await w.tick(repo);
+      expect(notifyStackChange).not.toHaveBeenCalled();
+    });
+
+    it('swallows notify errors so one bad row does not break the sweep', async () => {
+      const rows = [
+        { id: 1, stack: 'a', host: 'h' },
+        { id: 2, stack: 'b', host: 'h' },
+      ];
+      const notifyStackChange = mock()
+        .mockRejectedValueOnce(new Error('notify blew up'))
+        .mockResolvedValueOnce(undefined);
+      const repo = createRepoMock({
+        timeoutStuckDeploys: mock().mockResolvedValue(rows),
+        notifyStackChange,
+      } as unknown as Partial<DeployRepository>);
+      const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+      const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
+      await expect(w.tick(repo)).resolves.toBeUndefined();
+      expect(notifyStackChange).toHaveBeenCalledTimes(2);
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+
+    it('logs and swallows timeoutStuckDeploys errors', async () => {
+      const repo = createRepoMock({
+        timeoutStuckDeploys: mock().mockRejectedValue(new Error('db is sad')),
+      } as unknown as Partial<DeployRepository>);
+      const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+      const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
+      await expect(w.tick(repo)).resolves.toBeUndefined();
+      expect(errSpy).toHaveBeenCalled();
+      errSpy.mockRestore();
+    });
+
+    it('is reentrancy-safe: a second call while a tick is running is ignored', async () => {
+      let resolveFirst!: (v: unknown[]) => void;
+      const timeoutStuckDeploys = mock().mockImplementation(
+        () => new Promise((r) => { resolveFirst = r as (v: unknown[]) => void; }),
+      );
+      const repo = createRepoMock({
+        timeoutStuckDeploys,
+      } as unknown as Partial<DeployRepository>);
+      const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
+
+      const firstTick = w.tick(repo);
+      await w.tick(repo); // should return immediately without calling repo a 2nd time
+      expect(timeoutStuckDeploys).toHaveBeenCalledTimes(1);
+
+      resolveFirst([]);
+      await firstTick;
+    });
+  });
+
+  describe('interval firing', () => {
+    it('invokes tick when the interval callback runs', async () => {
+      const rows = [{ id: 9, stack: 'a', host: 'h' }];
+      const timeoutStuckDeploys = mock().mockResolvedValue(rows);
+      const notifyStackChange = mock().mockResolvedValue(undefined);
+      const repo = createRepoMock({
+        timeoutStuckDeploys,
+        notifyStackChange,
+      } as unknown as Partial<DeployRepository>);
+
+      const w = new DeployWatchdog({ intervalMs: 100, thresholdMinutes: 5 });
+      w.start(repo);
+      expect(harness.intervals).toHaveLength(1);
+
+      // Manually fire the registered callback and wait for the void promise to settle.
+      harness.intervals[0].cb();
+      await new Promise((r) => setTimeout(r, 0));
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(timeoutStuckDeploys).toHaveBeenCalledTimes(1);
+      expect(notifyStackChange).toHaveBeenCalledWith('a', 'h');
+      w.stop();
+    });
+  });
+
+  describe('loadDeployWatchdogConfig', () => {
+    const originalInterval = process.env.DEPLOY_WATCHDOG_INTERVAL_MS;
+    const originalThreshold = process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES;
+
+    afterEach(() => {
+      if (originalInterval === undefined) delete process.env.DEPLOY_WATCHDOG_INTERVAL_MS;
+      else process.env.DEPLOY_WATCHDOG_INTERVAL_MS = originalInterval;
+      if (originalThreshold === undefined) delete process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES;
+      else process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES = originalThreshold;
+    });
+
+    it('falls back to defaults when env vars are unset', () => {
+      delete process.env.DEPLOY_WATCHDOG_INTERVAL_MS;
+      delete process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES;
+      const cfg = loadDeployWatchdogConfig();
+      expect(cfg.intervalMs).toBe(2 * 60 * 1000);
+      expect(cfg.thresholdMinutes).toBe(30);
+    });
+
+    it('reads env vars when provided', () => {
+      process.env.DEPLOY_WATCHDOG_INTERVAL_MS = '5000';
+      process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES = '15';
+      const cfg = loadDeployWatchdogConfig();
+      expect(cfg.intervalMs).toBe(5000);
+      expect(cfg.thresholdMinutes).toBe(15);
+    });
+
+    it('falls back to defaults for invalid values', () => {
+      process.env.DEPLOY_WATCHDOG_INTERVAL_MS = 'not-a-number';
+      process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES = '-5';
+      const cfg = loadDeployWatchdogConfig();
+      expect(cfg.intervalMs).toBe(2 * 60 * 1000);
+      expect(cfg.thresholdMinutes).toBe(30);
+    });
+
+    it('floors fractional values', () => {
+      process.env.DEPLOY_WATCHDOG_INTERVAL_MS = '1234.9';
+      process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES = '10.7';
+      const cfg = loadDeployWatchdogConfig();
+      expect(cfg.intervalMs).toBe(1234);
+      expect(cfg.thresholdMinutes).toBe(10);
+    });
+  });
+});

--- a/src/lib/deploy/__tests__/deploy-watchdog.test.ts
+++ b/src/lib/deploy/__tests__/deploy-watchdog.test.ts
@@ -30,12 +30,18 @@ function createIntervalHarness() {
   };
 }
 
-function createRepoMock(overrides: Partial<DeployRepository> = {}): DeployRepository {
+type RepoMock = Pick<DeployRepository, 'timeoutStuckDeploys' | 'notifyStackChange'>;
+
+function createRepoMock(overrides: Partial<RepoMock> = {}): RepoMock {
   return {
-    timeoutStuckDeploys: mock().mockResolvedValue([]),
-    notifyStackChange: mock().mockResolvedValue(undefined),
+    timeoutStuckDeploys: mock().mockResolvedValue([]) as unknown as DeployRepository['timeoutStuckDeploys'],
+    notifyStackChange: mock().mockResolvedValue(undefined) as unknown as DeployRepository['notifyStackChange'],
     ...overrides,
-  } as unknown as DeployRepository;
+  };
+}
+
+function asRepo(mock: RepoMock): DeployRepository {
+  return mock as unknown as DeployRepository;
 }
 
 describe('DeployWatchdog', () => {
@@ -53,7 +59,7 @@ describe('DeployWatchdog', () => {
     it('registers a setInterval with the configured interval', () => {
       const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
       const repo = createRepoMock();
-      w.start(repo);
+      w.start(asRepo(repo));
       expect(harness.intervals).toHaveLength(1);
       expect(harness.intervals[0].ms).toBe(500);
       w.stop();
@@ -61,7 +67,7 @@ describe('DeployWatchdog', () => {
 
     it('is a no-op when start is called twice', () => {
       const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
-      const repo = createRepoMock();
+      const repo = asRepo(createRepoMock());
       w.start(repo);
       w.start(repo);
       expect(harness.intervals).toHaveLength(1);
@@ -71,7 +77,7 @@ describe('DeployWatchdog', () => {
     it('clears the interval on stop', () => {
       const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
       const repo = createRepoMock();
-      w.start(repo);
+      w.start(asRepo(repo));
       w.stop();
       expect(harness.intervals[0].cleared).toBe(true);
     });
@@ -84,7 +90,7 @@ describe('DeployWatchdog', () => {
 
     it('can be restarted after stop', () => {
       const w = new DeployWatchdog({ intervalMs: 500, thresholdMinutes: 10 });
-      const repo = createRepoMock();
+      const repo = asRepo(createRepoMock());
       w.start(repo);
       w.stop();
       w.start(repo);
@@ -96,10 +102,10 @@ describe('DeployWatchdog', () => {
   describe('tick', () => {
     it('calls timeoutStuckDeploys with the configured threshold and formatted message', async () => {
       const timeoutStuckDeploys = mock().mockResolvedValue([]);
-      const repo = createRepoMock({ timeoutStuckDeploys } as unknown as Partial<DeployRepository>);
+      const repo = createRepoMock({ timeoutStuckDeploys });
       const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 45 });
 
-      await w.tick(repo);
+      await w.tick(asRepo(repo));
 
       expect(timeoutStuckDeploys).toHaveBeenCalledTimes(1);
       const [threshold, message] = timeoutStuckDeploys.mock.calls[0] as [number, string];
@@ -206,9 +212,7 @@ describe('DeployWatchdog', () => {
       w.start(repo);
       expect(harness.intervals).toHaveLength(1);
 
-      // Manually fire the registered callback and wait for the void promise to settle.
       harness.intervals[0].cb();
-      await new Promise((r) => setTimeout(r, 0));
       await new Promise((r) => setTimeout(r, 0));
 
       expect(timeoutStuckDeploys).toHaveBeenCalledTimes(1);

--- a/src/lib/deploy/__tests__/deploy-watchdog.test.ts
+++ b/src/lib/deploy/__tests__/deploy-watchdog.test.ts
@@ -233,7 +233,7 @@ describe('DeployWatchdog', () => {
       delete process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES;
       const cfg = loadDeployWatchdogConfig();
       expect(cfg.intervalMs).toBe(2 * 60 * 1000);
-      expect(cfg.thresholdMinutes).toBe(30);
+      expect(cfg.thresholdMinutes).toBe(10);
     });
 
     it('reads env vars when provided', () => {
@@ -249,7 +249,7 @@ describe('DeployWatchdog', () => {
       process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES = '-5';
       const cfg = loadDeployWatchdogConfig();
       expect(cfg.intervalMs).toBe(2 * 60 * 1000);
-      expect(cfg.thresholdMinutes).toBe(30);
+      expect(cfg.thresholdMinutes).toBe(10);
     });
 
     it('floors fractional values', () => {

--- a/src/lib/deploy/__tests__/startup-recovery.test.ts
+++ b/src/lib/deploy/__tests__/startup-recovery.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, mock, spyOn } from 'bun:test';
+import {
+  performStartupRecovery,
+  type StartupRecoveryRepo,
+  type WatchdogController,
+} from '../startup-recovery';
+
+function createRepo(overrides: Partial<StartupRecoveryRepo> = {}): StartupRecoveryRepo {
+  return {
+    recoverStuckDeploys: mock().mockResolvedValue([]) as unknown as StartupRecoveryRepo['recoverStuckDeploys'],
+    timeoutStuckDeploys: mock().mockResolvedValue([]) as unknown as StartupRecoveryRepo['timeoutStuckDeploys'],
+    notifyStackChange: mock().mockResolvedValue(undefined) as unknown as StartupRecoveryRepo['notifyStackChange'],
+    ...overrides,
+  };
+}
+
+function createWatchdog(): WatchdogController & { startMock: ReturnType<typeof mock> } {
+  const startMock = mock();
+  return {
+    start: startMock as unknown as WatchdogController['start'],
+    startMock,
+  };
+}
+
+describe('performStartupRecovery', () => {
+  it('starts the watchdog when no rows are recovered', async () => {
+    const repo = createRepo();
+    const watchdog = createWatchdog();
+
+    await performStartupRecovery(repo, watchdog);
+
+    expect(repo.recoverStuckDeploys).toHaveBeenCalledTimes(1);
+    expect(repo.notifyStackChange).not.toHaveBeenCalled();
+    expect(watchdog.startMock).toHaveBeenCalledTimes(1);
+    expect(watchdog.startMock).toHaveBeenCalledWith(repo);
+  });
+
+  it('passes the STARTUP_RECOVERY_MESSAGE mentioning restart and re-trigger guidance', async () => {
+    const recoverStuckDeploys = mock().mockResolvedValue([]);
+    const repo = createRepo({
+      recoverStuckDeploys: recoverStuckDeploys as unknown as StartupRecoveryRepo['recoverStuckDeploys'],
+    });
+
+    await performStartupRecovery(repo, createWatchdog());
+
+    const [msg] = recoverStuckDeploys.mock.calls[0] as [string];
+    expect(msg).toContain('server restarted');
+    expect(msg).toContain('verify');
+  });
+
+  it('notifies each recovered row on stack_change with correct args', async () => {
+    const recovered = [
+      { id: 1, stack: 'plex', host: 'home' },
+      { id: 2, stack: 'traefik', host: 'home' },
+    ];
+    const notifyStackChange = mock().mockResolvedValue(undefined);
+    const repo = createRepo({
+      recoverStuckDeploys: mock().mockResolvedValue(recovered) as unknown as StartupRecoveryRepo['recoverStuckDeploys'],
+      notifyStackChange: notifyStackChange as unknown as StartupRecoveryRepo['notifyStackChange'],
+    });
+
+    await performStartupRecovery(repo, createWatchdog());
+
+    expect(notifyStackChange).toHaveBeenCalledTimes(2);
+    expect(notifyStackChange.mock.calls[0]).toEqual(['plex', 'home']);
+    expect(notifyStackChange.mock.calls[1]).toEqual(['traefik', 'home']);
+  });
+
+  it('swallows per-row notify errors and continues the loop', async () => {
+    const recovered = [
+      { id: 1, stack: 'a', host: 'h' },
+      { id: 2, stack: 'b', host: 'h' },
+    ];
+    const notifyStackChange = mock()
+      .mockRejectedValueOnce(new Error('notify blew up'))
+      .mockResolvedValueOnce(undefined);
+    const repo = createRepo({
+      recoverStuckDeploys: mock().mockResolvedValue(recovered) as unknown as StartupRecoveryRepo['recoverStuckDeploys'],
+      notifyStackChange: notifyStackChange as unknown as StartupRecoveryRepo['notifyStackChange'],
+    });
+    const watchdog = createWatchdog();
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    await performStartupRecovery(repo, watchdog);
+
+    expect(notifyStackChange).toHaveBeenCalledTimes(2);
+    expect(notifyStackChange.mock.calls[1]).toEqual(['b', 'h']);
+    expect(watchdog.startMock).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
+  });
+
+  it('retries recoverStuckDeploys on transient failure and succeeds', async () => {
+    const recoverStuckDeploys = mock()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce([]);
+    const repo = createRepo({
+      recoverStuckDeploys: recoverStuckDeploys as unknown as StartupRecoveryRepo['recoverStuckDeploys'],
+    });
+    const watchdog = createWatchdog();
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    await performStartupRecovery(repo, watchdog, {
+      maxAttempts: 3,
+      backoffMs: () => 0,
+      sleep: async () => {},
+    });
+
+    expect(recoverStuckDeploys).toHaveBeenCalledTimes(2);
+    expect(watchdog.startMock).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
+  });
+
+  it('gives up after maxAttempts and still starts the watchdog', async () => {
+    const recoverStuckDeploys = mock().mockRejectedValue(new Error('db down'));
+    const repo = createRepo({
+      recoverStuckDeploys: recoverStuckDeploys as unknown as StartupRecoveryRepo['recoverStuckDeploys'],
+    });
+    const watchdog = createWatchdog();
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    await performStartupRecovery(repo, watchdog, {
+      maxAttempts: 3,
+      backoffMs: () => 0,
+      sleep: async () => {},
+    });
+
+    expect(recoverStuckDeploys).toHaveBeenCalledTimes(3);
+    expect(watchdog.startMock).toHaveBeenCalledTimes(1);
+    const messages = errSpy.mock.calls.map((c) => String(c[0]));
+    expect(messages.some((m) => m.includes('exhausted after 3 attempts'))).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it('sleeps between retry attempts using the provided backoff', async () => {
+    const sleep = mock().mockResolvedValue(undefined);
+    const backoffMs = mock().mockImplementation((attempt: number) => 100 * (attempt + 1));
+    const repo = createRepo({
+      recoverStuckDeploys: mock()
+        .mockRejectedValueOnce(new Error('1'))
+        .mockRejectedValueOnce(new Error('2'))
+        .mockResolvedValueOnce([]) as unknown as StartupRecoveryRepo['recoverStuckDeploys'],
+    });
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    await performStartupRecovery(repo, createWatchdog(), {
+      maxAttempts: 3,
+      backoffMs: backoffMs as unknown as (attempt: number) => number,
+      sleep: sleep as unknown as (ms: number) => Promise<void>,
+    });
+
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep.mock.calls[0][0]).toBe(100);
+    expect(sleep.mock.calls[1][0]).toBe(200);
+    errSpy.mockRestore();
+  });
+});

--- a/src/lib/deploy/deploy-watchdog.ts
+++ b/src/lib/deploy/deploy-watchdog.ts
@@ -11,9 +11,9 @@ const DEFAULT_INTERVAL_MS = 2 * 60 * 1000;
 const DEFAULT_THRESHOLD_MINUTES = 10;
 
 /**
- * Load DeployWatchdog config from environment variables, falling back to sensible
- * defaults (2 minute interval, 10 minute threshold — 2x the agent's 5-minute
- * compose subprocess timeout in agent/src/routes/stacks.ts).
+ * Defaults: 2 min interval / 10 min threshold — 2× the agent's 5-min compose
+ * subprocess cap in agent/src/routes/stacks.ts, so deploys still in_progress
+ * past this point mean the failure path itself got lost.
  */
 export function loadDeployWatchdogConfig(): DeployWatchdogConfig {
   return {
@@ -28,11 +28,7 @@ function parsePositiveInt(raw: string | undefined, fallback: number): number {
   return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
 }
 
-/**
- * Periodic background job that fails deploys stuck in `in_progress` longer than
- * the configured threshold. Recovery on startup is handled separately in
- * `server-init.ts` via `DeployRepository.recoverStuckDeploys`.
- */
+/** Periodic sweep that fails deploys stuck in `in_progress` past the threshold. */
 export class DeployWatchdog {
   private readonly config: DeployWatchdogConfig;
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -42,7 +38,7 @@ export class DeployWatchdog {
     this.config = config;
   }
 
-  /** Start the periodic check. Safe to call multiple times; extra calls are no-ops. */
+  /** Idempotent — extra calls are no-ops. */
   start(deployRepo: DeployRepository): void {
     if (this.timer !== null) return;
     this.timer = setInterval(() => {
@@ -50,7 +46,7 @@ export class DeployWatchdog {
     }, this.config.intervalMs);
   }
 
-  /** Stop the periodic check. Safe to call when not started. */
+  /** Idempotent — safe to call before start. */
   stop(): void {
     if (this.timer !== null) {
       clearInterval(this.timer);
@@ -58,11 +54,7 @@ export class DeployWatchdog {
     }
   }
 
-  /**
-   * Execute a single sweep. Exposed so callers (and tests) can trigger manually.
-   * Reentrancy-guarded — if a previous tick is still running, subsequent calls
-   * return immediately.
-   */
+  /** Reentrancy-guarded — if a previous tick is still running, returns immediately. */
   async tick(deployRepo: DeployRepository): Promise<void> {
     if (this.running) return;
     this.running = true;

--- a/src/lib/deploy/deploy-watchdog.ts
+++ b/src/lib/deploy/deploy-watchdog.ts
@@ -1,5 +1,7 @@
 import type { DeployRepository } from '@/lib/database/repositories/deploy-repository';
 
+export type WatchdogRepo = Pick<DeployRepository, 'timeoutStuckDeploys' | 'notifyStackChange'>;
+
 export interface DeployWatchdogConfig {
   /** How often to check for stuck deploys. */
   intervalMs: number;
@@ -39,7 +41,7 @@ export class DeployWatchdog {
   }
 
   /** Idempotent — extra calls are no-ops. */
-  start(deployRepo: DeployRepository): void {
+  start(deployRepo: WatchdogRepo): void {
     if (this.timer !== null) return;
     this.timer = setInterval(() => {
       void this.tick(deployRepo);
@@ -55,7 +57,7 @@ export class DeployWatchdog {
   }
 
   /** Reentrancy-guarded — if a previous tick is still running, returns immediately. */
-  async tick(deployRepo: DeployRepository): Promise<void> {
+  async tick(deployRepo: WatchdogRepo): Promise<void> {
     if (this.running) return;
     this.running = true;
     try {

--- a/src/lib/deploy/deploy-watchdog.ts
+++ b/src/lib/deploy/deploy-watchdog.ts
@@ -8,11 +8,12 @@ export interface DeployWatchdogConfig {
 }
 
 const DEFAULT_INTERVAL_MS = 2 * 60 * 1000;
-const DEFAULT_THRESHOLD_MINUTES = 30;
+const DEFAULT_THRESHOLD_MINUTES = 10;
 
 /**
  * Load DeployWatchdog config from environment variables, falling back to sensible
- * defaults (2 minute interval, 30 minute threshold).
+ * defaults (2 minute interval, 10 minute threshold — 2x the agent's 5-minute
+ * compose subprocess timeout in agent/src/routes/stacks.ts).
  */
 export function loadDeployWatchdogConfig(): DeployWatchdogConfig {
   return {

--- a/src/lib/deploy/deploy-watchdog.ts
+++ b/src/lib/deploy/deploy-watchdog.ts
@@ -3,19 +3,20 @@ import type { DeployRepository } from '@/lib/database/repositories/deploy-reposi
 export type WatchdogRepo = Pick<DeployRepository, 'timeoutStuckDeploys' | 'notifyStackChange'>;
 
 export interface DeployWatchdogConfig {
-  /** How often to check for stuck deploys. */
+  /** How often to check for stuck deploys. Must be > 0. */
   intervalMs: number;
-  /** How long an in_progress deploy may sit before being failed. */
+  /** How long an in_progress deploy may sit before being failed. Must be > 0. */
   thresholdMinutes: number;
 }
 
 const DEFAULT_INTERVAL_MS = 2 * 60 * 1000;
 const DEFAULT_THRESHOLD_MINUTES = 10;
+const FAILURE_ESCALATION_THRESHOLD = 3;
 
 /**
- * Defaults: 2 min interval / 10 min threshold — 2× the agent's 5-min compose
- * subprocess cap in agent/src/routes/stacks.ts, so deploys still in_progress
- * past this point mean the failure path itself got lost.
+ * Defaults: 2 min interval / 10 min threshold — ~2× the agent's 5-min compose
+ * subprocess cap, so deploys still in_progress past this point mean the
+ * failure path itself got lost.
  */
 export function loadDeployWatchdogConfig(): DeployWatchdogConfig {
   return {
@@ -35,8 +36,15 @@ export class DeployWatchdog {
   private readonly config: DeployWatchdogConfig;
   private timer: ReturnType<typeof setInterval> | null = null;
   private running = false;
+  private consecutiveFailures = 0;
 
   constructor(config: DeployWatchdogConfig = loadDeployWatchdogConfig()) {
+    if (config.intervalMs <= 0 || !Number.isFinite(config.intervalMs)) {
+      throw new Error(`DeployWatchdog: intervalMs must be > 0, got ${config.intervalMs}`);
+    }
+    if (config.thresholdMinutes <= 0 || !Number.isFinite(config.thresholdMinutes)) {
+      throw new Error(`DeployWatchdog: thresholdMinutes must be > 0, got ${config.thresholdMinutes}`);
+    }
     this.config = config;
   }
 
@@ -56,6 +64,11 @@ export class DeployWatchdog {
     }
   }
 
+  /** Exposed for observability — number of consecutive tick failures. Resets to 0 on success. */
+  getConsecutiveFailures(): number {
+    return this.consecutiveFailures;
+  }
+
   /** Reentrancy-guarded — if a previous tick is still running, returns immediately. */
   async tick(deployRepo: WatchdogRepo): Promise<void> {
     if (this.running) return;
@@ -63,6 +76,7 @@ export class DeployWatchdog {
     try {
       const message = buildTimeoutMessage(this.config.thresholdMinutes);
       const timedOut = await deployRepo.timeoutStuckDeploys(this.config.thresholdMinutes, message);
+      this.consecutiveFailures = 0;
       if (timedOut.length === 0) return;
 
       console.info(
@@ -79,7 +93,11 @@ export class DeployWatchdog {
         }
       }
     } catch (err) {
-      console.error('[DeployWatchdog] Tick failed:', err);
+      this.consecutiveFailures += 1;
+      const prefix = this.consecutiveFailures >= FAILURE_ESCALATION_THRESHOLD
+        ? `[DeployWatchdog] Tick failed (${this.consecutiveFailures} consecutive failures — watchdog degraded)`
+        : '[DeployWatchdog] Tick failed';
+      console.error(`${prefix}:`, err);
     } finally {
       this.running = false;
     }

--- a/src/lib/deploy/deploy-watchdog.ts
+++ b/src/lib/deploy/deploy-watchdog.ts
@@ -37,6 +37,7 @@ export class DeployWatchdog {
   private timer: ReturnType<typeof setInterval> | null = null;
   private running = false;
   private consecutiveFailures = 0;
+  private skippedTicks = 0;
 
   constructor(config: DeployWatchdogConfig = loadDeployWatchdogConfig()) {
     if (config.intervalMs <= 0 || !Number.isFinite(config.intervalMs)) {
@@ -69,9 +70,18 @@ export class DeployWatchdog {
     return this.consecutiveFailures;
   }
 
-  /** Reentrancy-guarded — if a previous tick is still running, returns immediately. */
+  /** Exposed for observability — total ticks dropped because a prior tick was still running. */
+  getSkippedTicks(): number {
+    return this.skippedTicks;
+  }
+
+  /** Reentrancy-guarded — if a previous tick is still running, logs and returns. */
   async tick(deployRepo: WatchdogRepo): Promise<void> {
-    if (this.running) return;
+    if (this.running) {
+      this.skippedTicks += 1;
+      console.info(`[DeployWatchdog] Skipped tick — already running (skipped=${this.skippedTicks})`);
+      return;
+    }
     this.running = true;
     try {
       const message = buildTimeoutMessage(this.config.thresholdMinutes);

--- a/src/lib/deploy/deploy-watchdog.ts
+++ b/src/lib/deploy/deploy-watchdog.ts
@@ -1,0 +1,96 @@
+import type { DeployRepository } from '@/lib/database/repositories/deploy-repository';
+
+export interface DeployWatchdogConfig {
+  /** How often to check for stuck deploys. */
+  intervalMs: number;
+  /** How long an in_progress deploy may sit before being failed. */
+  thresholdMinutes: number;
+}
+
+const DEFAULT_INTERVAL_MS = 2 * 60 * 1000;
+const DEFAULT_THRESHOLD_MINUTES = 30;
+
+/**
+ * Load DeployWatchdog config from environment variables, falling back to sensible
+ * defaults (2 minute interval, 30 minute threshold).
+ */
+export function loadDeployWatchdogConfig(): DeployWatchdogConfig {
+  return {
+    intervalMs: parsePositiveInt(process.env.DEPLOY_WATCHDOG_INTERVAL_MS, DEFAULT_INTERVAL_MS),
+    thresholdMinutes: parsePositiveInt(process.env.DEPLOY_WATCHDOG_TIMEOUT_MINUTES, DEFAULT_THRESHOLD_MINUTES),
+  };
+}
+
+function parsePositiveInt(raw: string | undefined, fallback: number): number {
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Periodic background job that fails deploys stuck in `in_progress` longer than
+ * the configured threshold. Recovery on startup is handled separately in
+ * `server-init.ts` via `DeployRepository.recoverStuckDeploys`.
+ */
+export class DeployWatchdog {
+  private readonly config: DeployWatchdogConfig;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private running = false;
+
+  constructor(config: DeployWatchdogConfig = loadDeployWatchdogConfig()) {
+    this.config = config;
+  }
+
+  /** Start the periodic check. Safe to call multiple times; extra calls are no-ops. */
+  start(deployRepo: DeployRepository): void {
+    if (this.timer !== null) return;
+    this.timer = setInterval(() => {
+      void this.tick(deployRepo);
+    }, this.config.intervalMs);
+  }
+
+  /** Stop the periodic check. Safe to call when not started. */
+  stop(): void {
+    if (this.timer !== null) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * Execute a single sweep. Exposed so callers (and tests) can trigger manually.
+   * Reentrancy-guarded — if a previous tick is still running, subsequent calls
+   * return immediately.
+   */
+  async tick(deployRepo: DeployRepository): Promise<void> {
+    if (this.running) return;
+    this.running = true;
+    try {
+      const message = buildTimeoutMessage(this.config.thresholdMinutes);
+      const timedOut = await deployRepo.timeoutStuckDeploys(this.config.thresholdMinutes, message);
+      if (timedOut.length === 0) return;
+
+      console.info(
+        `[DeployWatchdog] Timed out ${timedOut.length} deploy(s) exceeding ${this.config.thresholdMinutes}min threshold`,
+      );
+      for (const row of timedOut) {
+        try {
+          await deployRepo.notifyStackChange(row.stack, row.host);
+        } catch (err) {
+          console.error(
+            `[DeployWatchdog] Failed to notify stack change for ${row.stack}/${row.host}:`,
+            err,
+          );
+        }
+      }
+    } catch (err) {
+      console.error('[DeployWatchdog] Tick failed:', err);
+    } finally {
+      this.running = false;
+    }
+  }
+}
+
+function buildTimeoutMessage(minutes: number): string {
+  return `Deploy marked failed by watchdog — no completion signal received after ${minutes} minutes. The deploy may still be running on the host; check the agent before re-triggering.`;
+}

--- a/src/lib/deploy/startup-recovery.ts
+++ b/src/lib/deploy/startup-recovery.ts
@@ -72,14 +72,15 @@ async function runWithRetry<T>(
     onAttemptFailed: (attempt: number, err: unknown) => void;
   },
 ): Promise<T> {
+  const attempts = Math.max(1, Math.floor(opts.maxAttempts));
   let lastErr: unknown;
-  for (let attempt = 1; attempt <= opts.maxAttempts; attempt += 1) {
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
     try {
       return await fn();
     } catch (err) {
       lastErr = err;
       opts.onAttemptFailed(attempt, err);
-      if (attempt < opts.maxAttempts) await opts.sleep(opts.backoff(attempt - 1));
+      if (attempt < attempts) await opts.sleep(opts.backoff(attempt - 1));
     }
   }
   throw lastErr;

--- a/src/lib/deploy/startup-recovery.ts
+++ b/src/lib/deploy/startup-recovery.ts
@@ -1,0 +1,86 @@
+import type { StuckDeployRow } from '@/lib/database/repositories/deploy-repository';
+import type { WatchdogRepo } from '@/lib/deploy/deploy-watchdog';
+
+export interface StartupRecoveryRepo extends WatchdogRepo {
+  recoverStuckDeploys(logMessage: string): Promise<StuckDeployRow[]>;
+}
+
+export interface WatchdogController {
+  start(repo: WatchdogRepo): void;
+}
+
+export interface StartupRecoveryOptions {
+  maxAttempts?: number;
+  backoffMs?: (attempt: number) => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export const STARTUP_RECOVERY_MESSAGE =
+  'Deploy interrupted — server restarted while this deploy was in progress. The actual outcome on the host is unknown. Please verify stack status and re-trigger if needed.';
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+const DEFAULT_BACKOFF_MS = 500;
+
+/**
+ * Orchestrates startup recovery: retry `recoverStuckDeploys` on transient errors,
+ * broadcast stack changes for recovered rows, then start the watchdog. The watchdog
+ * is started even if recovery ultimately fails so future recoveries still happen.
+ */
+export async function performStartupRecovery(
+  repo: StartupRecoveryRepo,
+  watchdog: WatchdogController,
+  options: StartupRecoveryOptions = {},
+): Promise<void> {
+  const maxAttempts = options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS;
+  const backoff = options.backoffMs ?? ((attempt) => DEFAULT_BACKOFF_MS * 2 ** attempt);
+  const sleep = options.sleep ?? ((ms) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  try {
+    const recovered = await runWithRetry(
+      () => repo.recoverStuckDeploys(STARTUP_RECOVERY_MESSAGE),
+      { maxAttempts, backoff, sleep, onAttemptFailed: (attempt, err) => {
+        console.error(`[Server] Startup recovery attempt ${attempt}/${maxAttempts} failed:`, err);
+      } },
+    );
+
+    if (recovered.length > 0) {
+      console.info(`[Server] Recovered ${recovered.length} stuck deploy(s) on startup`);
+      for (const r of recovered) {
+        try {
+          await repo.notifyStackChange(r.stack, r.host);
+        } catch (err) {
+          console.error(`[Server] Failed to notify stack change for ${r.stack}/${r.host}:`, err);
+        }
+      }
+    }
+  } catch (err) {
+    console.error(
+      `[Server] Startup recovery exhausted after ${maxAttempts} attempts — watchdog will keep retrying:`,
+      err,
+    );
+  }
+
+  watchdog.start(repo);
+}
+
+async function runWithRetry<T>(
+  fn: () => Promise<T>,
+  opts: {
+    maxAttempts: number;
+    backoff: (attempt: number) => number;
+    sleep: (ms: number) => Promise<void>;
+    onAttemptFailed: (attempt: number, err: unknown) => void;
+  },
+): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt += 1) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      opts.onAttemptFailed(attempt, err);
+      if (attempt < opts.maxAttempts) await opts.sleep(opts.backoff(attempt - 1));
+    }
+  }
+  throw lastErr;
+}

--- a/src/lib/server-init.ts
+++ b/src/lib/server-init.ts
@@ -2,8 +2,41 @@ import { statsPollService } from '@/lib/database/subscription-service';
 import { settingsBroadcastService } from '@/lib/settings/settings-broadcast-service';
 import { stackStatusBroadcastService } from '@/lib/stacks/stack-status-broadcast-service';
 import { databaseConnectionManager } from '@/lib/clients/database-client';
+import { DeployWatchdog } from '@/lib/deploy/deploy-watchdog';
 
 let initialized = false;
+const deployWatchdog = new DeployWatchdog();
+
+const STARTUP_RECOVERY_MESSAGE =
+  'Deploy interrupted — server restarted while this deploy was in progress. The actual outcome on the host is unknown. Please verify stack status and re-trigger if needed.';
+
+/**
+ * Mark any pending/in_progress deploys as failed on startup. Runs fire-and-forget so
+ * startup is not blocked on the database — errors are logged but non-fatal.
+ * Also starts the watchdog interval once the repo is resolved.
+ */
+async function recoverStuckDeploysAndStartWatchdog(): Promise<void> {
+  const { databaseConnectionManager: dbm } = await import('@/lib/clients/database-client');
+  const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+  const { DeployRepository } = await import('@/lib/database/repositories/deploy-repository');
+
+  const dbClient = await dbm.getClient(loadDatabaseConfig());
+  const repo = new DeployRepository(dbClient.getPool());
+
+  const recovered = await repo.recoverStuckDeploys(STARTUP_RECOVERY_MESSAGE);
+  if (recovered.length > 0) {
+    console.info(`[Server] Recovered ${recovered.length} stuck deploy(s) on startup`);
+    for (const r of recovered) {
+      try {
+        await repo.notifyStackChange(r.stack, r.host);
+      } catch (err) {
+        console.error(`[Server] Failed to notify stack change for ${r.stack}/${r.host}:`, err);
+      }
+    }
+  }
+
+  deployWatchdog.start(repo);
+}
 
 /**
  * Initialize server-side resources and register shutdown handlers.
@@ -12,6 +45,10 @@ let initialized = false;
  * It registers handlers for SIGTERM and SIGINT that stop the stats poller, stop the settings
  * broadcast service, and close all database connections; on successful cleanup the process
  * exits with code 0, and on error it exits with code 1.
+ *
+ * Also fires a best-effort deploy recovery sweep and starts the DeployWatchdog so a
+ * single crash or hung deploy cannot permanently block the stack+host active-deploy
+ * unique index.
  */
 export function initServer(): void {
   if (initialized) return;
@@ -21,6 +58,7 @@ export function initServer(): void {
     console.info('[Server] Shutdown signal received, cleaning up...');
 
     try {
+      deployWatchdog.stop();
       await statsPollService.stop();
       await settingsBroadcastService.stop();
       await stackStatusBroadcastService.stop();
@@ -36,6 +74,11 @@ export function initServer(): void {
 
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
+
+  // Fire-and-forget: never block startup on the database. Errors are logged only.
+  recoverStuckDeploysAndStartWatchdog().catch((err) => {
+    console.error('[Server] Deploy recovery / watchdog startup failed:', err);
+  });
 
   console.info('[Server] Shutdown handlers registered');
 }

--- a/src/lib/server-init.ts
+++ b/src/lib/server-init.ts
@@ -7,41 +7,19 @@ import { DeployWatchdog } from '@/lib/deploy/deploy-watchdog';
 let initialized = false;
 const deployWatchdog = new DeployWatchdog();
 
-const STARTUP_RECOVERY_MESSAGE =
-  'Deploy interrupted — server restarted while this deploy was in progress. The actual outcome on the host is unknown. Please verify stack status and re-trigger if needed.';
-
-/** Startup recovery + watchdog. Fire-and-forget; errors are logged and non-fatal. */
 async function startDeployRecovery(): Promise<void> {
   const { databaseConnectionManager: dbm } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
   const { DeployRepository } = await import('@/lib/database/repositories/deploy-repository');
+  const { performStartupRecovery } = await import('@/lib/deploy/startup-recovery');
 
   const dbClient = await dbm.getClient(loadDatabaseConfig());
   const repo = new DeployRepository(dbClient.getPool());
 
-  const recovered = await repo.recoverStuckDeploys(STARTUP_RECOVERY_MESSAGE);
-  if (recovered.length > 0) {
-    console.info(`[Server] Recovered ${recovered.length} stuck deploy(s) on startup`);
-    for (const r of recovered) {
-      try {
-        await repo.notifyStackChange(r.stack, r.host);
-      } catch (err) {
-        console.error(`[Server] Failed to notify stack change for ${r.stack}/${r.host}:`, err);
-      }
-    }
-  }
-
-  deployWatchdog.start(repo);
+  await performStartupRecovery(repo, deployWatchdog);
 }
 
-/**
- * Initialize server-side resources and register shutdown handlers.
- *
- * This function is idempotent: if initialization has already occurred it returns immediately.
- * It registers handlers for SIGTERM and SIGINT that stop the stats poller, stop the settings
- * broadcast service, and close all database connections; on successful cleanup the process
- * exits with code 0, and on error it exits with code 1.
- */
+/** Idempotent. Registers SIGTERM/SIGINT shutdown handlers and kicks off deploy recovery. */
 export function initServer(): void {
   if (initialized) return;
   initialized = true;
@@ -74,7 +52,6 @@ export function initServer(): void {
   console.info('[Server] Shutdown handlers registered');
 }
 
-// Auto-initialize when this module is imported on the server
 if (typeof window === 'undefined') {
   initServer();
 }

--- a/src/lib/server-init.ts
+++ b/src/lib/server-init.ts
@@ -10,12 +10,8 @@ const deployWatchdog = new DeployWatchdog();
 const STARTUP_RECOVERY_MESSAGE =
   'Deploy interrupted — server restarted while this deploy was in progress. The actual outcome on the host is unknown. Please verify stack status and re-trigger if needed.';
 
-/**
- * Mark any pending/in_progress deploys as failed on startup. Runs fire-and-forget so
- * startup is not blocked on the database — errors are logged but non-fatal.
- * Also starts the watchdog interval once the repo is resolved.
- */
-async function recoverStuckDeploysAndStartWatchdog(): Promise<void> {
+/** Startup recovery + watchdog. Fire-and-forget; errors are logged and non-fatal. */
+async function startDeployRecovery(): Promise<void> {
   const { databaseConnectionManager: dbm } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
   const { DeployRepository } = await import('@/lib/database/repositories/deploy-repository');
@@ -45,10 +41,6 @@ async function recoverStuckDeploysAndStartWatchdog(): Promise<void> {
  * It registers handlers for SIGTERM and SIGINT that stop the stats poller, stop the settings
  * broadcast service, and close all database connections; on successful cleanup the process
  * exits with code 0, and on error it exits with code 1.
- *
- * Also fires a best-effort deploy recovery sweep and starts the DeployWatchdog so a
- * single crash or hung deploy cannot permanently block the stack+host active-deploy
- * unique index.
  */
 export function initServer(): void {
   if (initialized) return;
@@ -75,8 +67,7 @@ export function initServer(): void {
   process.on('SIGTERM', shutdown);
   process.on('SIGINT', shutdown);
 
-  // Fire-and-forget: never block startup on the database. Errors are logged only.
-  recoverStuckDeploysAndStartWatchdog().catch((err) => {
+  startDeployRecovery().catch((err) => {
     console.error('[Server] Deploy recovery / watchdog startup failed:', err);
   });
 


### PR DESCRIPTION
## Summary
- Add `DeployRepository.recoverStuckDeploys()` — called on server startup to mark any `pending`/`in_progress` rows as `failed`.
- Add `DeployRepository.timeoutStuckDeploys()` and `DeployWatchdog` — periodic job that fails deploys stuck past a threshold (default 30min, configurable).
- Prevents a single server crash or hung deploy from permanently blocking the stack+host via the `idx_deploy_one_active_per_stack_host` partial unique index.

Closes #99.

## Test plan
- [ ] `bun run typecheck` clean
- [ ] `bun test` green
- [ ] Startup recovery: simulate server with `in_progress` row → starts → row flipped to `failed` with recovery message
- [ ] Watchdog: simulate `in_progress` row older than threshold → watchdog tick flips it to `failed` with timeout message
- [ ] Log messages are draft text — reviewer should edit wording if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection and recovery of deployments stuck in progress
  * Introduced periodic watchdog monitoring to identify and handle stuck deployment states
  * Added automatic recovery of interrupted deployments during server startup
  * Configurable watchdog interval and timeout thresholds via optional environment variables

* **Tests**
  * Comprehensive test coverage added for watchdog and recovery mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->