### PR TITLE
fix(demo): emit docker-inventory init so /docker renders rows

### DIFF
--- a/src/lib/mock/__tests__/mock-event-source.test.ts
+++ b/src/lib/mock/__tests__/mock-event-source.test.ts
@@ -112,6 +112,31 @@ describe('MockEventSource', () => {
     });
   });
 
+  describe('docker-inventory endpoint', () => {
+    it('emits init event with containers array', async () => {
+      instance = new MockEventSource(`${ORIGIN}/api/docker-inventory`);
+
+      const data = await new Promise<unknown>((resolve) => {
+        instance.onmessage = (event) => {
+          resolve(JSON.parse(event.data as string));
+        };
+      });
+
+      const msg = data as { type: string; containers: unknown[] };
+      expect(msg.type).toBe('init');
+      expect(Array.isArray(msg.containers)).toBe(true);
+      expect(msg.containers.length).toBeGreaterThan(0);
+
+      const first = msg.containers[0] as Record<string, unknown>;
+      expect(typeof first.host).toBe('string');
+      expect(typeof first.containerId).toBe('string');
+      expect(first.state).toBe('running');
+      // Date fields serialize as ISO strings, matching the real broadcast wire format.
+      expect(typeof first.startedAt).toBe('string');
+      expect(typeof first.updatedAt).toBe('string');
+    });
+  });
+
   describe('settings endpoint', () => {
     it('emits init message with settings', async () => {
       instance = new MockEventSource(`${ORIGIN}/api/settings`);

--- a/src/lib/mock/generators/__tests__/docker.test.ts
+++ b/src/lib/mock/generators/__tests__/docker.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'bun:test';
-import { generateDockerSnapshot, generateDockerHistory, generateContainerHistory, generateContainerLogBatch, generateContainerLogHistory } from '../docker';
+import {
+  generateDockerSnapshot,
+  generateDockerInventorySnapshot,
+  generateDockerHistory,
+  generateContainerHistory,
+  generateContainerLogBatch,
+  generateContainerLogHistory,
+} from '../docker';
 import { DOCKER_ENTITIES } from '../../entities';
 
 describe('generateDockerSnapshot', () => {
@@ -43,6 +50,48 @@ describe('generateDockerSnapshot', () => {
     const hosts = new Set(rows.map((r) => r.host));
     const expectedHosts = new Set(DOCKER_ENTITIES.map((e) => e.host));
     expect(hosts).toEqual(expectedHosts);
+  });
+});
+
+describe('generateDockerInventorySnapshot', () => {
+  const now = new Date('2025-06-15T12:00:00Z');
+
+  it('returns one container per entity', () => {
+    const containers = generateDockerInventorySnapshot(now);
+    expect(containers).toHaveLength(DOCKER_ENTITIES.length);
+  });
+
+  it('matches each entity on host, containerId, name, image, serviceKey', () => {
+    const containers = generateDockerInventorySnapshot(now);
+    for (const c of containers) {
+      const entity = DOCKER_ENTITIES.find(
+        (e) => e.host === c.host && e.containerId === c.containerId,
+      );
+      expect(entity).toBeDefined();
+      expect(c.name).toBe(entity!.containerName);
+      expect(c.image).toBe(entity!.image);
+      expect(c.serviceKey).toBe(entity!.serviceKey);
+    }
+  });
+
+  it('marks every container running with empty labels and no exit info', () => {
+    const containers = generateDockerInventorySnapshot(now);
+    for (const c of containers) {
+      expect(c.state).toBe('running');
+      expect(c.composeProject).toBeNull();
+      expect(c.finishedAt).toBeNull();
+      expect(c.exitCode).toBeNull();
+      expect(c.labels).toEqual({});
+    }
+  });
+
+  it('uses Date objects for startedAt and updatedAt so JSON.stringify emits ISO strings', () => {
+    const containers = generateDockerInventorySnapshot(now);
+    for (const c of containers) {
+      expect(c.startedAt).toBeInstanceOf(Date);
+      expect(c.updatedAt).toBeInstanceOf(Date);
+      expect(c.startedAt!.getTime()).toBeLessThan(now.getTime());
+    }
   });
 });
 

--- a/src/lib/mock/generators/docker.ts
+++ b/src/lib/mock/generators/docker.ts
@@ -1,4 +1,5 @@
 import type { DockerStatsRow } from '@/types/docker';
+import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
 import { generateSimplexMetric, spike } from '@/lib/mock/patterns';
 import { DOCKER_ENTITIES, type DockerEntityDef } from '@/lib/mock/entities';
 import { mulberry32, hashCode } from '@/lib/mock/prng';
@@ -39,6 +40,35 @@ export function generateDockerSnapshot(time: Date): DockerStatsRow[] {
   const timeMs = time.getTime();
   const timeStr = time.toISOString();
   return DOCKER_ENTITIES.map((e) => buildDockerRow(e, timeMs, timeStr));
+}
+
+/**
+ * Generate a Docker inventory init snapshot for demo mode.
+ *
+ * Returns one entry per entity matching `DockerInventorySnapshotContainer`. All containers are
+ * `running`; `startedAt`/`updatedAt` are staggered per-entity so deterministic tie-breaking in
+ * any downstream dedup path has something to work with. Downstream `JSON.stringify` serializes
+ * the `Date` fields to ISO strings, matching the real broadcast wire format.
+ */
+export function generateDockerInventorySnapshot(now: Date): DockerInventorySnapshotContainer[] {
+  const nowMs = now.getTime();
+  return DOCKER_ENTITIES.map((e, idx) => {
+    const startedAt = new Date(nowMs - (idx + 1) * 60_000);
+    return {
+      host: e.host,
+      containerId: e.containerId,
+      name: e.containerName,
+      image: e.image,
+      state: 'running',
+      composeProject: null,
+      serviceKey: e.serviceKey,
+      startedAt,
+      finishedAt: null,
+      exitCode: null,
+      labels: {},
+      updatedAt: startedAt,
+    };
+  });
 }
 
 /**

--- a/src/lib/mock/mock-event-source.ts
+++ b/src/lib/mock/mock-event-source.ts
@@ -1,4 +1,9 @@
-import { generateDockerSnapshot, generateContainerLogBatch, generateContainerLogHistory } from '@/lib/mock/generators/docker';
+import {
+  generateDockerSnapshot,
+  generateDockerInventorySnapshot,
+  generateContainerLogBatch,
+  generateContainerLogHistory,
+} from '@/lib/mock/generators/docker';
 import { generateZFSSnapshot } from '@/lib/mock/generators/zfs';
 import { generateProxmoxSnapshot } from '@/lib/mock/generators/proxmox';
 import { DEMO_SETTINGS_STORAGE_KEY } from '@/lib/constants/settings-keys';
@@ -119,6 +124,16 @@ export class MockEventSource {
       // Docker logs endpoint: emit log batches every 3 seconds
       if (path.includes('docker-logs')) {
         this._startDockerLogs(path, parsed.searchParams);
+        return;
+      }
+
+      // Docker inventory endpoint: emit one init snapshot then stay quiet. Inventory is the
+      // table's source-of-truth, so without this the Docker page renders no rows even though
+      // stats stream fine. In the real pipeline updates arrive via pg NOTIFY, which the demo
+      // does not simulate.
+      if (path.includes('docker-inventory')) {
+        const event = { type: 'init', containers: generateDockerInventorySnapshot(new Date()) };
+        this._dispatchEvent('message', new MessageEvent('message', { data: JSON.stringify(event) }));
         return;
       }
 


### PR DESCRIPTION
## Summary
- The demo mode Docker page (https://jaredglaser.github.io/homelab-manager/docker) showed no rows because `MockEventSource` never handled `/api/docker-inventory`.
- After 8b09273 (`feat(docker): container inventory pipeline`), `buildDockerTableHierarchy` walks `inventory` as source-of-truth for which rows exist. An empty inventory Map yields zero rows, regardless of streamed stats.
- Adds `generateDockerInventorySnapshot(now: Date)` and routes the path in `MockEventSource` to emit a single `init` event on open, matching the real broadcast wire format (Date fields are serialized to ISO strings via `JSON.stringify`).

## Scope notes
- All 10 demo containers render as `running` for this fix. Follow-up to showcase stopped/paused/restarting UI tracked in #137.
- Stacks demo page is likely also broken on `/api/stack-status` for the same reason, but out of scope here.

## Test plan
- [x] `bun run typecheck` clean
- [x] Demo build (`bun run build:demo`) succeeds
- [x] New unit tests cover generator shape and SSE `init` emission
- [ ] After merge, verify https://jaredglaser.github.io/homelab-manager/docker renders container rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)