### PR TITLE
feat(agent): retry transient failures in AgentClient (#100)

### DIFF
--- a/src/lib/clients/__tests__/agent-client.test.ts
+++ b/src/lib/clients/__tests__/agent-client.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { AgentClient, AgentClientError, type ZfsPool } from '../agent-client';
 
 describe('AgentClient', () => {
@@ -75,7 +75,8 @@ describe('AgentClient', () => {
     });
 
     it('throws AgentClientError on fetch failure (network error)', async () => {
-      fetchMock.mockRejectedValueOnce(new Error('Connection refused'));
+      // Network errors retry up to 3 times — reject all attempts so we see the final error.
+      fetchMock.mockRejectedValue(new Error('Connection refused'));
 
       await expect(client.deploy({
         stack: 'plex',
@@ -139,7 +140,8 @@ describe('AgentClient', () => {
     });
 
     it('throws AgentClientError when agent is unreachable', async () => {
-      fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      // Network errors retry up to 3 times — reject all attempts.
+      fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
 
       await expect(client.health()).rejects.toThrow(AgentClientError);
     });
@@ -319,6 +321,196 @@ describe('AgentClient', () => {
 
       expect(results).toHaveLength(1);
       expect(results[0]).toEqual({ line: 'ok', timestamp: 999 });
+    });
+  });
+
+  describe('retry behaviour', () => {
+    // Collapse retry backoff sleeps so we don't wait real 1s/2s intervals.
+    // Scoped to this block so stream tests above keep real setTimeout.
+    let setTimeoutSpy: ReturnType<typeof spyOn>;
+    let capturedDelays: number[];
+
+    beforeEach(() => {
+      capturedDelays = [];
+      setTimeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(
+        ((fn: TimerHandler, delay?: number) => {
+          capturedDelays.push(delay ?? 0);
+          if (typeof fn === 'function') fn();
+          return 0 as unknown as ReturnType<typeof setTimeout>;
+        }) as unknown as typeof setTimeout,
+      );
+    });
+
+    afterEach(() => {
+      setTimeoutSpy.mockRestore();
+    });
+
+    const successResponse = () =>
+      new Response(JSON.stringify({ status: 'success', stdout: 'ok', stderr: '' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      });
+
+    const deployPayload = {
+      stack: 'plex',
+      composeContent: 'version: "3"',
+      envContent: '',
+      action: 'deploy' as const,
+    };
+
+    it('success on first attempt → fetch called once, no retry', async () => {
+      fetchMock.mockResolvedValueOnce(successResponse());
+
+      const result = await client.deploy(deployPayload);
+
+      expect(result.success).toBe(true);
+      expect(fetchMock.mock.calls).toHaveLength(1);
+      expect(capturedDelays).toEqual([]);
+    });
+
+    it('network error on attempts 1 & 2, success on 3 → fetch called 3 times', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('ECONNRESET'));
+      fetchMock.mockRejectedValueOnce(new Error('socket hang up'));
+      fetchMock.mockResolvedValueOnce(successResponse());
+
+      const result = await client.deploy(deployPayload);
+
+      expect(result.success).toBe(true);
+      expect(fetchMock.mock.calls).toHaveLength(3);
+      // 1s then 2s (baseMs 1000, maxExponent 2 → 2^0=1, 2^1=2).
+      expect(capturedDelays).toEqual([1000, 2000]);
+    });
+
+    it('503 on attempt 1, 200 on attempt 2 → fetch called 2 times', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('Service Unavailable', { status: 503 }));
+      fetchMock.mockResolvedValueOnce(successResponse());
+
+      const result = await client.deploy(deployPayload);
+
+      expect(result.success).toBe(true);
+      expect(fetchMock.mock.calls).toHaveLength(2);
+      expect(capturedDelays).toEqual([1000]);
+    });
+
+    it('400 on attempt 1 → throws immediately, fetch called once', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('Bad Request', { status: 400 }));
+
+      let thrown: unknown;
+      try {
+        await client.deploy(deployPayload);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AgentClientError);
+      expect((thrown as AgentClientError).statusCode).toBe(400);
+      expect(fetchMock.mock.calls).toHaveLength(1);
+      expect(capturedDelays).toEqual([]);
+    });
+
+    it('500 (non-retryable 5xx) → throws immediately, fetch called once', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('Internal Server Error', { status: 500 }));
+
+      let thrown: unknown;
+      try {
+        await client.deploy(deployPayload);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AgentClientError);
+      expect((thrown as AgentClientError).statusCode).toBe(500);
+      expect(fetchMock.mock.calls).toHaveLength(1);
+      expect(capturedDelays).toEqual([]);
+    });
+
+    it('504 all 3 attempts → throws AgentClientError with statusCode 504 after 3 fetches', async () => {
+      fetchMock.mockResolvedValueOnce(new Response('Gateway Timeout', { status: 504 }));
+      fetchMock.mockResolvedValueOnce(new Response('Gateway Timeout', { status: 504 }));
+      fetchMock.mockResolvedValueOnce(new Response('Gateway Timeout', { status: 504 }));
+
+      let thrown: unknown;
+      try {
+        await client.deploy(deployPayload);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AgentClientError);
+      expect((thrown as AgentClientError).statusCode).toBe(504);
+      expect(fetchMock.mock.calls).toHaveLength(3);
+      expect(capturedDelays).toEqual([1000, 2000]);
+    });
+
+    it('network error all 3 attempts → throws with statusCode undefined after 3 fetches', async () => {
+      fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+      fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+      let thrown: unknown;
+      try {
+        await client.deploy(deployPayload);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AgentClientError);
+      expect((thrown as AgentClientError).statusCode).toBeUndefined();
+      expect((thrown as AgentClientError).wasTimeout).toBe(false);
+      expect(fetchMock.mock.calls).toHaveLength(3);
+      expect(capturedDelays).toEqual([1000, 2000]);
+    });
+
+    it('per-attempt timeout → throws with wasTimeout true, fetch called exactly once', async () => {
+      // Simulate AbortSignal.timeout() rejection with a TimeoutError.
+      const timeoutErr = new Error('The operation timed out.');
+      timeoutErr.name = 'TimeoutError';
+      fetchMock.mockRejectedValueOnce(timeoutErr);
+
+      let thrown: unknown;
+      try {
+        await client.deploy(deployPayload);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AgentClientError);
+      expect((thrown as AgentClientError).wasTimeout).toBe(true);
+      expect((thrown as AgentClientError).statusCode).toBeUndefined();
+      expect(fetchMock.mock.calls).toHaveLength(1);
+      expect(capturedDelays).toEqual([]);
+    });
+
+    it('AbortError (runtime variant of timeout) → wasTimeout true, no retry', async () => {
+      const abortErr = new Error('The operation was aborted.');
+      abortErr.name = 'AbortError';
+      fetchMock.mockRejectedValueOnce(abortErr);
+
+      let thrown: unknown;
+      try {
+        await client.deploy(deployPayload);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AgentClientError);
+      expect((thrown as AgentClientError).wasTimeout).toBe(true);
+      expect(fetchMock.mock.calls).toHaveLength(1);
+      expect(capturedDelays).toEqual([]);
+    });
+
+    it('invalid JSON response → throws immediately (non-retryable), fetch called once', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response('<html>Not JSON</html>', {
+          status: 200,
+          headers: { 'Content-Type': 'text/html' },
+        }),
+      );
+
+      let thrown: unknown;
+      try {
+        await client.deploy(deployPayload);
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(AgentClientError);
+      expect((thrown as AgentClientError).message).toMatch(/invalid JSON/);
+      expect(fetchMock.mock.calls).toHaveLength(1);
+      expect(capturedDelays).toEqual([]);
     });
   });
 });

--- a/src/lib/clients/agent-client.ts
+++ b/src/lib/clients/agent-client.ts
@@ -193,9 +193,10 @@ export class AgentClient {
   }
 
   private async request<T>(path: string, init: RequestInit): Promise<T> {
+    const MAX_RETRIES = 2; // maxAttempts - 1
     const url = `${this.agentUrl}${path}`;
     return retry(() => this.attempt<T>(url, init), {
-      maxAttempts: 3,
+      maxAttempts: MAX_RETRIES + 1,
       baseMs: 1000,
       maxExponent: 2,
       isRetryable: AgentClient.isRetryable,
@@ -204,7 +205,7 @@ export class AgentClient {
           ? (err.statusCode ?? 'network error')
           : 'unknown';
         console.info(
-          `[AgentClient] Retry ${attempt}/2 for ${path} after ${code}, waiting ${delayMs}ms`,
+          `[AgentClient] Retry ${attempt}/${MAX_RETRIES} for ${path} after ${code}, waiting ${delayMs}ms`,
         );
       },
     });

--- a/src/lib/clients/agent-client.ts
+++ b/src/lib/clients/agent-client.ts
@@ -1,5 +1,6 @@
 import type { AgentStackResponse, AgentHealthCheckResponse } from '@homelab-manager/agent/types';
 import type { AgentDeployPayload, AgentDeployResponse } from '@/lib/deploy/types';
+import { retry } from '@/lib/utils/backoff';
 
 export interface ZfsPool {
   name: string;
@@ -22,6 +23,10 @@ export class AgentClientError extends Error {
     message: string,
     public readonly statusCode?: number,
     public readonly agentUrl?: string,
+    /** True when the per-attempt timeout fired. Retry classifier uses this to avoid
+     *  re-running a long-running operation (e.g. `docker compose up`) that may still
+     *  be in flight on the agent. */
+    public readonly wasTimeout: boolean = false,
   ) {
     super(message);
     this.name = 'AgentClientError';
@@ -50,6 +55,11 @@ export interface AgentHealthResponse {
  * HTTPS is supported natively — use https:// in the agent URL.
  * For self-signed certs (e.g., from OpenBao PKI), set NODE_EXTRA_CA_CERTS
  * env var to the CA certificate path.
+ *
+ * Transient failures (network errors, 502/503/504) are retried up to 3 total
+ * attempts with exponential backoff (1s, 2s) via the shared `retry()` helper.
+ * 4xx responses, non-retryable 5xx responses, per-attempt timeouts, and invalid
+ * JSON bodies fail immediately.
  */
 export class AgentClient {
   private readonly agentUrl: string;
@@ -107,16 +117,17 @@ export class AgentClient {
         `Agent request failed: ${err instanceof Error ? err.message : String(err)}`,
         undefined,
         url,
+        false,
       );
     }
 
     if (!response.ok) {
       const body = await response.text().catch(() => '');
-      throw new AgentClientError(`Agent returned ${response.status}: ${body}`, response.status, url);
+      throw new AgentClientError(`Agent returned ${response.status}: ${body}`, response.status, url, false);
     }
 
     if (!response.body) {
-      throw new AgentClientError('No response body for SSE stream', undefined, url);
+      throw new AgentClientError('No response body for SSE stream', undefined, url, false);
     }
 
     const reader = response.body.getReader();
@@ -168,9 +179,38 @@ export class AgentClient {
     });
   }
 
+  /** Classifier used by the retry wrapper. Exposed as a static so the retry
+   *  helper can call it without binding `this`. */
+  private static isRetryable(err: unknown): boolean {
+    if (!(err instanceof AgentClientError)) return false;
+    // Never retry our own per-attempt timeout: the in-flight operation (e.g.
+    // `docker compose up`) may still be running on the agent.
+    if (err.wasTimeout) return false;
+    // Network-layer failures (fetch threw) have no statusCode — retry.
+    if (err.statusCode === undefined) return true;
+    // Transient gateway errors are retryable; everything else is not.
+    return err.statusCode === 502 || err.statusCode === 503 || err.statusCode === 504;
+  }
+
   private async request<T>(path: string, init: RequestInit): Promise<T> {
     const url = `${this.agentUrl}${path}`;
+    return retry(() => this.attempt<T>(url, init), {
+      maxAttempts: 3,
+      baseMs: 1000,
+      maxExponent: 2,
+      isRetryable: AgentClient.isRetryable,
+      onRetry: (err, attempt, delayMs) => {
+        const code = err instanceof AgentClientError
+          ? (err.statusCode ?? 'network error')
+          : 'unknown';
+        console.info(
+          `[AgentClient] Retry ${attempt}/2 for ${path} after ${code}, waiting ${delayMs}ms`,
+        );
+      },
+    });
+  }
 
+  private async attempt<T>(url: string, init: RequestInit): Promise<T> {
     let response: Response;
     try {
       response = await this.fetchFn(url, {
@@ -178,10 +218,17 @@ export class AgentClient {
         signal: AbortSignal.timeout(this.timeoutMs),
       });
     } catch (err) {
+      // Distinguish our own per-attempt timeout from a genuine network failure.
+      // DOMException('...', 'TimeoutError') is the canonical AbortSignal.timeout()
+      // rejection, but some runtimes surface a plain AbortError — treat both as
+      // "our timeout" to be safe.
+      const wasTimeout =
+        err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError');
       throw new AgentClientError(
         `Agent request failed: ${err instanceof Error ? err.message : String(err)}`,
         undefined,
         url,
+        wasTimeout,
       );
     }
 
@@ -191,6 +238,7 @@ export class AgentClient {
         `Agent returned ${response.status}: ${body}`,
         response.status,
         url,
+        false,
       );
     }
 
@@ -199,9 +247,10 @@ export class AgentClient {
       return JSON.parse(text) as T;
     } catch {
       throw new AgentClientError(
-        `Agent returned invalid JSON from ${path}: ${text.slice(0, 200)}`,
+        `Agent returned invalid JSON from ${url}: ${text.slice(0, 200)}`,
         response.status,
         url,
+        false,
       );
     }
   }


### PR DESCRIPTION
## Problem

`AgentClient.request()` throws `AgentClientError` on the very first failure (any network error or non-2xx response). The deploy pipeline catches that and marks the deploy `failed` permanently. A brief network hiccup, agent restart, or transient 503 mid-deploy is therefore unrecoverable.

## Fix

Wrap `AgentClient.request()` with the shared `retry()` helper (from PR #123). Transient failures retry up to 3 total attempts with exponential backoff (1s, 2s). Non-transient failures still fail immediately.

### Retry policy

- **Retryable:** fetch throws that are NOT our own per-attempt timeout (DNS, ECONNREFUSED, ECONNRESET, socket hangup) + HTTP 502, 503, 504.
- **Non-retryable (fail immediately):** all 4xx; all 5xx other than 502/503/504; our own per-attempt timeout firing; invalid JSON bodies.
- **Attempts:** 3 total (1 initial + 2 retries).
- **Backoff:** `retry()` with `baseMs: 1000`, `maxExponent: 2` → sleeps of 1000ms, 2000ms.
- **Per-attempt timeout:** unchanged — each attempt still uses `AbortSignal.timeout(this.timeoutMs)`. There is no outer total budget. Because timeouts are treated as non-retryable, the per-attempt timeout does not compound.

### Key safety decision

Per-attempt timeouts are never retried. A `docker compose up` that locally times out may still be running on the agent; firing a second attempt would double-apply. This is enforced via a new `AgentClientError.wasTimeout` field (defaulted `false` — backward-compatible) that the retry classifier reads.

## Scope

- `streamZfsStats` is NOT retried (it has its own fetch path; the ZFS collector handles reconnect via `BaseCollector`'s backoff).
- No pipeline changes.
- No env-var configuration.
- No jitter.

## Tests

New `retry behaviour` block in `agent-client.test.ts` covering:
1. Success on first attempt → 1 fetch, no sleep.
2. Network error × 2, then success → 3 fetches, delays `[1000, 2000]`.
3. 503 then 200 → 2 fetches, delay `[1000]`.
4. 400 → throws immediately, 1 fetch.
5. 500 (non-retryable 5xx) → throws immediately, 1 fetch.
6. 504 × 3 → throws with `statusCode: 504`, 3 fetches.
7. Network error × 3 → throws with `statusCode: undefined`, 3 fetches.
8. Per-attempt timeout (`TimeoutError`) → `wasTimeout: true`, 1 fetch.
9. `AbortError` variant → `wasTimeout: true`, 1 fetch.
10. Invalid JSON (2xx with bad body) → throws immediately, 1 fetch.

`setTimeout` is spied at the block scope so sleeps fire synchronously.

Two pre-existing tests that rejected once now use `mockRejectedValue` (all attempts) since the new retry means a single rejection is no longer the terminal failure.

## Depends on

- #123 (shared backoff utility) — this PR's base is `reliability/backoff-utility`, not `main`. Should be rebased onto `main` and merged after #123.

## Verification

- `bun run typecheck` — clean.
- `bun test src/lib/clients/__tests__/agent-client.test.ts` — 26 pass.
- `bun test` — full suite passes (9 pre-existing unrelated failures in chart/stacks-context tests, confirmed present on base branch).

Closes #100