### PR TITLE
refactor(tests): eliminate stack-service mock.module pollution via DI seams

### DIFF
--- a/src/components/stacks/ComposeEditor.tsx
+++ b/src/components/stacks/ComposeEditor.tsx
@@ -17,9 +17,10 @@ interface ComposeEditorProps {
   content: string;
   variables: string[];
   _monacoLoader?: () => Promise<unknown>;
+  _saveCompose?: typeof saveComposeFile;
 }
 
-export default function ComposeEditor({ stackName, content, variables: initialVariables, _monacoLoader }: Readonly<ComposeEditorProps>) {
+export default function ComposeEditor({ stackName, content, variables: initialVariables, _monacoLoader, _saveCompose }: Readonly<ComposeEditorProps>) {
   const [monacoReady, setMonacoReady] = useState(false);
   const [monacoLoadFailed, setMonacoLoadFailed] = useState(false);
   const [editorContent, setEditorContent] = useState(content);
@@ -50,7 +51,7 @@ export default function ComposeEditor({ stackName, content, variables: initialVa
   const isDirty = editorContent !== content;
 
   const saveMutation = useMutation({
-    mutationFn: () => saveComposeFile({ data: { stackName, content: editorContent } }),
+    mutationFn: () => (_saveCompose ?? saveComposeFile)({ data: { stackName, content: editorContent } }),
     onSuccess: async () => {
       await queryClient.invalidateQueries({ queryKey: ['stack-detail', stackName] });
     },

--- a/src/components/stacks/DeployHistoryList.tsx
+++ b/src/components/stacks/DeployHistoryList.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import { Skeleton, ToggleButton, ToggleButtonGroup, Tooltip, Typography } from '@mui/material';
 import { HelpCircle } from 'lucide-react';
 import type { StackDeployRecord, DeployStatus } from '@/types/stacks';
+import type { triggerDeploy } from '@/data/stacks/functions';
 import DeployHistoryRow from '@/components/stacks/DeployHistoryRow';
 
 type StatusFilter = DeployStatus | 'all';
@@ -13,6 +14,7 @@ interface DeployHistoryListProps {
   host?: string;
   onRollbackComplete?: () => void;
   onRollbackError?: (err: Error) => void;
+  _triggerDeploy?: typeof triggerDeploy;
 }
 
 export default function DeployHistoryList({
@@ -22,6 +24,7 @@ export default function DeployHistoryList({
   host,
   onRollbackComplete,
   onRollbackError,
+  _triggerDeploy,
 }: Readonly<DeployHistoryListProps>) {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
 
@@ -109,6 +112,7 @@ export default function DeployHistoryList({
               host={host}
               onRollbackComplete={onRollbackComplete}
               onRollbackError={onRollbackError}
+              _triggerDeploy={_triggerDeploy}
             />
           ))}
         </div>

--- a/src/components/stacks/DeployHistoryRow.tsx
+++ b/src/components/stacks/DeployHistoryRow.tsx
@@ -41,9 +41,10 @@ interface DeployHistoryRowProps {
   host?: string;
   onRollbackComplete?: () => void;
   onRollbackError?: (err: Error) => void;
+  _triggerDeploy?: typeof triggerDeploy;
 }
 
-export default function DeployHistoryRow({ record, stackName, host, onRollbackComplete, onRollbackError }: Readonly<DeployHistoryRowProps>) {
+export default function DeployHistoryRow({ record, stackName, host, onRollbackComplete, onRollbackError, _triggerDeploy }: Readonly<DeployHistoryRowProps>) {
   const [expanded, setExpanded] = useState(false);
   const [rollbackOpen, setRollbackOpen] = useState(false);
   const statusColor = STATUS_COLOR[record.status];
@@ -52,7 +53,7 @@ export default function DeployHistoryRow({ record, stackName, host, onRollbackCo
 
   const rollbackMutation = useMutation({
     mutationFn: () =>
-      triggerDeploy({ data: { stack: stackName!, host: host!, action: 'deploy', commitSha: record.commitSha } }),
+      (_triggerDeploy ?? triggerDeploy)({ data: { stack: stackName!, host: host!, action: 'deploy', commitSha: record.commitSha } }),
     onSuccess: () => onRollbackComplete?.(),
     onError: (err) => onRollbackError?.(err instanceof Error ? err : new Error(String(err))),
   });

--- a/src/components/stacks/__tests__/ComposeEditor-fallback.test.tsx
+++ b/src/components/stacks/__tests__/ComposeEditor-fallback.test.tsx
@@ -2,18 +2,6 @@ import { describe, it, expect, mock } from 'bun:test';
 import { render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
-mock.module('@/lib/stacks/stack-service', () => ({
-  getStackSummaries: mock(() => Promise.resolve([])),
-  getStackDetailByName: mock(() => Promise.resolve(null)),
-  triggerStackDeploy: mock(() => Promise.resolve({ deployId: 1 })),
-  getStackDeployHistory: mock(() => Promise.resolve([])),
-  saveStackComposeFile: mock(() => Promise.resolve({ commitSha: 'abc123' })),
-  updateStackIconSlug: mock(() => Promise.resolve()),
-  createStackInRepo: mock(() => Promise.resolve()),
-  deleteStackFromRepo: mock(() => Promise.resolve()),
-  getManagedHostNames: mock(() => Promise.resolve([])),
-}));
-
 mock.module('@monaco-editor/react', () => ({
   default: () => <div data-testid="mock-editor" />,
 }));

--- a/src/components/stacks/__tests__/ComposeEditor.test.tsx
+++ b/src/components/stacks/__tests__/ComposeEditor.test.tsx
@@ -1,20 +1,17 @@
 import { describe, it, expect, mock } from 'bun:test';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { saveComposeFile } from '@/data/stacks/functions';
 
-const mockSaveStackComposeFile = mock(() => Promise.resolve({ commitSha: 'abc123' }));
-
-mock.module('@/lib/stacks/stack-service', () => ({
-  getStackSummaries: mock(() => Promise.resolve([])),
-  getStackDetailByName: mock(() => Promise.resolve(null)),
-  triggerStackDeploy: mock(() => Promise.resolve({ deployId: 1 })),
-  getStackDeployHistory: mock(() => Promise.resolve([])),
-  saveStackComposeFile: mockSaveStackComposeFile,
-  updateStackIconSlug: mock(() => Promise.resolve()),
-  createStackInRepo: mock(() => Promise.resolve()),
-  deleteStackFromRepo: mock(() => Promise.resolve()),
-  getManagedHostNames: mock(() => Promise.resolve([])),
-}));
+/**
+ * Test-only stub for saveComposeFile. Injected via the `_saveCompose` prop
+ * on ComposeEditor to avoid mock.module() on the stack-service module, which
+ * would pollute concurrent test files that import the real service.
+ * bun's mock() doesn't structurally match the createServerFn fetcher type
+ * (extra properties like url/method/__executeServer), so we cast at the seam.
+ */
+const mockSaveCompose = mock(() => Promise.resolve({ commitSha: 'abc123' }));
+const saveComposeStub = mockSaveCompose as unknown as typeof saveComposeFile;
 
 /**
  * Monaco Editor cannot render in Happy-DOM (CDN script loading is blocked).
@@ -71,7 +68,7 @@ async function renderComposeEditor(props?: Partial<{ stackName: string; content:
     variables: [],
     ...props,
   };
-  const result = render(<ComposeEditor {...defaultProps} />, { wrapper: createWrapper() });
+  const result = render(<ComposeEditor {...defaultProps} _saveCompose={saveComposeStub} />, { wrapper: createWrapper() });
   // Wait for monaco-setup dynamic import to resolve and Editor to render
   await waitFor(() => expect(screen.getByTestId('mock-editor')).toBeDefined());
   return result;
@@ -193,7 +190,7 @@ describe('ComposeEditor component', () => {
   });
 
   it('triggers save mutation and invalidates queries on success', async () => {
-    mockSaveStackComposeFile.mockClear();
+    mockSaveCompose.mockClear();
     const { act } = await import('@testing-library/react');
 
     const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -203,7 +200,7 @@ describe('ComposeEditor component', () => {
     const { default: ComposeEditor } = await import('../ComposeEditor');
     render(
       <QueryClientProvider client={queryClient}>
-        <ComposeEditor stackName="test-stack" content="image: nginx" variables={[]} />
+        <ComposeEditor stackName="test-stack" content="image: nginx" variables={[]} _saveCompose={saveComposeStub} />
       </QueryClientProvider>,
     );
     await waitFor(() => expect(screen.getByTestId('mock-editor')).toBeDefined());
@@ -212,7 +209,7 @@ describe('ComposeEditor component', () => {
     const saveButton = screen.getByRole('button', { name: /save & commit/i });
 
     await act(async () => { fireEvent.click(saveButton); });
-    await waitFor(() => expect(mockSaveStackComposeFile).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockSaveCompose).toHaveBeenCalledTimes(1));
 
     await waitFor(() => expect(invalidateSpy).toHaveBeenCalled());
     expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ['stack-detail', 'test-stack'] });

--- a/src/components/stacks/__tests__/DeployHistoryList.test.tsx
+++ b/src/components/stacks/__tests__/DeployHistoryList.test.tsx
@@ -2,22 +2,18 @@ import { describe, it, expect, mock } from 'bun:test';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { StackDeployRecord } from '@/types/stacks';
+import type { triggerDeploy } from '@/data/stacks/functions';
+import DeployHistoryList from '../DeployHistoryList';
 
-const mockTriggerStackDeploy = mock(() => Promise.resolve({ deployId: 1 }));
-
-mock.module('@/lib/stacks/stack-service', () => ({
-  getStackSummaries: mock(() => Promise.resolve([])),
-  getStackDetailByName: mock(() => Promise.resolve(null)),
-  triggerStackDeploy: mockTriggerStackDeploy,
-  getStackDeployHistory: mock(() => Promise.resolve([])),
-  saveStackComposeFile: mock(() => Promise.resolve({ commitSha: 'abc123' })),
-  updateStackIconSlug: mock(() => Promise.resolve()),
-  createStackInRepo: mock(() => Promise.resolve()),
-  deleteStackFromRepo: mock(() => Promise.resolve()),
-  getManagedHostNames: mock(() => Promise.resolve([])),
-}));
-
-const { default: DeployHistoryList } = await import('../DeployHistoryList');
+/**
+ * Test-only stub for triggerDeploy. Injected via the `_triggerDeploy` prop
+ * on DeployHistoryList to avoid mock.module() on the stack-service module,
+ * which would pollute concurrent test files that import the real service.
+ * bun's mock() doesn't structurally match the createServerFn fetcher type
+ * (extra properties like url/method/__executeServer), so we cast at the seam.
+ */
+const mockTriggerDeploy = mock(() => Promise.resolve({ deployId: 1 }));
+const triggerDeployStub = mockTriggerDeploy as unknown as typeof triggerDeploy;
 
 const mockRecords: StackDeployRecord[] = [
   {
@@ -173,7 +169,7 @@ describe('DeployHistoryList', () => {
   });
 
   it('calls triggerDeploy when rollback is confirmed', async () => {
-    mockTriggerStackDeploy.mockClear();
+    mockTriggerDeploy.mockClear();
 
     render(
       <DeployHistoryList
@@ -181,6 +177,7 @@ describe('DeployHistoryList', () => {
         isLoading={false}
         stackName="plex"
         host="homeserver"
+        _triggerDeploy={triggerDeployStub}
       />,
       { wrapper: createWrapper() },
     );
@@ -191,14 +188,16 @@ describe('DeployHistoryList', () => {
     fireEvent.click(screen.getByText('Confirm Rollback'));
 
     await waitFor(() => {
-      expect(mockTriggerStackDeploy).toHaveBeenCalledTimes(1);
+      expect(mockTriggerDeploy).toHaveBeenCalledTimes(1);
     });
 
-    expect(mockTriggerStackDeploy).toHaveBeenCalledWith({
-      stack: 'plex',
-      host: 'homeserver',
-      action: 'deploy',
-      commitSha: 'a1b2c3d4e5f6',
+    expect(mockTriggerDeploy).toHaveBeenCalledWith({
+      data: {
+        stack: 'plex',
+        host: 'homeserver',
+        action: 'deploy',
+        commitSha: 'a1b2c3d4e5f6',
+      },
     });
   });
 
@@ -231,7 +230,7 @@ describe('DeployHistoryList', () => {
   });
 
   it('calls onRollbackComplete after successful rollback', async () => {
-    mockTriggerStackDeploy.mockClear();
+    mockTriggerDeploy.mockClear();
     const onComplete = mock(() => {});
 
     render(
@@ -241,6 +240,7 @@ describe('DeployHistoryList', () => {
         stackName="plex"
         host="homeserver"
         onRollbackComplete={onComplete}
+        _triggerDeploy={triggerDeployStub}
       />,
       { wrapper: createWrapper() },
     );
@@ -252,7 +252,7 @@ describe('DeployHistoryList', () => {
   });
 
   it('calls onRollbackError when rollback fails', async () => {
-    mockTriggerStackDeploy.mockImplementationOnce(() => Promise.reject(new Error('deploy failed')));
+    const failingTriggerDeploy = mock(() => Promise.reject(new Error('deploy failed'))) as unknown as typeof triggerDeploy;
     const onError = mock(() => {});
 
     render(
@@ -262,6 +262,7 @@ describe('DeployHistoryList', () => {
         stackName="plex"
         host="homeserver"
         onRollbackError={onError}
+        _triggerDeploy={failingTriggerDeploy}
       />,
       { wrapper: createWrapper() },
     );

--- a/src/components/stacks/__tests__/StackNav.test.tsx
+++ b/src/components/stacks/__tests__/StackNav.test.tsx
@@ -43,6 +43,12 @@ mock.module('@tanstack/react-router', () => ({
       {children}
     </a>
   ),
+  // Additional exports that leak into concurrent test files via the shared module
+  // registry. `@tanstack/react-start`'s createServerFn imports both at runtime, so
+  // unrelated tests that transitively load a server function crash with a cryptic
+  // "Export not found" error unless we provide no-op stubs here.
+  isRedirect: () => false,
+  useRouter: () => ({ navigate: () => {}, invalidate: () => {} }),
 }));
 
 let StackNav: ComponentType<{ onCreateClick: () => void }>;


### PR DESCRIPTION
## Summary
- Adds optional test-only props (`_saveCompose`, `_triggerDeploy`) to `ComposeEditor`, `DeployHistoryRow`, and `DeployHistoryList`, matching the existing `_monacoLoader` DI convention. Production paths fall back to the real imports.
- Removes `mock.module('@/lib/stacks/stack-service', ...)` from 3 component test files — they now inject mocks via props.
- Fixes a pre-existing incomplete `@tanstack/react-router` mock in `StackNav.test.tsx` (missing `isRedirect` / `useRouter`). The stack-service mock was previously masking this — removing it in the DI'd tests surfaced the bug.

Follow-up to #120 review note about the latent `mock.module()` pollution footgun.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test src/components/stacks` — 135/135 pass
- [x] Pollution isolation: `bun test ComposeEditor.test.tsx stack-service.test.ts` — 57/57 pass
- [x] Pollution isolation: `bun test DeployHistoryList.test.tsx repo.test.ts` — 29/29 pass

## Out of scope
- `VariablesPanel.test.tsx` (separate CLAUDE.md violation — mocks the `@/data/stacks/functions` barrel directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)