### PR TITLE
fix(git): eliminate createStackInRepo race with callback-style commitFiles

### DIFF
--- a/src/lib/git/__tests__/editor-operations.test.ts
+++ b/src/lib/git/__tests__/editor-operations.test.ts
@@ -13,14 +13,14 @@ describe('saveAndCommitFile', () => {
     testDir = mkdtempSync(join(getTestTmpDir(), 'git-editor-'));
     repoPath = join(testDir, 'test.git');
     await initBareRepo(repoPath);
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/docker-compose.yml', content: 'services:\n  plex:\n    image: plex:v1\n' },
       ],
       message: 'initial',
       author: { name: 'system', email: 'system@localhost' },
-    });
+    }));
   });
 
   afterEach(() => {
@@ -90,13 +90,13 @@ describe('updateManifest', () => {
     testDir = mkdtempSync(join(getTestTmpDir(), 'git-manifest-'));
     repoPath = join(testDir, 'test.git');
     await initBareRepo(repoPath);
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
       ],
       message: 'initial',
       author: { name: 'system', email: 'system@localhost' },
-    });
+    }));
   });
 
   afterEach(() => {

--- a/src/lib/git/__tests__/git-server.test.ts
+++ b/src/lib/git/__tests__/git-server.test.ts
@@ -21,11 +21,11 @@ describe('handleInfoRefs', () => {
   });
 
   it('should return info/refs for upload-pack service', async () => {
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'test.txt', content: 'hello' }],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const response = await handleInfoRefs(repoPath, 'git-upload-pack');
     expect(response.status).toBe(200);
@@ -35,11 +35,11 @@ describe('handleInfoRefs', () => {
   });
 
   it('should return info/refs for receive-pack service', async () => {
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'test.txt', content: 'hello' }],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const response = await handleInfoRefs(repoPath, 'git-receive-pack');
     expect(response.status).toBe(200);
@@ -67,11 +67,11 @@ describe('handleUploadPack', () => {
     testDir = mkdtempSync(join(getTestTmpDir(), 'git-upload-'));
     repoPath = join(testDir, 'test.git');
     await initBareRepo(repoPath);
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'test.txt', content: 'hello' }],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
   });
 
   afterEach(() => {
@@ -131,11 +131,11 @@ describe('handleReceivePack', () => {
     testDir = mkdtempSync(join(getTestTmpDir(), 'git-receive-'));
     repoPath = join(testDir, 'test.git');
     await initBareRepo(repoPath);
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'test.txt', content: 'hello' }],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
   });
 
   afterEach(() => {
@@ -163,11 +163,11 @@ describe('request body size limit', () => {
     testDir = mkdtempSync(join(getTestTmpDir(), 'git-size-'));
     repoPath = join(testDir, 'test.git');
     await initBareRepo(repoPath);
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'test.txt', content: 'hello' }],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
   });
 
   afterEach(() => {
@@ -217,11 +217,11 @@ describe('getHeadOid', () => {
   });
 
   it('should return commit OID when HEAD exists', async () => {
-    const commitSha = await commitFiles(repoPath, {
+    const commitSha = await commitFiles(repoPath, () => ({
       files: [{ path: 'test.txt', content: 'hello' }],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const oid = await getHeadOid(repoPath);
     expect(oid).toBe(commitSha);

--- a/src/lib/git/__tests__/integration.test.ts
+++ b/src/lib/git/__tests__/integration.test.ts
@@ -24,7 +24,7 @@ describe('Git management integration', () => {
 
   it('should support full workflow: init -> add stack -> edit -> detect changes -> deploy request', async () => {
     // 1. Create initial manifest and stack
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         {
           path: 'manifest.yaml',
@@ -37,7 +37,7 @@ describe('Git management integration', () => {
       ],
       message: 'Initial setup',
       author: { name: 'jared', email: 'jared@example.com' },
-    });
+    }));
 
     // 2. Verify files are readable
     const manifest = await readFileFromRepo(repoPath, 'manifest.yaml');

--- a/src/lib/git/__tests__/post-receive-handler-pipeline.test.ts
+++ b/src/lib/git/__tests__/post-receive-handler-pipeline.test.ts
@@ -34,19 +34,19 @@ const TEST_HOST: ManagedHost = {
 };
 
 async function buildPlexChangeCommits(repoPath: string): Promise<{ sha1: string; sha2: string }> {
-  const sha1 = await commitFiles(repoPath, {
+  const sha1 = await commitFiles(repoPath, () => ({
     files: [
       { path: 'manifest.yaml', content: MANIFEST_WITH_PLEX },
       { path: 'plex/docker-compose.yml', content: 'v1' },
     ],
     message: 'initial',
     author: { name: 'test', email: 'test@test.com' },
-  });
-  const sha2 = await commitFiles(repoPath, {
+  }));
+  const sha2 = await commitFiles(repoPath, () => ({
     files: [{ path: 'plex/docker-compose.yml', content: 'v2' }],
     message: 'update plex',
     author: { name: 'test', email: 'test@test.com' },
-  });
+  }));
   return { sha1, sha2 };
 }
 
@@ -145,19 +145,19 @@ describe('processPostReceive (pipeline paths)', () => {
 
   it('returns early when all compose file reads fail (changedStacks.size === 0)', async () => {
     // Non-compose file in plex/ triggers buildDeployRequests but compose read throws.
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: MANIFEST_WITH_PLEX },
         { path: 'plex/readme.txt', content: 'info' },
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
-    const sha2 = await commitFiles(repoPath, {
+    }));
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/readme.txt', content: 'updated info' }],
       message: 'update plex readme',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     await expect(processPostReceive(repoPath, sha1, sha2)).resolves.toBeUndefined();
 
@@ -219,7 +219,7 @@ describe('processPostReceive (pipeline paths)', () => {
     // Make getByName throw for the first stack (plex) but succeed for the second (sonarr).
     // getByName throws BEFORE the try/catch in dispatch(), so execute() propagates the throw.
     // processPostReceive's per-deploy catch logs the per-deploy error.
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         {
           path: 'manifest.yaml',
@@ -231,15 +231,15 @@ describe('processPostReceive (pipeline paths)', () => {
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
-    const sha2 = await commitFiles(repoPath, {
+    }));
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'plex/docker-compose.yml', content: 'v2' },
         { path: 'sonarr/docker-compose.yml', content: 'v2' },
       ],
       message: 'update both stacks',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     getByNameSpy
       .mockRejectedValueOnce(new Error('host lookup failed'))
@@ -288,7 +288,7 @@ describe('processPostReceive (pipeline paths)', () => {
     );
 
     try {
-      const sha1 = await commitFiles(repoPath, {
+      const sha1 = await commitFiles(repoPath, () => ({
         files: [
           { path: 'manifest.yaml', content: MANIFEST_WITH_PLEX },
           {
@@ -298,8 +298,8 @@ describe('processPostReceive (pipeline paths)', () => {
         ],
         message: 'initial',
         author: { name: 'test', email: 'test@test.com' },
-      });
-      const sha2 = await commitFiles(repoPath, {
+      }));
+      const sha2 = await commitFiles(repoPath, () => ({
         files: [
           {
             path: 'plex/docker-compose.yml',
@@ -309,7 +309,7 @@ describe('processPostReceive (pipeline paths)', () => {
         ],
         message: 'update plex',
         author: { name: 'test', email: 'test@test.com' },
-      });
+      }));
 
       await expect(processPostReceive(repoPath, sha1, sha2)).resolves.toBeUndefined();
 
@@ -367,7 +367,7 @@ describe('processPostReceive (pipeline paths)', () => {
     // isOpenBaoConfigured=false (default), so baoClient=null.
     // secretResolver.resolve is called with variables but returns {} because baoClient is null.
     // To trigger secretResolver with variables, use a compose file with env var references.
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: MANIFEST_WITH_PLEX },
         {
@@ -377,8 +377,8 @@ describe('processPostReceive (pipeline paths)', () => {
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
-    const sha2 = await commitFiles(repoPath, {
+    }));
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [
         {
           path: 'plex/docker-compose.yml',
@@ -388,7 +388,7 @@ describe('processPostReceive (pipeline paths)', () => {
       ],
       message: 'update plex',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     await expect(processPostReceive(repoPath, sha1, sha2)).resolves.toBeUndefined();
 

--- a/src/lib/git/__tests__/post-receive-handler.test.ts
+++ b/src/lib/git/__tests__/post-receive-handler.test.ts
@@ -27,20 +27,20 @@ describe('processPostReceive', () => {
   });
 
   it('should log deploy requests for changed stacks and resolve without error', async () => {
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/docker-compose.yml', content: 'v1' },
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/docker-compose.yml', content: 'v2' }],
       message: 'update plex',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     // processPostReceive catches all pipeline errors internally, so it should always resolve
     await expect(processPostReceive(repoPath, sha1, sha2)).resolves.toBeUndefined();
@@ -51,22 +51,22 @@ describe('processPostReceive', () => {
   });
 
   it('should handle manifest-only changes gracefully without logging deploy requests', async () => {
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/docker-compose.yml', content: 'v1' },
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: false\n' },
       ],
       message: 'update manifest only',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     await expect(processPostReceive(repoPath, sha1, sha2)).resolves.toBeUndefined();
 
@@ -78,17 +78,17 @@ describe('processPostReceive', () => {
   });
 
   it('should throw when manifest.yaml is missing', async () => {
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/docker-compose.yml', content: 'v1' }],
       message: 'initial without manifest',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/docker-compose.yml', content: 'v2' }],
       message: 'update plex',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     await expect(processPostReceive(repoPath, sha1, sha2)).rejects.toThrow();
   });
@@ -96,20 +96,20 @@ describe('processPostReceive', () => {
   it('should exclude stacks whose compose file is missing from results', async () => {
 
     // Commit a manifest listing 'plex' with a non-compose file change (so stack is detected as changed)
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/README.md', content: 'v1' },
       ],
       message: 'initial — has README but no docker-compose.yml',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/README.md', content: 'v2' }],
       message: 'update README, no compose file',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     await processPostReceive(repoPath, sha1, sha2);
     // plex changed but has no docker-compose.yml — should be excluded (logged as error)
@@ -130,20 +130,20 @@ describe('processPostReceive', () => {
       }),
     } as unknown as DeployRepository;
 
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/README.md', content: 'v1' },
       ],
       message: 'initial without compose',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/README.md', content: 'v2' }],
       message: 'update plex README, no compose',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     await processPostReceive(repoPath, sha1, sha2, deployRepo);
     expect(insertedDeploys).toHaveLength(1);
@@ -155,20 +155,20 @@ describe('processPostReceive', () => {
 
   it('should log full error object (not just message) when compose read fails', async () => {
 
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/README.md', content: 'v1' },
       ],
       message: 'initial without compose',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/README.md', content: 'v2' }],
       message: 'update plex README, no compose',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     await processPostReceive(repoPath, sha1, sha2);
 
@@ -188,20 +188,20 @@ describe('processPostReceive', () => {
       insertDeploy: mock(async () => { throw new Error('DB unavailable'); }),
     } as unknown as DeployRepository;
 
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/README.md', content: 'v1' },
       ],
       message: 'initial without compose',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/README.md', content: 'v2' }],
       message: 'update plex README, no compose',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     // Should resolve (not throw), even though deployRepo.insertDeploy throws
     await processPostReceive(repoPath, sha1, sha2, deployRepo);

--- a/src/lib/git/__tests__/post-receive.test.ts
+++ b/src/lib/git/__tests__/post-receive.test.ts
@@ -66,7 +66,7 @@ describe('buildDeployRequests', () => {
   });
 
   it('should build deploy requests for autoDeploy stacks', async () => {
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n  traefik:\n    host: homeserver\n    autoDeploy: false\n' },
         { path: 'plex/docker-compose.yml', content: 'services:\n  plex:\n    image: plex:v1\n' },
@@ -74,16 +74,16 @@ describe('buildDeployRequests', () => {
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'plex/docker-compose.yml', content: 'services:\n  plex:\n    image: plex:v2\n' },
         { path: 'traefik/docker-compose.yml', content: 'services:\n  traefik:\n    image: traefik:v2\n' },
       ],
       message: 'update both stacks',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const requests = await buildDeployRequests(repoPath, sha1, sha2);
 
@@ -101,40 +101,40 @@ describe('buildDeployRequests', () => {
   });
 
   it('should skip stacks not in manifest', async () => {
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'unknown/docker-compose.yml', content: 'services: {}' },
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'unknown/docker-compose.yml', content: 'services: {updated: true}' }],
       message: 'update unknown',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const requests = await buildDeployRequests(repoPath, sha1, sha2);
     expect(requests).toHaveLength(0);
   });
 
   it('should include compose path in deploy request', async () => {
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/docker-compose.yml', content: 'v1' },
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/docker-compose.yml', content: 'v2' }],
       message: 'update',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const requests = await buildDeployRequests(repoPath, sha1, sha2);
     expect(requests[0].composePath).toBe('plex/docker-compose.yml');

--- a/src/lib/git/__tests__/repo-diff.test.ts
+++ b/src/lib/git/__tests__/repo-diff.test.ts
@@ -19,17 +19,17 @@ describe('getLog', () => {
   });
 
   it('should return commit log entries', async () => {
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'file.txt', content: 'hello' }],
       message: 'first commit',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'file.txt', content: 'world' }],
       message: 'second commit',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const log = await getLog(repoPath, 10);
     expect(log).toHaveLength(2);
@@ -38,21 +38,21 @@ describe('getLog', () => {
   });
 
   it('should respect depth limit', async () => {
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'a.txt', content: 'a' }],
       message: 'first',
       author: { name: 'test', email: 'test@test.com' },
-    });
-    await commitFiles(repoPath, {
+    }));
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'b.txt', content: 'b' }],
       message: 'second',
       author: { name: 'test', email: 'test@test.com' },
-    });
-    await commitFiles(repoPath, {
+    }));
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'c.txt', content: 'c' }],
       message: 'third',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const log = await getLog(repoPath, 2);
     expect(log).toHaveLength(2);
@@ -74,20 +74,20 @@ describe('diffCommits', () => {
   });
 
   it('should detect changed files between two commits', async () => {
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks: {}' },
         { path: 'plex/docker-compose.yml', content: 'v1' },
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'plex/docker-compose.yml', content: 'v2' }],
       message: 'update plex',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const changed = await diffCommits(repoPath, sha1, sha2);
     expect(changed).toContain('plex/docker-compose.yml');
@@ -95,17 +95,17 @@ describe('diffCommits', () => {
   });
 
   it('should detect new files', async () => {
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [{ path: 'manifest.yaml', content: 'stacks: {}' }],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'traefik/docker-compose.yml', content: 'services: {}' }],
       message: 'add traefik',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const changed = await diffCommits(repoPath, sha1, sha2);
     expect(changed).toContain('traefik/docker-compose.yml');
@@ -114,17 +114,17 @@ describe('diffCommits', () => {
   it('should detect deleted files', async () => {
     // sha1 has only manifest, sha2 adds traefik on top
     // Diffing sha2→sha1 exercises the deletion detection code path
-    const sha1 = await commitFiles(repoPath, {
+    const sha1 = await commitFiles(repoPath, () => ({
       files: [{ path: 'manifest.yaml', content: 'stacks: {}' }],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
-    const sha2 = await commitFiles(repoPath, {
+    const sha2 = await commitFiles(repoPath, () => ({
       files: [{ path: 'traefik/docker-compose.yml', content: 'services: {}' }],
       message: 'add traefik',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     // Reverse diff: from sha2 (has traefik) to sha1 (no traefik) = traefik deleted
     const changed = await diffCommits(repoPath, sha2, sha1);

--- a/src/lib/git/__tests__/repo.test.ts
+++ b/src/lib/git/__tests__/repo.test.ts
@@ -81,14 +81,14 @@ describe('readFileFromRepo', () => {
     repoPath = join(testDir, 'test.git');
     await initBareRepo(repoPath);
     // Seed with a commit
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/docker-compose.yml', content: 'services:\n  plex:\n    image: plexinc/pms-docker\n' },
       ],
       message: 'initial commit',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
   });
 
   afterEach(() => {
@@ -119,7 +119,7 @@ describe('listFilesInRepo', () => {
     testDir = mkdtempSync(join(getTestTmpDir(), 'git-list-'));
     repoPath = join(testDir, 'test.git');
     await initBareRepo(repoPath);
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks: {}' },
         { path: 'plex/docker-compose.yml', content: 'services: {}' },
@@ -127,7 +127,7 @@ describe('listFilesInRepo', () => {
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
   });
 
   afterEach(() => {
@@ -155,7 +155,7 @@ describe('commitFiles with filesToDelete', () => {
     testDir = mkdtempSync(join(getTestTmpDir(), 'git-delete-'));
     repoPath = join(testDir, 'test.git');
     await initBareRepo(repoPath);
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [
         { path: 'manifest.yaml', content: 'stacks: {}' },
         { path: 'plex/docker-compose.yml', content: 'services: {}' },
@@ -164,7 +164,7 @@ describe('commitFiles with filesToDelete', () => {
       ],
       message: 'initial',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
   });
 
   afterEach(() => {
@@ -172,12 +172,12 @@ describe('commitFiles with filesToDelete', () => {
   });
 
   it('should delete a single file', async () => {
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [],
       filesToDelete: ['manifest.yaml'],
       message: 'delete manifest',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const files = await listFilesInRepo(repoPath);
     expect(files).not.toContain('manifest.yaml');
@@ -185,12 +185,12 @@ describe('commitFiles with filesToDelete', () => {
   });
 
   it('should delete an entire directory', async () => {
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [],
       filesToDelete: ['plex'],
       message: 'delete plex stack',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const files = await listFilesInRepo(repoPath);
     expect(files).not.toContain('plex/docker-compose.yml');
@@ -200,12 +200,12 @@ describe('commitFiles with filesToDelete', () => {
   });
 
   it('should handle trailing slash in directory path', async () => {
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [],
       filesToDelete: ['plex/'],
       message: 'delete plex with trailing slash',
       author: { name: 'test', email: 'test@test.com' },
-    });
+    }));
 
     const files = await listFilesInRepo(repoPath);
     expect(files).not.toContain('plex/docker-compose.yml');
@@ -231,16 +231,16 @@ describe('commitFiles mutex', () => {
     const author = { name: 'test', email: 'test@test.com' };
 
     const [oid1, oid2] = await Promise.all([
-      commitFiles(repoPath, {
+      commitFiles(repoPath, () => ({
         files: [{ path: 'a.txt', content: 'file-a' }],
         message: 'add a',
         author,
-      }),
-      commitFiles(repoPath, {
+      })),
+      commitFiles(repoPath, () => ({
         files: [{ path: 'b.txt', content: 'file-b' }],
         message: 'add b',
         author,
-      }),
+      })),
     ]);
 
     expect(oid1).not.toBe(oid2);
@@ -255,5 +255,121 @@ describe('commitFiles mutex', () => {
     const contentB = await readFileFromRepo(repoPath, 'b.txt');
     expect(contentA).toBe('file-a');
     expect(contentB).toBe('file-b');
+  });
+});
+
+describe('commitFiles callback runs inside lock (issue #98)', () => {
+  let testDir: string;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    testDir = mkdtempSync(join(getTestTmpDir(), 'git-race-'));
+    repoPath = join(testDir, 'test.git');
+    await initBareRepo(repoPath);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('concurrent manifest-merging commits for different stacks both end up in manifest', async () => {
+    // Simulates createStackInRepo's pattern: read manifest from HEAD, add a new stack,
+    // write updated manifest + a new compose file — all inside the commit callback.
+    //
+    // Before the #98 fix: readers outside the lock both saw manifest = {} and
+    // then serialized their pre-built plans, clobbering each other's manifest entries
+    // while the compose files survived as orphans.
+    // With the callback-inside-lock pattern, the second caller sees the first's
+    // committed manifest via existingFiles and merges its entry on top.
+    const author = { name: 'test', email: 'test@test.com' };
+
+    function addStackCallback(stackName: string, host: string) {
+      return (existingFiles: ReadonlyMap<string, string>) => {
+        const current = existingFiles.get('manifest.yaml') ?? 'stacks: {}\n';
+        // Trivial YAML merge: append a new entry under "stacks:".
+        // (Parsing/dumping is exercised elsewhere — we just need a deterministic merge.)
+        const hasEntry = current.includes(`${stackName}:`);
+        const updated = hasEntry
+          ? current
+          : current.replace(/stacks:\s*(\{\}\s*)?\n?/, `stacks:\n`) +
+            `  ${stackName}:\n    host: ${host}\n    autoDeploy: true\n`;
+        return {
+          files: [
+            { path: `${stackName}/docker-compose.yml`, content: `# ${stackName} compose\n` },
+            { path: 'manifest.yaml', content: updated },
+          ],
+          message: `Add stack: ${stackName}`,
+          author,
+        };
+      };
+    }
+
+    await Promise.all([
+      commitFiles(repoPath, addStackCallback('alpha', 'host-a')),
+      commitFiles(repoPath, addStackCallback('beta', 'host-b')),
+    ]);
+
+    const manifest = await readFileFromRepo(repoPath, 'manifest.yaml');
+    // Both stacks' entries must be present — neither overwrote the other.
+    expect(manifest).toContain('alpha:');
+    expect(manifest).toContain('beta:');
+    expect(manifest).toContain('host: host-a');
+    expect(manifest).toContain('host: host-b');
+
+    // Both compose files must survive in HEAD — no orphan, no lost entry.
+    const alphaCompose = await readFileFromRepo(repoPath, 'alpha/docker-compose.yml');
+    const betaCompose = await readFileFromRepo(repoPath, 'beta/docker-compose.yml');
+    expect(alphaCompose).toContain('alpha compose');
+    expect(betaCompose).toContain('beta compose');
+  });
+
+  it('passes a snapshot of existing HEAD files into the callback', async () => {
+    await commitFiles(repoPath, () => ({
+      files: [{ path: 'seed.txt', content: 'initial' }],
+      message: 'seed',
+      author: { name: 'test', email: 'test@test.com' },
+    }));
+
+    let observedInsideCallback: string | undefined;
+    await commitFiles(repoPath, (existingFiles) => {
+      observedInsideCallback = existingFiles.get('seed.txt');
+      return {
+        files: [{ path: 'seed.txt', content: 'updated' }],
+        message: 'update',
+        author: { name: 'test', email: 'test@test.com' },
+      };
+    });
+
+    expect(observedInsideCallback).toBe('initial');
+  });
+
+  it('passes an empty map to the callback on the first commit', async () => {
+    let observedSize = -1;
+    await commitFiles(repoPath, (existingFiles) => {
+      observedSize = existingFiles.size;
+      return {
+        files: [{ path: 'first.txt', content: 'hi' }],
+        message: 'first',
+        author: { name: 'test', email: 'test@test.com' },
+      };
+    });
+    expect(observedSize).toBe(0);
+  });
+
+  it('propagates errors thrown from the callback without writing a commit', async () => {
+    await commitFiles(repoPath, () => ({
+      files: [{ path: 'seed.txt', content: 'v1' }],
+      message: 'seed',
+      author: { name: 'test', email: 'test@test.com' },
+    }));
+
+    await expect(
+      commitFiles(repoPath, () => {
+        throw new Error('callback rejected plan');
+      }),
+    ).rejects.toThrow(/callback rejected plan/);
+
+    const log = await getLog(repoPath, 10);
+    expect(log).toHaveLength(1);
   });
 });

--- a/src/lib/git/__tests__/repo.test.ts
+++ b/src/lib/git/__tests__/repo.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import git from 'isomorphic-git';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'node:path';
+import yaml from 'js-yaml';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import {
   initBareRepo,
@@ -286,13 +287,9 @@ describe('commitFiles callback runs inside lock (issue #98)', () => {
     function addStackCallback(stackName: string, host: string) {
       return (existingFiles: ReadonlyMap<string, string>) => {
         const current = existingFiles.get('manifest.yaml') ?? 'stacks: {}\n';
-        // Trivial YAML merge: append a new entry under "stacks:".
-        // (Parsing/dumping is exercised elsewhere — we just need a deterministic merge.)
-        const hasEntry = current.includes(`${stackName}:`);
-        const updated = hasEntry
-          ? current
-          : current.replace(/stacks:\s*(\{\}\s*)?\n?/, `stacks:\n`) +
-            `  ${stackName}:\n    host: ${host}\n    autoDeploy: true\n`;
+        const parsed = (yaml.load(current) as { stacks?: Record<string, unknown> } | null) ?? { stacks: {} };
+        parsed.stacks = { ...(parsed.stacks ?? {}), [stackName]: { host, autoDeploy: true } };
+        const updated = yaml.dump(parsed, { indent: 2, sortKeys: true });
         return {
           files: [
             { path: `${stackName}/docker-compose.yml`, content: `# ${stackName} compose\n` },

--- a/src/lib/git/editor-operations.ts
+++ b/src/lib/git/editor-operations.ts
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import { commitFiles, readFileFromRepo } from '@/lib/git/repo';
+import { commitFiles } from '@/lib/git/repo';
 import { parseManifest } from '@/lib/git/manifest';
 
 interface SaveFileOptions {
@@ -21,11 +21,11 @@ export async function saveAndCommitFile(
   repoPath: string,
   options: SaveFileOptions,
 ): Promise<SaveResult> {
-  const commitSha = await commitFiles(repoPath, {
+  const commitSha = await commitFiles(repoPath, () => ({
     files: [{ path: options.filePath, content: options.content }],
     message: options.message,
     author: options.author,
-  });
+  }));
 
   return { commitSha };
 }
@@ -39,30 +39,34 @@ interface UpdateManifestOptions {
 
 /**
  * Add or update a stack entry in manifest.yaml and commit.
+ * The manifest is read inside the commit callback (under the repo lock)
+ * so concurrent callers never overwrite each other's mutations.
  */
 export async function updateManifest(
   repoPath: string,
   options: UpdateManifestOptions,
 ): Promise<SaveResult> {
-  const manifestContent = await readFileFromRepo(repoPath, 'manifest.yaml');
-  const manifest = parseManifest(manifestContent);
+  const commitSha = await commitFiles(repoPath, (existingFiles) => {
+    const manifestContent = existingFiles.get('manifest.yaml') ?? 'stacks: {}\n';
+    const manifest = parseManifest(manifestContent);
 
-  manifest.stacks[options.stackName] = {
-    host: options.host,
-    autoDeploy: options.autoDeploy,
-  };
+    manifest.stacks[options.stackName] = {
+      host: options.host,
+      autoDeploy: options.autoDeploy,
+    };
 
-  const newContent = yaml.dump(manifest, {
-    indent: 2,
-    lineWidth: -1,
-    noRefs: true,
-    sortKeys: true,
-  });
+    const newContent = yaml.dump(manifest, {
+      indent: 2,
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: true,
+    });
 
-  const commitSha = await commitFiles(repoPath, {
-    files: [{ path: 'manifest.yaml', content: newContent }],
-    message: `Update manifest: ${options.stackName} on ${options.host}`,
-    author: options.author,
+    return {
+      files: [{ path: 'manifest.yaml', content: newContent }],
+      message: `Update manifest: ${options.stackName} on ${options.host}`,
+      author: options.author,
+    };
   });
 
   return { commitSha };

--- a/src/lib/git/editor-operations.ts
+++ b/src/lib/git/editor-operations.ts
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import { commitFiles } from '@/lib/git/repo';
+import { commitFiles, FileNotFoundError } from '@/lib/git/repo';
 import { parseManifest } from '@/lib/git/manifest';
 
 interface SaveFileOptions {
@@ -39,15 +39,16 @@ interface UpdateManifestOptions {
 
 /**
  * Add or update a stack entry in manifest.yaml and commit.
- * The manifest is read inside the commit callback (under the repo lock)
- * so concurrent callers never overwrite each other's mutations.
  */
 export async function updateManifest(
   repoPath: string,
   options: UpdateManifestOptions,
 ): Promise<SaveResult> {
   const commitSha = await commitFiles(repoPath, (existingFiles) => {
-    const manifestContent = existingFiles.get('manifest.yaml') ?? 'stacks: {}\n';
+    const manifestContent = existingFiles.get('manifest.yaml');
+    if (manifestContent === undefined) {
+      throw new FileNotFoundError('manifest.yaml');
+    }
     const manifest = parseManifest(manifestContent);
 
     manifest.stacks[options.stackName] = {

--- a/src/lib/git/init-repo.ts
+++ b/src/lib/git/init-repo.ts
@@ -18,14 +18,14 @@ export async function ensureRepoInitialized(): Promise<void> {
 
   const hasCommits = await hasAnyCommits(repoPath);
   if (!hasCommits) {
-    await commitFiles(repoPath, {
+    await commitFiles(repoPath, () => ({
       files: [{ path: 'manifest.yaml', content: DEFAULT_MANIFEST }],
       message: 'Initialize stacks repository',
       author: {
         name: 'homelab-manager',
         email: 'homelab-manager@localhost',
       },
-    });
+    }));
   }
 }
 

--- a/src/lib/git/init-repo.ts
+++ b/src/lib/git/init-repo.ts
@@ -16,17 +16,19 @@ export async function ensureRepoInitialized(): Promise<void> {
 
   await initBareRepo(repoPath);
 
-  const hasCommits = await hasAnyCommits(repoPath);
-  if (!hasCommits) {
-    await commitFiles(repoPath, () => ({
+  if (await hasAnyCommits(repoPath)) return;
+
+  await commitFiles(repoPath, (existingFiles) => {
+    if (existingFiles.size > 0) return null; // another writer initialized first
+    return {
       files: [{ path: 'manifest.yaml', content: DEFAULT_MANIFEST }],
       message: 'Initialize stacks repository',
       author: {
         name: 'homelab-manager',
         email: 'homelab-manager@localhost',
       },
-    }));
-  }
+    };
+  });
 }
 
 async function hasAnyCommits(repoPath: string): Promise<boolean> {

--- a/src/lib/git/repo.ts
+++ b/src/lib/git/repo.ts
@@ -68,10 +68,6 @@ export interface FileEntry {
   content: string;
 }
 
-/**
- * Plan returned by a {@link CommitCallback}, describing the mutations to apply
- * to the repository's current HEAD tree.
- */
 export interface CommitPlan {
   files: FileEntry[];
   /** Paths to remove from the tree in this commit (e.g. deleting a stack directory). */
@@ -80,23 +76,14 @@ export interface CommitPlan {
   author: { name: string; email: string };
 }
 
-/**
- * Callback invoked inside the repo lock with a snapshot of the current HEAD tree.
- * Return a {@link CommitPlan} describing the mutations to apply on top of that snapshot.
- * Running the plan computation inside the lock prevents stale-read races between
- * concurrent `commitFiles` calls.
- */
+/** Runs inside the repo lock with a HEAD snapshot — guarantees mutations derive from current state, not a stale pre-lock read. */
 export type CommitCallback = (
   existingFiles: ReadonlyMap<string, string>,
 ) => Promise<CommitPlan> | CommitPlan;
 
 /**
- * Commit files to a bare repository.
- *
- * The caller provides a callback that runs INSIDE `withRepoLock` and receives a
- * snapshot of HEAD's tree. The callback decides what files to write or delete,
- * returning a {@link CommitPlan}. This prevents races where two callers read
- * stale state before the lock and then overwrite each other's mutations.
+ * Commit files to a bare repository. The callback runs inside the repo lock
+ * and receives a snapshot of HEAD's tree; it returns the commit plan.
  *
  * Note: This reads the entire existing tree into memory to overlay new files.
  * This is acceptable for v1 since repos only contain small compose files and manifests.

--- a/src/lib/git/repo.ts
+++ b/src/lib/git/repo.ts
@@ -68,7 +68,11 @@ export interface FileEntry {
   content: string;
 }
 
-export interface CommitOptions {
+/**
+ * Plan returned by a {@link CommitCallback}, describing the mutations to apply
+ * to the repository's current HEAD tree.
+ */
+export interface CommitPlan {
   files: FileEntry[];
   /** Paths to remove from the tree in this commit (e.g. deleting a stack directory). */
   filesToDelete?: string[];
@@ -77,9 +81,22 @@ export interface CommitOptions {
 }
 
 /**
+ * Callback invoked inside the repo lock with a snapshot of the current HEAD tree.
+ * Return a {@link CommitPlan} describing the mutations to apply on top of that snapshot.
+ * Running the plan computation inside the lock prevents stale-read races between
+ * concurrent `commitFiles` calls.
+ */
+export type CommitCallback = (
+  existingFiles: ReadonlyMap<string, string>,
+) => Promise<CommitPlan> | CommitPlan;
+
+/**
  * Commit files to a bare repository.
- * Builds a tree from scratch each time (full snapshot), writes it, and creates a commit
- * pointing to the current HEAD (if any) as parent.
+ *
+ * The caller provides a callback that runs INSIDE `withRepoLock` and receives a
+ * snapshot of HEAD's tree. The callback decides what files to write or delete,
+ * returning a {@link CommitPlan}. This prevents races where two callers read
+ * stale state before the lock and then overwrite each other's mutations.
  *
  * Note: This reads the entire existing tree into memory to overlay new files.
  * This is acceptable for v1 since repos only contain small compose files and manifests.
@@ -87,12 +104,10 @@ export interface CommitOptions {
  */
 export async function commitFiles(
   repoPath: string,
-  options: CommitOptions,
+  callback: CommitCallback,
 ): Promise<string> {
   return withRepoLock(repoPath, async () => {
-    const { files, filesToDelete, message, author } = options;
-
-    let existingFiles = new Map<string, string>();
+    const existingFiles = new Map<string, string>();
     let parentCommit: string | undefined;
     try {
       parentCommit = await git.resolveRef({ fs, gitdir: repoPath, ref: 'HEAD' });
@@ -102,8 +117,12 @@ export async function commitFiles(
 
     if (parentCommit) {
       const { tree } = await git.readTree({ fs, gitdir: repoPath, oid: parentCommit });
-      existingFiles = await readTreeRecursive(repoPath, tree, '');
+      const snapshot = await readTreeRecursive(repoPath, tree, '');
+      for (const [k, v] of snapshot) existingFiles.set(k, v);
     }
+
+    const plan = await callback(existingFiles);
+    const { files, filesToDelete, message, author } = plan;
 
     for (const file of files) {
       existingFiles.set(file.path, file.content);

--- a/src/lib/git/repo.ts
+++ b/src/lib/git/repo.ts
@@ -81,6 +81,11 @@ export type CommitCallback = (
   existingFiles: ReadonlyMap<string, string>,
 ) => Promise<CommitPlan> | CommitPlan;
 
+/** Like {@link CommitCallback} but may return null to skip the commit (e.g., another writer already did it). */
+export type SkippableCommitCallback = (
+  existingFiles: ReadonlyMap<string, string>,
+) => Promise<CommitPlan | null> | CommitPlan | null;
+
 /**
  * Commit files to a bare repository. The callback runs inside the repo lock
  * and receives a snapshot of HEAD's tree; it returns the commit plan.
@@ -89,10 +94,12 @@ export type CommitCallback = (
  * This is acceptable for v1 since repos only contain small compose files and manifests.
  * For optimization later, compare blob OIDs instead of reading content to skip unchanged files.
  */
+export async function commitFiles(repoPath: string, callback: CommitCallback): Promise<string>;
+export async function commitFiles(repoPath: string, callback: SkippableCommitCallback): Promise<string | null>;
 export async function commitFiles(
   repoPath: string,
-  callback: CommitCallback,
-): Promise<string> {
+  callback: SkippableCommitCallback,
+): Promise<string | null> {
   return withRepoLock(repoPath, async () => {
     const existingFiles = new Map<string, string>();
     let parentCommit: string | undefined;
@@ -109,6 +116,7 @@ export async function commitFiles(
     }
 
     const plan = await callback(existingFiles);
+    if (plan === null) return null;
     const { files, filesToDelete, message, author } = plan;
 
     for (const file of files) {

--- a/src/lib/stacks/stack-service.ts
+++ b/src/lib/stacks/stack-service.ts
@@ -209,7 +209,7 @@ export async function createStackInRepo(
     throw new Error(`Invalid stack name "${stackName}" — must contain only letters, numbers, hyphens, and underscores`);
   }
 
-  // Validate host exists in managed_hosts (DB call must stay OUTSIDE the git lock).
+  // Validate host exists in managed_hosts
   const { databaseConnectionManager } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
   const { ManagedHostsRepository } = await import('@/lib/database/repositories/managed-hosts-repository');
@@ -220,9 +220,6 @@ export async function createStackInRepo(
   const managedHost = await hostsRepo.getByName(host);
   if (!managedHost) throw new Error(`Host "${host}" not found in managed_hosts`);
 
-  // Manifest read + "already exists" check + manifest mutation all happen inside
-  // the commit callback so concurrent creates for different stacks cannot race:
-  // each call sees the other's committed manifest via the fresh HEAD snapshot.
   const commitSha = await commitFiles(repoPath, (existingFiles) => {
     const manifestContent = existingFiles.get(MANIFEST_FILENAME);
     const manifest = manifestContent ? parseManifest(manifestContent) : { stacks: {} };
@@ -258,16 +255,14 @@ export async function deleteStackFromRepo(
 ): Promise<{ commitSha: string }> {
   const repoPath = getRepoPath();
 
-  // Read manifest OUTSIDE the git lock to get the host for DB/teardown operations.
-  // The authoritative manifest read happens again inside the commit callback below.
   const manifestContent = await readFileFromRepo(repoPath, MANIFEST_FILENAME);
-  const preManifest = parseManifest(manifestContent);
-  const entry = preManifest.stacks[stackName];
+  const manifest = parseManifest(manifestContent);
+  const entry = manifest.stacks[stackName];
   if (!entry) throw new Error(`Stack "${stackName}" not found in manifest`);
 
   const { host } = entry;
 
-  // Check for active deploys (DB calls must stay OUTSIDE the git lock).
+  // Check for active deploys
   const { databaseConnectionManager } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
   const { DeployRepository } = await import('@/lib/database/repositories/deploy-repository');
@@ -286,11 +281,12 @@ export async function deleteStackFromRepo(
     await teardownAndAwait(stackName, host, deployRepo);
   }
 
-  // Manifest mutation + stack-file enumeration both derive from the fresh HEAD
-  // snapshot inside the lock so concurrent deletes/creates cannot clobber each other.
   const commitSha = await commitFiles(repoPath, (existingFiles) => {
     const freshManifestContent = existingFiles.get(MANIFEST_FILENAME);
-    const manifest = freshManifestContent ? parseManifest(freshManifestContent) : { stacks: {} };
+    if (freshManifestContent === undefined) {
+      throw new Error(`Stack "${stackName}" not found in manifest`);
+    }
+    const manifest = parseManifest(freshManifestContent);
 
     if (!manifest.stacks[stackName]) {
       throw new Error(`Stack "${stackName}" not found in manifest`);

--- a/src/lib/stacks/stack-service.ts
+++ b/src/lib/stacks/stack-service.ts
@@ -209,7 +209,7 @@ export async function createStackInRepo(
     throw new Error(`Invalid stack name "${stackName}" — must contain only letters, numbers, hyphens, and underscores`);
   }
 
-  // Validate host exists in managed_hosts
+  // Validate host exists in managed_hosts (DB call must stay OUTSIDE the git lock).
   const { databaseConnectionManager } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
   const { ManagedHostsRepository } = await import('@/lib/database/repositories/managed-hosts-repository');
@@ -220,41 +220,33 @@ export async function createStackInRepo(
   const managedHost = await hostsRepo.getByName(host);
   if (!managedHost) throw new Error(`Host "${host}" not found in managed_hosts`);
 
-  // Read manifest and validate stack doesn't already exist
-  let manifest: ReturnType<typeof parseManifest>;
-  try {
-    const manifestContent = await readFileFromRepo(repoPath, MANIFEST_FILENAME);
-    manifest = parseManifest(manifestContent);
-  } catch (err: unknown) {
-    if (err instanceof FileNotFoundError) {
-      // No manifest yet — start with empty stacks
-      manifest = { stacks: {} };
-    } else {
-      throw err;
+  // Manifest read + "already exists" check + manifest mutation all happen inside
+  // the commit callback so concurrent creates for different stacks cannot race:
+  // each call sees the other's committed manifest via the fresh HEAD snapshot.
+  const commitSha = await commitFiles(repoPath, (existingFiles) => {
+    const manifestContent = existingFiles.get(MANIFEST_FILENAME);
+    const manifest = manifestContent ? parseManifest(manifestContent) : { stacks: {} };
+
+    if (manifest.stacks[stackName]) {
+      throw new Error(`Stack "${stackName}" already exists`);
     }
-  }
 
-  if (manifest.stacks[stackName]) {
-    throw new Error(`Stack "${stackName}" already exists`);
-  }
+    manifest.stacks[stackName] = { host, autoDeploy };
+    const newManifestContent = yaml.dump(manifest, {
+      indent: 2,
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: true,
+    });
 
-  // Build updated manifest
-  manifest.stacks[stackName] = { host, autoDeploy };
-  const newManifestContent = yaml.dump(manifest, {
-    indent: 2,
-    lineWidth: -1,
-    noRefs: true,
-    sortKeys: true,
-  });
-
-  // Atomic commit: empty compose file + updated manifest
-  const commitSha = await commitFiles(repoPath, {
-    files: [
-      { path: `${stackName}/${COMPOSE_FILENAME}`, content: '' },
-      { path: MANIFEST_FILENAME, content: newManifestContent },
-    ],
-    message: `Add stack: ${stackName} on ${host}`,
-    author: SYSTEM_AUTHOR,
+    return {
+      files: [
+        { path: `${stackName}/${COMPOSE_FILENAME}`, content: '' },
+        { path: MANIFEST_FILENAME, content: newManifestContent },
+      ],
+      message: `Add stack: ${stackName} on ${host}`,
+      author: SYSTEM_AUTHOR,
+    };
   });
 
   return { commitSha };
@@ -266,15 +258,16 @@ export async function deleteStackFromRepo(
 ): Promise<{ commitSha: string }> {
   const repoPath = getRepoPath();
 
-  // Read manifest to get host for this stack
+  // Read manifest OUTSIDE the git lock to get the host for DB/teardown operations.
+  // The authoritative manifest read happens again inside the commit callback below.
   const manifestContent = await readFileFromRepo(repoPath, MANIFEST_FILENAME);
-  const manifest = parseManifest(manifestContent);
-  const entry = manifest.stacks[stackName];
+  const preManifest = parseManifest(manifestContent);
+  const entry = preManifest.stacks[stackName];
   if (!entry) throw new Error(`Stack "${stackName}" not found in manifest`);
 
   const { host } = entry;
 
-  // Check for active deploys
+  // Check for active deploys (DB calls must stay OUTSIDE the git lock).
   const { databaseConnectionManager } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
   const { DeployRepository } = await import('@/lib/database/repositories/deploy-repository');
@@ -293,33 +286,33 @@ export async function deleteStackFromRepo(
     await teardownAndAwait(stackName, host, deployRepo);
   }
 
-  // Remove stack from manifest
-  delete manifest.stacks[stackName];
-  const newManifestContent = yaml.dump(manifest, {
-    indent: 2,
-    lineWidth: -1,
-    noRefs: true,
-    sortKeys: true,
-  });
+  // Manifest mutation + stack-file enumeration both derive from the fresh HEAD
+  // snapshot inside the lock so concurrent deletes/creates cannot clobber each other.
+  const commitSha = await commitFiles(repoPath, (existingFiles) => {
+    const freshManifestContent = existingFiles.get(MANIFEST_FILENAME);
+    const manifest = freshManifestContent ? parseManifest(freshManifestContent) : { stacks: {} };
 
-  // Get all files in the stack directory to remove them
-  let stackFiles: string[];
-  try {
-    stackFiles = await (await import('@/lib/git/repo')).listFilesInRepo(repoPath, stackName);
-  } catch (err: unknown) {
-    if (err instanceof FileNotFoundError || (err instanceof Error && err.message.includes('Could not resolve'))) {
-      stackFiles = [];
-    } else {
-      throw err;
+    if (!manifest.stacks[stackName]) {
+      throw new Error(`Stack "${stackName}" not found in manifest`);
     }
-  }
 
-  // Atomic commit: remove stack files + update manifest
-  const commitSha = await commitFiles(repoPath, {
-    files: [{ path: MANIFEST_FILENAME, content: newManifestContent }],
-    filesToDelete: stackFiles,
-    message: `Remove stack: ${stackName}`,
-    author: SYSTEM_AUTHOR,
+    delete manifest.stacks[stackName];
+    const newManifestContent = yaml.dump(manifest, {
+      indent: 2,
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: true,
+    });
+
+    const stackDirPrefix = `${stackName}/`;
+    const stackFiles = Array.from(existingFiles.keys()).filter((p) => p.startsWith(stackDirPrefix));
+
+    return {
+      files: [{ path: MANIFEST_FILENAME, content: newManifestContent }],
+      filesToDelete: stackFiles,
+      message: `Remove stack: ${stackName}`,
+      author: SYSTEM_AUTHOR,
+    };
   });
 
   return { commitSha };


### PR DESCRIPTION
## Summary
- Refactored `commitFiles` to accept a callback that runs INSIDE `withRepoLock` and receives a `ReadonlyMap<string, string>` snapshot of the current HEAD tree. The callback returns a `CommitPlan` derived from that fresh state, so stale-read races like #98 become impossible by construction.
- Updated all callers: `createStackInRepo`, `deleteStackFromRepo`, `saveAndCommitFile`, `updateManifest`, and `ensureRepoInitialized`. Host validation and active-deploy checks stay outside the git lock to avoid holding the mutex across PostgreSQL round-trips.
- Added a concurrent-create race test plus callback-semantics coverage in `repo.test.ts`.

Closes #98.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` — 2107 pass, 0 new failures (9 pre-existing failures in `DualSeriesChart`, `getChartOption`, `stacks-context` are unrelated to this change)
- [x] New concurrent-commit race test covers the issue-#98 scenario (two parallel manifest-merging commits both land without clobber)
- [x] New coverage for callback snapshot semantics: receives prior HEAD contents, empty map on first commit, errors propagate without writing a commit

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved atomicity of file operations by enabling functions to inspect current state before committing changes, reducing race conditions in concurrent scenarios.

* **Tests**
  * Updated test infrastructure to verify new concurrency handling for stack and manifest operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->