### PR TITLE
fix(hooks): harden useVisibleRAF and clamp sparkline pulse on resume

### DIFF
--- a/src/components/shared-table/SparklineCanvas.tsx
+++ b/src/components/shared-table/SparklineCanvas.tsx
@@ -136,6 +136,11 @@ export default memo(function SparklineCanvas({
   // sliding smoothly without burning GPU on 60fps draws per sparkline.
   const IDLE_INTERVAL_MS = 250;
 
+  // After useVisibleRAF re-enters visibility, lastFrameTimeRef can be seconds
+  // stale. Treat any delta over this as a resume, not a real frame gap, so an
+  // in-flight pulse doesn't saturate (0 → 1) in a single post-resume tick.
+  const PULSE_RESUME_THRESHOLD_MS = 100;
+
   // Per-frame render, gated by useVisibleRAF: only runs while wrapper is in viewport.
   useVisibleRAF(wrapperRef, (now: number) => {
     const ctx = gradientCtxRef.current;
@@ -144,8 +149,9 @@ export default memo(function SparklineCanvas({
     const pxBuf = pointsXRef.current;
     const pyBuf = pointsYRef.current;
 
-    const delta = now - lastFrameTimeRef.current;
+    const rawDelta = now - lastFrameTimeRef.current;
     lastFrameTimeRef.current = now;
+    const delta = rawDelta > PULSE_RESUME_THRESHOLD_MS ? 0 : rawDelta;
 
     // Animate pulse
     pulseProgressRef.current = Math.min(1, pulseProgressRef.current + delta / 1200);

--- a/src/hooks/__tests__/useVisibleRAF.test.ts
+++ b/src/hooks/__tests__/useVisibleRAF.test.ts
@@ -192,22 +192,22 @@ describe('useVisibleRAF', () => {
     expect(cb1).not.toHaveBeenCalled();
   });
 
-  it('logs an error and no-ops (no observer) when targetRef.current is null', () => {
+  it('warns and no-ops (no observer) when targetRef.current is null', () => {
     const cb = mock(() => {});
     const targetRef = { current: null };
 
-    const errSpy = mock(() => {});
-    const originalErr = console.error;
-    console.error = errSpy as unknown as typeof console.error;
+    const warnSpy = mock(() => {});
+    const originalWarn = console.warn;
+    console.warn = warnSpy as unknown as typeof console.warn;
 
     try {
       renderHook(() => useVisibleRAF(targetRef, cb));
 
       expect(ioInstances.length).toBe(0);
       expect(rafCallbacks.length).toBe(0);
-      expect(errSpy).toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
     } finally {
-      console.error = originalErr;
+      console.warn = originalWarn;
     }
   });
 
@@ -218,13 +218,17 @@ describe('useVisibleRAF', () => {
     renderHook(() => useVisibleRAF(targetRef, cb));
 
     const ioInstance = ioInstances[0];
+    const rafSpy = globalThis.requestAnimationFrame as unknown as ReturnType<typeof mock>;
+    const rafCallsBefore = rafSpy.mock.calls.length;
 
     ioInstance.emit(targetRef.current, true);
     ioInstance.emit(targetRef.current, true);
     ioInstance.emit(targetRef.current, true);
 
     // Without the `visible` guard, three emits would queue three parallel rAF loops.
-    expect(rafCallbacks.length).toBe(1);
+    // Assert on the mock's call count directly so this cannot be masked by
+    // coincidental buffer-length matches in future refactors.
+    expect(rafSpy.mock.calls.length - rafCallsBefore).toBe(1);
   });
 
   it('disconnects old observer and observes new element when targetRef identity changes', () => {
@@ -316,6 +320,85 @@ describe('useVisibleRAF', () => {
       expect(cb).toHaveBeenCalledTimes(1);
     } finally {
       globalThis.IntersectionObserver = originalIoInner;
+      console.error = originalErr;
+    }
+  });
+
+  it('falls back to unconditional rAF when observer.observe() throws', () => {
+    const originalIoInner = globalThis.IntersectionObserver;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (globalThis as any).IntersectionObserver = class {
+      observe() { throw new Error('detached node'); }
+      unobserve() {}
+      disconnect() {}
+      takeRecords() { return []; }
+      root = null;
+      rootMargin = '';
+      thresholds: readonly number[] = [];
+    };
+
+    const errSpy = mock(() => {});
+    const originalErr = console.error;
+    console.error = errSpy as unknown as typeof console.error;
+
+    try {
+      const cb = mock(() => {});
+      const targetRef = makeTargetRef();
+
+      renderHook(() => useVisibleRAF(targetRef, cb));
+
+      expect(rafCallbacks.length).toBe(1);
+      expect(errSpy).toHaveBeenCalled();
+
+      rafCallbacks[0](performance.now());
+      expect(cb).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.IntersectionObserver = originalIoInner;
+      console.error = originalErr;
+    }
+  });
+
+  it('stops the loop and logs when the callback throws, allowing resume on next visibility toggle', () => {
+    const error = new Error('boom');
+    let throwOnce = true;
+    const cb = mock((_ts: number) => {
+      if (throwOnce) {
+        throwOnce = false;
+        throw error;
+      }
+    });
+    const targetRef = makeTargetRef();
+
+    const errSpy = mock(() => {});
+    const originalErr = console.error;
+    console.error = errSpy as unknown as typeof console.error;
+
+    try {
+      renderHook(() => useVisibleRAF(targetRef, cb));
+
+      const ioInstance = ioInstances[0];
+      const rafSpy = globalThis.requestAnimationFrame as unknown as ReturnType<typeof mock>;
+      const cafSpy = globalThis.cancelAnimationFrame as unknown as ReturnType<typeof mock>;
+
+      ioInstance.emit(targetRef.current, true);
+      expect(rafCallbacks.length).toBe(1);
+
+      const rafCallsBeforeFrame = rafSpy.mock.calls.length;
+      const cafCallsBeforeFrame = cafSpy.mock.calls.length;
+
+      // Fire the frame: callback throws, loop should tear down without propagating.
+      expect(() => rafCallbacks[0](performance.now())).not.toThrow();
+
+      expect(errSpy).toHaveBeenCalled();
+      expect(rafSpy.mock.calls.length).toBe(rafCallsBeforeFrame); // no re-schedule
+      expect(cafSpy.mock.calls.length).toBeGreaterThan(cafCallsBeforeFrame); // loop torn down
+
+      // Next visibility toggle false → true restarts the loop (self-heals).
+      ioInstance.emit(targetRef.current, false);
+      const rafCallsAfterStop = rafSpy.mock.calls.length;
+      ioInstance.emit(targetRef.current, true);
+      expect(rafSpy.mock.calls.length).toBeGreaterThan(rafCallsAfterStop);
+    } finally {
       console.error = originalErr;
     }
   });

--- a/src/hooks/useVisibleRAF.ts
+++ b/src/hooks/useVisibleRAF.ts
@@ -17,14 +17,19 @@ const ROOT_MARGIN = '100px';
  *   starts on any pixel of overlap with the expanded viewport.
  * - Latest `callback` is always invoked (no stale closure), so callers can pass
  *   a freshly-created closure on each render without re-subscribing the observer.
- * - Fallback: if `IntersectionObserver` is unavailable or its construction throws
- *   (broken polyfill, strict environments rejecting the options bag), the hook
- *   logs an error and runs an unconditional rAF loop, preserving prior behavior.
+ * - Fallback: if `IntersectionObserver` is unavailable, its construction throws,
+ *   or `observe()` throws (broken polyfill, detached node, strict environments),
+ *   the hook logs an error and runs an unconditional rAF loop, preserving prior
+ *   behavior.
  * - The effect re-runs only when the `targetRef` object identity changes, NOT
  *   when `targetRef.current` is reassigned. Pass a ref to a stable DOM element.
- *   If `targetRef.current` is null at effect-run time, the hook logs an error
- *   and no-ops; this almost always indicates the wrapper element is mounted
+ *   If `targetRef.current` is null at effect-run time, the hook warns and
+ *   no-ops; this almost always indicates the wrapper element is mounted
  *   conditionally and the gating won't work as expected.
+ * - If `callback` throws, the loop is torn down for this mount to avoid an
+ *   infinite error stream. Visibility can still resume the loop on the next
+ *   intersection toggle, so a transient throw self-heals on the next
+ *   isIntersecting:false → true transition.
  *
  * @param targetRef Ref to the DOM element whose visibility gates the loop.
  * @param callback  Frame callback invoked with the rAF timestamp.
@@ -39,15 +44,29 @@ export function useVisibleRAF(
   useEffect(() => {
     const el = targetRef.current;
     if (!el) {
-      console.error('useVisibleRAF: targetRef.current is null at effect-run time; loop will not start.');
+      console.warn('useVisibleRAF: targetRef.current is null at effect-run time; loop will not start.');
       return;
     }
 
     let rafId: number | null = null;
     let visible = false;
 
+    const stop = () => {
+      if (visible) {
+        visible = false;
+        if (rafId !== null) cancelAnimationFrame(rafId);
+        rafId = null;
+      }
+    };
+
     const tick = (ts: number) => {
-      callbackRef.current(ts);
+      try {
+        callbackRef.current(ts);
+      } catch (err) {
+        console.error('useVisibleRAF: callback threw; stopping rAF loop for this mount.', err);
+        stop();
+        return;
+      }
       rafId = requestAnimationFrame(tick);
     };
 
@@ -58,23 +77,14 @@ export function useVisibleRAF(
       }
     };
 
-    const stop = () => {
-      if (visible) {
-        visible = false;
-        if (rafId !== null) cancelAnimationFrame(rafId);
-        rafId = null;
-      }
-    };
-
     // Environments without IntersectionObserver (older test shims): run unconditionally.
     if (typeof IntersectionObserver === 'undefined') {
       start();
       return () => stop();
     }
 
-    let observer: IntersectionObserver;
     try {
-      observer = new IntersectionObserver(
+      const observer = new IntersectionObserver(
         (entries) => {
           const entry = entries[0];
           if (!entry) return;
@@ -83,17 +93,19 @@ export function useVisibleRAF(
         },
         { rootMargin: ROOT_MARGIN },
       );
+      observer.observe(el);
+      return () => {
+        try {
+          observer.disconnect();
+        } catch (err) {
+          console.error('useVisibleRAF: observer.disconnect threw during cleanup.', err);
+        }
+        stop();
+      };
     } catch (err) {
-      console.error('useVisibleRAF: IntersectionObserver construction failed; running rAF unconditionally.', err);
+      console.error('useVisibleRAF: IntersectionObserver setup failed; running rAF unconditionally.', err);
       start();
       return () => stop();
     }
-
-    observer.observe(el);
-
-    return () => {
-      observer.disconnect();
-      stop();
-    };
   }, [targetRef]);
 }


### PR DESCRIPTION
## Summary

Follow-up to #132 that resolves the remaining review findings. Applies on top of `main` as a standalone PR since #132 merged before these fixes landed.

- Wrap the rAF callback in try/catch. On throw: log, `stop()` the loop, and skip re-schedule so a broken callback doesn't produce an infinite error stream. A subsequent `isIntersecting: false → true` toggle restarts the loop, so transient throws self-heal.
- Guard `observer.observe()` and `observer.disconnect()` with the same fallback as construction. `observe()` throws (detached node, polyfill quirks) now route through the unconditional-rAF path instead of surfacing an uncaught error.
- Null `targetRef.current` now logs `console.warn` rather than `console.error`. CLAUDE.md rule 8 reserves `console.error` for real errors; conditional render is a plausible caller bug that shouldn't spam prod logs.
- `SparklineCanvas`: clamp per-frame delta on resume. After a visibility pause, `lastFrameTimeRef` can be seconds stale; without clamping, an in-flight pulse saturates (0 → 1) in a single post-resume tick. Threshold 100ms treats anything larger as a resume and advances pulse by 0, preserving mid-pulse state across pauses. Normal frame cadence (~16ms) is unaffected.

## Tests

- New: `observer.observe()` throws → fallback unconditional rAF + error log.
- New: callback throws → loop tears down without propagating; no re-schedule; `cancelAnimationFrame` runs; next visibility toggle restarts the loop.
- Strengthened: double-schedule test now asserts on the `requestAnimationFrame` mock's call count rather than the buffered-length side effect.
- Null-ref test updated to assert on `console.warn` spy.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` full suite: 2298 pass / 0 fail
- [ ] Manual: scroll Docker containers off-screen, confirm a thrown callback (e.g., via devtools override) no longer spams the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)