### PR TITLE
chore: remove em and en dashes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ POSTGRES_USER="homelab"
 POSTGRES_PASSWORD="changeme"
 POSTGRES_SSL="false"
 # Verify the PostgreSQL server's TLS certificate when POSTGRES_SSL is enabled.
-# Defaults to "true". Set to "false" ONLY for self-signed certificates — this
+# Defaults to "true". Set to "false" ONLY for self-signed certificates: this
 # disables chain validation and exposes the connection to MITM attacks.
 POSTGRES_SSL_REJECT_UNAUTHORIZED="true"
 POSTGRES_POOL_SIZE="10"
@@ -47,7 +47,7 @@ WORKER_COLLECTION_INTERVAL_MS="1000"
 GIT_REPOS_DIR="./data/repos"
 GIT_SERVER_TOKEN="dev-git-token"
 
-# Deploy watchdog — fails deploys stuck in "in_progress" past the threshold.
+# Deploy watchdog: fails deploys stuck in "in_progress" past the threshold.
 # DEPLOY_WATCHDOG_INTERVAL_MS="120000"
 # DEPLOY_WATCHDOG_TIMEOUT_MINUTES="10"
 

--- a/.github/scripts/fetch-sonar-issues.sh
+++ b/.github/scripts/fetch-sonar-issues.sh
@@ -46,7 +46,7 @@ TOTAL=-1
 FETCHED=0
 MAX_PAGES=$((10000 / PAGE_SIZE))
 
-# Use a temp file to accumulate pages — avoids ARG_MAX limits with large payloads
+# Use a temp file to accumulate pages: avoids ARG_MAX limits with large payloads
 PAGES_DIR=$(mktemp -d)
 trap 'rm -rf "$PAGES_DIR"' EXIT
 

--- a/.github/scripts/triage-issues.ts
+++ b/.github/scripts/triage-issues.ts
@@ -2,8 +2,8 @@
 /**
  * Reads sonar-issues.json, groups issues by rule/file/directory,
  * selects the best group to fix, and writes:
- *   selected-issues.json  — issues for Claude Code to fix
- *   triage-summary.md     — human-readable summary for the PR description
+ *   selected-issues.json: issues for Claude Code to fix
+ *   triage-summary.md: human-readable summary for the PR description
  */
 
 import { readFileSync, writeFileSync } from "fs";
@@ -133,7 +133,7 @@ function renderSummary(all: Group[], selected: Group | null, maxIssues: number):
   ];
 
   if (!selected) {
-    lines.push("_No group selected — no group had ≤ max_issues safe issues._");
+    lines.push("_No group selected: no group had <= max_issues safe issues._");
   } else {
     lines.push(`**Label:** ${selected.label}`);
     lines.push(`**Type:** ${selected.groupType}`);

--- a/.github/workflows/sonarqube-autofix.yml
+++ b/.github/workflows/sonarqube-autofix.yml
@@ -96,7 +96,7 @@ jobs:
             selected-issues.json
             triage-summary.md
 
-      - name: Dry run complete — no PR opened
+      - name: Dry run complete (no PR opened)
         if: ${{ inputs.dry_run }}
         run: |
           echo "### Dry Run Complete" >> "$GITHUB_STEP_SUMMARY"
@@ -157,7 +157,7 @@ jobs:
           git checkout -b "$BRANCH"
           git add src/ agent/ migrations/ .github/
           if git diff --cached --quiet; then
-            echo "No changes to commit — Claude Code made no edits."
+            echo "No changes to commit. Claude Code made no edits."
             exit 0
           fi
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,11 +7,11 @@
 - Check if `README.md` and `CLAUDE.md` need updates.
 
 **After editing files:**
-- When `<new-diagnostics>` appear with SonarQube issues on files you just edited, fix them before moving on. Only fix issues on files you modified — do not touch unrelated files.
+- When `<new-diagnostics>` appear with SonarQube issues on files you just edited, fix them before moving on. Only fix issues on files you modified, do not touch unrelated files.
 
 **PR stacks:**
-- Work through stacked PRs linearly (main→PR1→PR2→PR3→…) — never skip steps when rebasing; propagate lower-stack changes upward.
-- Always target the correct base branch — never target `main` for a mid-stack PR.
+- Work through stacked PRs linearly (main→PR1→PR2→PR3→…); never skip steps when rebasing; propagate lower-stack changes upward.
+- Always target the correct base branch; never target `main` for a mid-stack PR.
 
 **Coverage verification:**
 - Coverage percentages differ between local and CI (some tests skip in CI). Use `gh run view` or `gh pr checks` to verify pipeline results, not just local `bun test`.
@@ -54,13 +54,13 @@ cd agent && bun run typecheck  # Agent type checking
 4. **Dynamic Imports**: ALWAYS use `await import()` for server-only modules (pg, subscription-service, database-client) inside SSE handlers and server functions. Static imports leak into the client bundle and break the app with `node:async_hooks` errors.
 5. **SSE Pattern**: TanStack Router server routes (`src/routes/api/`) → `useTimeSeriesStream` hook → shared `DataTable` (CSS Grid + conditional `useVirtualizer`). Use div-based rows (not `<table>/<tr>/<td>`). Server handles client disconnect via `request.signal`. Never use TanStack Start streaming server functions for real-time data.
 6. **File Creation**: PREFER editing existing files over creating new ones.
-7. **Testing**: Tests in `__tests__/` folders co-located with source. Test utilities in `src/lib/test/` (NOT in `__tests__/`). Use `bun:test` imports. 95% functions / 99% lines coverage enforced. Avoid `mock.module()` on React or broadly-used modules - it pollutes globally across concurrent tests. Use `renderHook`, dependency injection, or narrow-scope mocks instead. **Never `mock.module()` on `functions.tsx` barrel modules** (e.g., `@/data/stacks/functions`) — mock the underlying service layer instead (e.g., `@/lib/stacks/stack-service`). This avoids global pollution while still intercepting the dynamic `await import()` calls inside `createServerFn` handlers. Always provide ALL exports when mocking a service module to prevent other test files from seeing `undefined` exports. When tests need `setTimeout` to fire immediately (retry loops, health checks), spy on `globalThis.setTimeout` in `beforeEach`/`afterEach` at the appropriate `describe` scope.
+7. **Testing**: Tests in `__tests__/` folders co-located with source. Test utilities in `src/lib/test/` (NOT in `__tests__/`). Use `bun:test` imports. 95% functions / 99% lines coverage enforced. Avoid `mock.module()` on React or broadly-used modules - it pollutes globally across concurrent tests. Use `renderHook`, dependency injection, or narrow-scope mocks instead. **Never `mock.module()` on `functions.tsx` barrel modules** (e.g., `@/data/stacks/functions`); mock the underlying service layer instead (e.g., `@/lib/stacks/stack-service`). This avoids global pollution while still intercepting the dynamic `await import()` calls inside `createServerFn` handlers. Always provide ALL exports when mocking a service module to prevent other test files from seeing `undefined` exports. When tests need `setTimeout` to fire immediately (retry loops, health checks), spy on `globalThis.setTimeout` in `beforeEach`/`afterEach` at the appropriate `describe` scope.
 8. **Logging**: Be purposeful with console methods. Use `console.error` for actual errors, `console.info` for operational messages (startup, shutdown), and `console.log` sparingly for temporary debugging only (do not commit). No drive-by `console.log` statements in committed code.
 9. **Routing**: Never edit `routeTree.gen.ts` (auto-generated). `AppShell` renders in root layout (`__root.tsx`) - never wrap individual routes with it. All routes use `ssr: false`. QueryClient is a singleton in `AppShell.tsx` - never create per-route.
 10. **Entity IDs**: Always use entity IDs with host prefix (e.g., `server1/tank`, `192.168.1.10/abc123`) for state keys and uniqueness checks. Never use display names - they collide across hosts.
-11. **Scope discipline**: When asked to plan, research, or review — produce only that deliverable. Do not start executing unless explicitly asked. Once a direction is approved, execute without re-confirming at each step.
-12. **Commit scope**: Only commit files relevant to the current task. When fixing coverage, only commit test files — don't push unrelated source changes.
-13. **Verify review findings**: When resolving PR review comments, verify each finding against current code before fixing. Don't blindly apply suggestions — the code may have already changed.
+11. **Scope discipline**: When asked to plan, research, or review, produce only that deliverable. Do not start executing unless explicitly asked. Once a direction is approved, execute without re-confirming at each step.
+12. **Commit scope**: Only commit files relevant to the current task. When fixing coverage, only commit test files; don't push unrelated source changes.
+13. **Verify review findings**: When resolving PR review comments, verify each finding against current code before fixing. Don't blindly apply suggestions; the code may have already changed.
 14. **Comments**: Write comments that capture project-specific WHY: hidden constraints, perf invariants with real numbers (e.g. "without this, a 30-min window accumulates ~1800 rows/container"), user-facing scenarios, operational concerns, non-obvious invariants a future reader would otherwise have to reverse-engineer. Don't restate framework/language behavior: `useRef`, `useMemo`, `useCallback`, `useEffect` deps, `??`/`?.`, discriminated unions, structural typing, JSX semantics, etc. are knowable from docs and add noise. JSDoc `@param`/`@returns` on complex public hooks and functions is encouraged when it documents semantics, units, defaults, or preference order, but skip it for trivial helpers where the signature already says everything.
 15. **No claudisms in written output**: Avoid LLM stylistic tells in code, comments, JSDoc, commit messages, PR descriptions, and docs. Banned: em dashes (`—`) and en dashes (`–`); vocabulary tells ("delve", "tapestry", "intricate", "robust", "comprehensive", "meticulous", "leverage", "utilize", "facilitate", "it's worth noting", "it's important to note", "essentially", "fundamentally"); performative qualifiers in comments and commits ("carefully", "thoroughly", "comprehensively"); boilerplate sign-offs in docs/PRs ("Hope this helps!", "Feel free to reach out"); excessive emojis (✅🎉🚀✨). Use plain alternatives: "use" not "leverage"/"utilize", "help" not "facilitate", "explore" not "delve", commas/parens/colons instead of em dashes.
 
@@ -96,13 +96,13 @@ Browser → Server (SSE) ← StatsPollService (1s poll) → Query DB → Broadca
 
 Two factories in `src/lib/sse/` own the shared boilerplate (`ReadableStream`, heartbeat, `closed` flag, abort/teardown):
 
-- **`createStatsSseHandler(source)`** — for `docker-stats`, `zfs-stats`, `proxmox-stats`. Wraps the three-arg `statsPollService.subscribe(source, sendData, sendError)` and emits an `event: stats_error` frame when the subscribe path fails.
-- **`createBroadcastSseHandler({ loadSubscribe, serialize })`** — for single-arg subscribe-based services (`docker-inventory`, `stack-status`, `settings`). Caller owns the full SSE frame via `serialize`, so named events (`event: foo`) are possible when needed.
+- **`createStatsSseHandler(source)`**: for `docker-stats`, `zfs-stats`, `proxmox-stats`. Wraps the three-arg `statsPollService.subscribe(source, sendData, sendError)` and emits an `event: stats_error` frame when the subscribe path fails.
+- **`createBroadcastSseHandler({ loadSubscribe, serialize })`**: for single-arg subscribe-based services (`docker-inventory`, `stack-status`, `settings`). Caller owns the full SSE frame via `serialize`, so named events (`event: foo`) are possible when needed.
 
 Server-only imports must happen inside the factory callbacks:
 
 ```typescript
-// ALWAYS dynamic import inside the factory callback — static imports break the client bundle:
+// ALWAYS dynamic import inside the factory callback; static imports break the client bundle:
 loadSubscribe: async () => {
   await import('@/lib/server-init');
   const { stackStatusBroadcastService } = await import('@/lib/stacks/stack-status-broadcast-service');
@@ -116,11 +116,11 @@ Hand-written routes (don't fit the factory shape): `docker-logs.$containerId` (a
 
 Unified table using TanStack Table v8 (headless) + CSS Grid rows. Key files: `DataTable.tsx`, `DataTableToolbar.tsx`, `columns.tsx` (factories: `metricColumn`, `nameColumn`, `statusColumn`, `progressColumn`), `MetricCell.tsx`, `SparklineCell.tsx`, `SparklineCanvas.tsx`.
 
-**Virtualization**: Automatic threshold at 150 rows. Below: normal DOM flow with `content-visibility: auto` + `contain-intrinsic-size` (browser-native off-screen optimization, preserves Collapse animations). Above: `useVirtualizer` with absolute positioning (no animations). Never remove virtualization to solve other problems — a single host can have hundreds of containers.
+**Virtualization**: Automatic threshold at 150 rows. Below: normal DOM flow with `content-visibility: auto` + `contain-intrinsic-size` (browser-native off-screen optimization, preserves Collapse animations). Above: `useVirtualizer` with absolute positioning (no animations). Never remove virtualization to solve other problems; a single host can have hundreds of containers.
 
-**Expansion**: Two patterns — `getSubRows` for tree data sharing the same columns (ZFS hierarchy), `renderDetailPanel` for full-width custom content like nested DataTables (Docker hosts → containers, Proxmox hosts → guests). Detail panels always render inline within the DataTable row, never outside. Entire expandable rows are clickable (not just the name cell).
+**Expansion**: Two patterns: `getSubRows` for tree data sharing the same columns (ZFS hierarchy), `renderDetailPanel` for full-width custom content like nested DataTables (Docker hosts → containers, Proxmox hosts → guests). Detail panels always render inline within the DataTable row, never outside. Entire expandable rows are clickable (not just the name cell).
 
-**Mobile**: `ResizeObserver` on DataTable container detects <1024px (not media queries). Sticky toolbar shows metric group toggles (CPU/RAM, Disk I/O, Net I/O) — one group at a time.
+**Mobile**: `ResizeObserver` on DataTable container detects <1024px (not media queries). Sticky toolbar shows metric group toggles (CPU/RAM, Disk I/O, Net I/O), one group at a time.
 
 **Scroll**: Table fills remaining viewport height (`flex-1 min-h-0`). `scrollbar-gutter: stable` on the DataTable scroll container (not `html`). Sticky header inside scroll container tracks horizontal scroll.
 
@@ -128,14 +128,14 @@ Unified table using TanStack Table v8 (headless) + CSS Grid rows. Key files: `Da
 
 - **Styling**: TailwindCSS v4 configured in `App.css` with `@import "tailwindcss"`. MUI theme in `src/theme.ts` uses `cssVariables` mode. Custom backgrounds: `chartBg`, `level1-3`, `popup`. Chart CSS vars (`--chart-cpu`, `--chart-memory`, etc.) in `App.css`.
 - **Settings**: Jotai atoms synced via SSE (`/api/settings`). Domain-scoped hooks (`useDockerSettings`, `useZfsSettings`, `useProxmoxSettings`, `useGeneralSettings`) provide optimistic setters and subscribe via `selectAtom` so each consumer only re-renders when its own slice changes. `useSettings()` remains as a composite wrapper for the settings page. Keys in `src/lib/constants/settings-keys.ts`. PostgreSQL `NOTIFY settings_change` broadcasts to all clients.
-- **Multi-host**: Docker and ZFS monitoring both use managed hosts registered via **Settings → Managed Hosts**. User deploys the agent container on each host, then provides the agent URL, token, and capabilities (docker/zfs). The worker subscribes to each agent's SSE streams (`AgentStatsCollector`, `ZFSCollector`, `ContainerInventoryCollector`) — it never connects to Docker directly. The agent token is stored in OpenBao (`OPENBAO_URL`/`OPENBAO_TOKEN`) or a permissioned file, not in .env.
+- **Multi-host**: Docker and ZFS monitoring both use managed hosts registered via **Settings → Managed Hosts**. User deploys the agent container on each host, then provides the agent URL, token, and capabilities (docker/zfs). The worker subscribes to each agent's SSE streams (`AgentStatsCollector`, `ZFSCollector`, `ContainerInventoryCollector`); it never connects to Docker directly. The agent token is stored in OpenBao (`OPENBAO_URL`/`OPENBAO_TOKEN`) or a permissioned file, not in .env.
 - **Demo mode**: `VITE_DEMO_MODE=true` swaps server functions via Vite aliases and patches `EventSource`. Zero changes to routes/hooks/components. Mock entities defined in `src/lib/mock/entities.ts`.
 - **Worker**: Collectors extend `BaseCollector` (AsyncDisposable, exponential backoff). Entry point uses `AsyncDisposableStack` for cleanup.
 - **Entity IDs**: Docker=`host/container_id`, ZFS=`host/pool/vdev/disk` (hierarchy via indent: 0=pool, 2=vdev, 4+=disk), Proxmox=varies by type.
 
 ### Agent (`agent/`)
 
-Separate Bun package that runs as a sidecar container alongside Docker hosts. Provides a REST/SSE API for Docker management operations (deploy, logs, stats streaming). Uses raw `Bun.serve()` with manual route matching and timing-safe auth middleware — zero framework dependencies beyond Dockerode. The agent replaces direct Docker API calls from the worker — the main app communicates with agents rather than Docker hosts directly.
+Separate Bun package that runs as a sidecar container alongside Docker hosts. Provides a REST/SSE API for Docker management operations (deploy, logs, stats streaming). Uses raw `Bun.serve()` with manual route matching and timing-safe auth middleware (zero framework dependencies beyond Dockerode). The agent replaces direct Docker API calls from the worker; the main app communicates with agents rather than Docker hosts directly.
 
 ### Deploy Pipeline (`src/lib/deploy/`)
 
@@ -158,14 +158,14 @@ Non-obvious pitfalls from past sessions (not restated from rules above):
 3. **Stable ordering from Maps**: Map iteration is insertion-order, not sorted. Always sort data from Maps before rendering to prevent layout shift.
 4. **PostgreSQL extended query protocol**: Parameterized queries use extended protocol which doesn't support multi-statement. INSERT and NOTIFY must be separate `client.query()` calls.
 5. **React.memo with streaming data**: Incorrect memoization freezes streaming updates. Be cautious with `React.memo` on components receiving `latestByEntity` or `rows`.
-6. **Conditional rendering belongs in the parent**: When a component only renders for a subset of rows/items (e.g., container rows but not host rows), guard at the call site — `if (!row.container) return null` in the column `cell` function — rather than adding an early return inside the component. This makes it immediately clear from reading the parent what is always rendered vs. conditionally rendered, and avoids calling hooks conditionally inside the child.
+6. **Conditional rendering belongs in the parent**: When a component only renders for a subset of rows/items (e.g., container rows but not host rows), guard at the call site (`if (!row.container) return null` in the column `cell` function) rather than adding an early return inside the component. This makes it immediately clear from reading the parent what is always rendered vs. conditionally rendered, and avoids calling hooks conditionally inside the child.
 7. **Layout shift in metric columns**: Dynamic number formatting (KB→MB, varying decimals) causes width instability. Use minimum widths with `ch` units in MetricValue.
 8. **Fix root causes, not symptoms**: Investigate actual bugs rather than adding caching/memoization workarounds. Past band-aid fixes were frequently reverted.
 9. **Icon attribution**: Dashboard icons from `homarr-labs/dashboard-icons` (NOT the old `walkxcode` name).
-10. **Parallel agent worktree isolation**: When dispatching multiple agents into git worktrees, each agent must `cd "$WORKTREE_PATH"` before any file writes and use relative paths only. Never run `git stash` inside a worktree while other worktrees are active — `.git/refs/stash` is shared across all worktrees, so a stash created in one worktree can be popped (and destroyed) by an agent in another.
+10. **Parallel agent worktree isolation**: When dispatching multiple agents into git worktrees, each agent must `cd "$WORKTREE_PATH"` before any file writes and use relative paths only. Never run `git stash` inside a worktree while other worktrees are active: `.git/refs/stash` is shared across all worktrees, so a stash created in one worktree can be popped (and destroyed) by an agent in another.
 11. **CSS vars empty on initial render**: CSS custom properties can resolve to empty strings before the theme applies. `CanvasGradient.addColorStop()` throws on empty color. Always guard canvas color operations.
 12. **Virtualizer remounting resets component state**: When `useVirtualizer` repositions rows after collapse, components remount and lose refs/state. Use entity-keyed external state (not component-local refs) for data that must survive remounting (e.g., sparkline accumulators).
-13. **Collapse + virtualizer can't sync**: MUI Collapse (CSS transitions) and virtualizer repositioning (JS `measureElement`) run on different systems. Don't virtualize the outer level (host rows) — only virtualize inner levels (container rows).
+13. **Collapse + virtualizer can't sync**: MUI Collapse (CSS transitions) and virtualizer repositioning (JS `measureElement`) run on different systems. Don't virtualize the outer level (host rows); only virtualize inner levels (container rows).
 
 ## CI/CD
 

--- a/agent-updater/src/agent-updater.ts
+++ b/agent-updater/src/agent-updater.ts
@@ -218,7 +218,7 @@ export class AgentUpdater {
           return false;
         }
         if (healthStatus === undefined) {
-          // No healthcheck defined — consider running as healthy
+          // No healthcheck defined; consider running as healthy
           if (info.State.Running) {
             return true;
           }

--- a/agent-updater/src/index.ts
+++ b/agent-updater/src/index.ts
@@ -31,7 +31,7 @@ async function main(): Promise<void> {
     checkIntervalMs,
   }, healthReporter);
 
-  console.info(`Agent updater started — watching container '${containerName}' for image '${imageName}'`);
+  console.info(`Agent updater started, watching container '${containerName}' for image '${imageName}'`);
   console.info(`Check interval: ${intervalStr} (${checkIntervalMs}ms)`);
 
   let shutdownRequested = false;

--- a/agent/Dockerfile
+++ b/agent/Dockerfile
@@ -1,4 +1,4 @@
-# Toolchain stage — downloads Docker CLI + Compose (cached independently)
+# Toolchain stage: downloads Docker CLI + Compose (cached independently)
 FROM oven/bun:1 AS toolchain
 
 # Pin versions for reproducible builds
@@ -23,7 +23,7 @@ RUN apt-get update && \
     -o /tmp/docker-compose.sha256 && \
     sed -i "s|docker-compose-linux-${COMPOSE_ARCH}|/usr/local/lib/docker/cli-plugins/docker-compose|" /tmp/docker-compose.sha256 && \
     grep -q '/usr/local/lib/docker/cli-plugins/docker-compose$' /tmp/docker-compose.sha256 || \
-      { echo "ERROR: sha256 file rewrite failed — expected absolute path in checksum file"; exit 1; } && \
+      { echo "ERROR: sha256 file rewrite failed, expected absolute path in checksum file"; exit 1; } && \
     sha256sum -c /tmp/docker-compose.sha256 && \
     rm /tmp/docker-compose.sha256 && \
     chmod +x /usr/local/lib/docker/cli-plugins/docker-compose && \

--- a/agent/src/__tests__/containers-events.test.ts
+++ b/agent/src/__tests__/containers-events.test.ts
@@ -87,7 +87,7 @@ function makeDocker(
   };
 }
 
-describe('handleContainerEvents — response headers', () => {
+describe('handleContainerEvents: response headers', () => {
   test('returns SSE response with correct headers and 200 status', async () => {
     const docker = makeDocker([]);
     const ac = new AbortController();
@@ -102,7 +102,7 @@ describe('handleContainerEvents — response headers', () => {
   });
 });
 
-describe('handleContainerEvents — init snapshot', () => {
+describe('handleContainerEvents: init snapshot', () => {
   test('emits init event with all containers on connect', async () => {
     const containers = [
       makeContainer('c1', 'app1', 'running'),
@@ -209,7 +209,7 @@ describe('handleContainerEvents — init snapshot', () => {
   });
 });
 
-describe('handleContainerEvents — start event produces upsert', () => {
+describe('handleContainerEvents: start event produces upsert', () => {
   test('docker start event emits op:upsert with state:running', async () => {
     const eventsEmitter = new EventEmitter();
     const containers = [makeContainer('c1', 'app1', 'running')];
@@ -243,7 +243,7 @@ describe('handleContainerEvents — start event produces upsert', () => {
   });
 });
 
-describe('handleContainerEvents — die event produces upsert with exited state', () => {
+describe('handleContainerEvents: die event produces upsert with exited state', () => {
   test('docker die event emits op:upsert with state:dead or exited', async () => {
     const eventsEmitter = new EventEmitter();
     const containers = [makeContainer('c1', 'app1', 'running')];
@@ -287,7 +287,7 @@ describe('handleContainerEvents — die event produces upsert with exited state'
   });
 });
 
-describe('handleContainerEvents — destroy event', () => {
+describe('handleContainerEvents: destroy event', () => {
   test('docker destroy event emits op:destroy', async () => {
     const eventsEmitter = new EventEmitter();
     const containers = [makeContainer('c1', 'app1')];
@@ -318,7 +318,7 @@ describe('handleContainerEvents — destroy event', () => {
   });
 });
 
-describe('handleContainerEvents — multiple subscribers', () => {
+describe('handleContainerEvents: multiple subscribers', () => {
   test('each subscriber gets independent SSE streams', async () => {
     const eventsEmitter = new EventEmitter();
     const containers = [makeContainer('c1', 'app1')];
@@ -384,7 +384,7 @@ describe('handleContainerEvents — multiple subscribers', () => {
     ac1.abort();
     await new Promise((r) => setTimeout(r, 20));
 
-    // Emit destroy — subscriber2 should still receive it
+    // Emit destroy; subscriber2 should still receive it
     eventsEmitter.emit('data', Buffer.from(JSON.stringify({
       Type: 'container',
       Action: 'destroy',
@@ -398,7 +398,7 @@ describe('handleContainerEvents — multiple subscribers', () => {
   });
 });
 
-describe('handleContainerEvents — request abort cleanup', () => {
+describe('handleContainerEvents: request abort cleanup', () => {
   test('stream closes when request is aborted', async () => {
     const docker = makeDocker([]);
     const ac = new AbortController();
@@ -459,7 +459,7 @@ describe('handleContainerEvents — request abort cleanup', () => {
   });
 });
 
-describe('handleContainerEvents — error resilience', () => {
+describe('handleContainerEvents: error resilience', () => {
   test('continues serving after stream error on events stream', async () => {
     const eventsEmitter = new EventEmitter();
     const docker = makeDocker([], eventsEmitter);

--- a/agent/src/__tests__/logs.test.ts
+++ b/agent/src/__tests__/logs.test.ts
@@ -241,7 +241,7 @@ describe('handleLogStream', () => {
     liveEmitter.emit('error', new Error('pipe broken'));
     await new Promise((r) => setTimeout(r, 10));
 
-    // Abort after error — controller.close() will throw TypeError (already closed)
+    // Abort after error; controller.close() will throw TypeError (already closed)
     abortController.abort();
     await new Promise((r) => setTimeout(r, 10));
 
@@ -434,7 +434,7 @@ describe('handleLogStream', () => {
 
       await new Promise((r) => setTimeout(r, 20));
 
-      // Close the stream, then fire heartbeat — it should clearInterval
+      // Close the stream, then fire heartbeat; it should clearInterval
       abortController.abort();
       await new Promise((r) => setTimeout(r, 10));
       heartbeatCb!();
@@ -456,7 +456,7 @@ describe('handleLogStream', () => {
       inspect: mock(() => Promise.resolve({ Config: { Tty: true } })),
       logs: mock((opts: Record<string, unknown>) => {
         if (!opts.follow) return Promise.resolve(Buffer.alloc(0));
-        // Return a promise that we control — abort will fire while it's pending
+        // Return a promise that we control; abort will fire while it's pending
         return new Promise((resolve) => { resolveLogsPromise = resolve; });
       }),
     };

--- a/agent/src/__tests__/stacks.test.ts
+++ b/agent/src/__tests__/stacks.test.ts
@@ -141,7 +141,7 @@ describe('handleStackDeploy', () => {
   });
 });
 
-describe('handleStackDeploy — type validation', () => {
+describe('handleStackDeploy: type validation', () => {
   test('returns 400 when stack is not a string', async () => {
     const request = new Request('http://localhost/stacks/deploy', {
       method: 'POST',
@@ -182,7 +182,7 @@ describe('handleStackDeploy — type validation', () => {
   });
 });
 
-describe('handleStackDeploy — payload size limits', () => {
+describe('handleStackDeploy: payload size limits', () => {
   test('returns 413 for oversized composeContent', async () => {
     const request = new Request('http://localhost/stacks/deploy', {
       method: 'POST',
@@ -210,7 +210,7 @@ describe('handleStackDeploy — payload size limits', () => {
   });
 });
 
-describe('handleStackDeploy — path traversal', () => {
+describe('handleStackDeploy: path traversal', () => {
   test('rejects stack names with path traversal', async () => {
     const request = new Request('http://localhost/stacks/deploy', {
       method: 'POST',
@@ -249,7 +249,7 @@ describe('handleStackDeploy — path traversal', () => {
   });
 });
 
-describe('handleStackDeploy — file write failure', () => {
+describe('handleStackDeploy: file write failure', () => {
   test('returns 500 when writing stack files fails', async () => {
     // Create a file where the stack directory should be, so mkdirSync fails
     await Bun.write(join(TEST_STACKS_DIR, 'plex'), 'not a directory');
@@ -272,7 +272,7 @@ describe('handleStackDeploy — file write failure', () => {
   });
 });
 
-describe('handleStackDeploy — subprocess timeout', () => {
+describe('handleStackDeploy: subprocess timeout', () => {
   test('returns 500 with timeout message when subprocess exceeds deadline', async () => {
     let resolveExited: (code: number) => void;
     const hangingSpawn = mock(() => ({
@@ -302,7 +302,7 @@ describe('handleStackDeploy — subprocess timeout', () => {
   });
 });
 
-describe('handleStackDeploy — spawn failure', () => {
+describe('handleStackDeploy: spawn failure', () => {
   test('returns 500 with detail when spawn throws', async () => {
     const throwSpawn = mock(() => { throw new Error('docker: not found'); });
 
@@ -414,7 +414,7 @@ describe('handleStackTeardown', () => {
   });
 });
 
-describe('handleStackTeardown — path traversal', () => {
+describe('handleStackTeardown: path traversal', () => {
   test('returns 400 with "Invalid stack path" when resolved path escapes stacksDir', async () => {
     const request = new Request('http://localhost/stacks/teardown', {
       method: 'POST',
@@ -429,7 +429,7 @@ describe('handleStackTeardown — path traversal', () => {
   });
 });
 
-describe('handleStackTeardown — subprocess timeout', () => {
+describe('handleStackTeardown: subprocess timeout', () => {
   test('returns 500 with timeout message when subprocess exceeds deadline', async () => {
     mkdirSync(join(TEST_STACKS_DIR, 'plex'), { recursive: true });
     await Bun.write(join(TEST_STACKS_DIR, 'plex', 'docker-compose.yml'), 'services: {}');
@@ -457,7 +457,7 @@ describe('handleStackTeardown — subprocess timeout', () => {
   });
 });
 
-describe('handleStackTeardown — spawn failure', () => {
+describe('handleStackTeardown: spawn failure', () => {
   test('returns 500 with detail when spawn throws', async () => {
     mkdirSync(join(TEST_STACKS_DIR, 'plex'), { recursive: true });
     await Bun.write(join(TEST_STACKS_DIR, 'plex', 'docker-compose.yml'), 'services: {}');
@@ -566,7 +566,7 @@ describe('handleStackRestart', () => {
   });
 });
 
-describe('handleStackRestart — path traversal', () => {
+describe('handleStackRestart: path traversal', () => {
   test('returns 400 with "Invalid stack path" when resolved path escapes stacksDir', async () => {
     const request = new Request('http://localhost/stacks/restart', {
       method: 'POST',
@@ -581,7 +581,7 @@ describe('handleStackRestart — path traversal', () => {
   });
 });
 
-describe('handleStackRestart — subprocess timeout', () => {
+describe('handleStackRestart: subprocess timeout', () => {
   test('returns 500 with timeout message when subprocess exceeds deadline', async () => {
     mkdirSync(join(TEST_STACKS_DIR, 'traefik'), { recursive: true });
     await Bun.write(join(TEST_STACKS_DIR, 'traefik', 'docker-compose.yml'), 'services: {}');
@@ -609,7 +609,7 @@ describe('handleStackRestart — subprocess timeout', () => {
   });
 });
 
-describe('handleStackRestart — spawn failure', () => {
+describe('handleStackRestart: spawn failure', () => {
   test('returns 500 with detail when spawn throws', async () => {
     mkdirSync(join(TEST_STACKS_DIR, 'traefik'), { recursive: true });
     await Bun.write(join(TEST_STACKS_DIR, 'traefik', 'docker-compose.yml'), 'services: {}');
@@ -629,7 +629,7 @@ describe('handleStackRestart — spawn failure', () => {
   });
 });
 
-describe('handleStackDeploy — without envContent', () => {
+describe('handleStackDeploy: without envContent', () => {
   test('deploys stack without creating .env file when envContent is absent', async () => {
     const mockSpawn = mock(() => ({
       exited: Promise.resolve(0),
@@ -951,7 +951,7 @@ describe('parseContainerNames', () => {
   });
 
   test('returns the literal string for container names with unresolved env var syntax', () => {
-    // parseContainerNames does simple regex extraction — it does not interpolate
+    // parseContainerNames does simple regex extraction; it does not interpolate
     // env vars. Resolution happens upstream in handleStackDeploy via
     // `docker compose config` before this function is called during force-recreate.
     const compose = `services:
@@ -961,7 +961,7 @@ describe('parseContainerNames', () => {
   });
 });
 
-describe('handleStackDeploy — force recreate', () => {
+describe('handleStackDeploy: force recreate', () => {
   test('runs docker rm -f for each container_name then docker compose up --force-recreate', async () => {
     const spawnCalls: { cmd: string[] }[] = [];
     const trackingSpawn = mock((opts: any) => {
@@ -1094,7 +1094,7 @@ describe('handleStackDeploy — force recreate', () => {
     const response = await handleStackDeploy(request, TEST_STACKS_DIR, trackingSpawn as any);
     expect(response.status).toBe(200);
 
-    // Falls back to raw content — literal name is still used
+    // Falls back to raw content; literal name is still used
     const rmCalls = spawnCalls.filter(c => c.cmd.includes('rm'));
     expect(rmCalls).toHaveLength(1);
     expect(rmCalls[0].cmd).toEqual(['docker', 'rm', '-f', 'myapp-web']);

--- a/agent/src/__tests__/stats.test.ts
+++ b/agent/src/__tests__/stats.test.ts
@@ -395,11 +395,11 @@ describe('handleStatsStream', () => {
 
     await new Promise((r) => setTimeout(r, 20));
 
-    // Emit end — the stream should be cleaned up
+    // Emit end; the stream should be cleaned up
     statsEmitter.emit('end');
     await new Promise((r) => setTimeout(r, 10));
 
-    // Now abort — destroy should NOT be called since stream already ended and was removed
+    // Now abort; destroy should NOT be called since stream already ended and was removed
     ac.abort();
     await new Promise((r) => setTimeout(r, 10));
 
@@ -499,7 +499,7 @@ describe('handleStatsStream', () => {
 
 const fastOptions: StatsStreamOptions = { refreshIntervalMs: 0, pollIntervalMs: 10 };
 
-describe('handleStatsStream — container refresh', () => {
+describe('handleStatsStream: container refresh', () => {
   test('detects new containers and opens streams for them', async () => {
     const container1 = { Id: 'c1', Names: ['/first'], Image: 'a:latest' };
     const container2 = { Id: 'c2', Names: ['/second'], Image: 'b:latest' };

--- a/agent/src/__tests__/zfs.test.ts
+++ b/agent/src/__tests__/zfs.test.ts
@@ -145,7 +145,7 @@ describe('handleZfsStatsStream', () => {
     const killMock = mock(() => {});
     const readableStream = new ReadableStream<Uint8Array>({
       start() {
-        // Keep stream open — simulates long-running iostat
+        // Keep stream open; simulates long-running iostat
       },
     });
 
@@ -201,7 +201,7 @@ describe('handleZfsStatsStream', () => {
     ac.abort();
     await new Promise((r) => setTimeout(r, 20));
 
-    // Now release the second chunk — enqueue should catch
+    // Now release the second chunk; enqueue should catch
     resolveSecondChunk?.();
     await new Promise((r) => setTimeout(r, 20));
 

--- a/agent/src/lib/__tests__/docker-events-broadcaster.test.ts
+++ b/agent/src/lib/__tests__/docker-events-broadcaster.test.ts
@@ -63,7 +63,7 @@ function makeDocker(containers: MinimalContainerInfo[] = [], eventsEmitter = new
   };
 }
 
-describe('subscribe — init snapshot', () => {
+describe('subscribe: init snapshot', () => {
   test('sends init event with all containers on first subscribe', async () => {
     const containers = [
       makeContainer('c1', 'app1'),
@@ -99,7 +99,7 @@ describe('subscribe — init snapshot', () => {
   });
 });
 
-describe('subscribe — multiple subscribers', () => {
+describe('subscribe: multiple subscribers', () => {
   test('each subscriber receives its own independent init event', async () => {
     const containers = [makeContainer('c1', 'app1')];
     const docker = makeDocker(containers);
@@ -159,7 +159,7 @@ describe('subscribe — multiple subscribers', () => {
 
     unsub1();
 
-    // Emit a start event — subscriber2 should still receive it
+    // Emit a start event; subscriber2 should still receive it
     eventsEmitter.emit('data', Buffer.from(JSON.stringify({
       Type: 'container',
       Action: 'start',
@@ -174,7 +174,7 @@ describe('subscribe — multiple subscribers', () => {
   });
 });
 
-describe('subscribe — upsert events', () => {
+describe('subscribe: upsert events', () => {
   test('start event produces an upsert with the container info', async () => {
     const eventsEmitter = new EventEmitter();
     const containers = [makeContainer('c1', 'app1')];
@@ -303,7 +303,7 @@ describe('subscribe — upsert events', () => {
   });
 });
 
-describe('subscribe — destroy events', () => {
+describe('subscribe: destroy events', () => {
   test('destroy action emits a destroy event', async () => {
     const eventsEmitter = new EventEmitter();
     const containers = [makeContainer('c1', 'app1')];
@@ -356,7 +356,7 @@ describe('subscribe — destroy events', () => {
   });
 });
 
-describe('subscribe — stream reconnect', () => {
+describe('subscribe: stream reconnect', () => {
   test('reconnects after stream error with scheduled timer', async () => {
     const eventsEmitter = new EventEmitter();
     const docker = makeDocker([], eventsEmitter);
@@ -364,7 +364,7 @@ describe('subscribe — stream reconnect', () => {
     const unsub = await subscribe(docker as any, () => {});
     await new Promise((r) => setTimeout(r, 20));
 
-    // Emit stream error — broadcaster should log and schedule reconnect
+    // Emit stream error; broadcaster should log and schedule reconnect
     eventsEmitter.emit('error', new Error('stream error'));
     await new Promise((r) => setTimeout(r, 20));
 
@@ -498,7 +498,7 @@ describe('subscribe — stream reconnect', () => {
       // Unsubscribe before the timer fires
       unsub();
 
-      // Fire the captured timer — no subscribers remain, should clear reconnecting
+      // Fire the captured timer; no subscribers remain, should clear reconnecting
       for (const cb of timerCallbacks) {
         await (cb as () => Promise<void> | void)();
       }
@@ -519,7 +519,7 @@ describe('subscribe — stream reconnect', () => {
   });
 });
 
-describe('subscribe — cleanup (last unsubscribe)', () => {
+describe('subscribe: cleanup (last unsubscribe)', () => {
   test('destroys the events stream when the last subscriber unsubscribes', async () => {
     const eventsEmitter = new EventEmitter();
     const destroySpy = mock(() => {});
@@ -555,7 +555,7 @@ describe('subscribe — cleanup (last unsubscribe)', () => {
   });
 });
 
-describe('subscribe — error handling', () => {
+describe('subscribe: error handling', () => {
   test('handles listContainers failure gracefully', async () => {
     const eventsEmitter = new EventEmitter();
     const docker = {
@@ -655,7 +655,7 @@ describe('subscribe — error handling', () => {
   });
 });
 
-describe('broadcastToAll — subscriber isolation', () => {
+describe('broadcastToAll: subscriber isolation', () => {
   test('a throwing subscriber does not prevent delivery to other subscribers', async () => {
     const eventsEmitter = new EventEmitter();
     const containers = [makeContainer('c1', 'app1')];
@@ -664,7 +664,7 @@ describe('broadcastToAll — subscriber isolation', () => {
     const received1: BroadcasterEvent[] = [];
     const received2: BroadcasterEvent[] = [];
     // Skip 'init' in assertions/throws: init is delivered directly by subscribe(),
-    // not via broadcastToAll — throwing there would fail subscribe() itself.
+    // not via broadcastToAll; throwing there would fail subscribe() itself.
     const throwingCallback = (e: BroadcasterEvent) => {
       if (e.op !== 'init') throw new Error('subscriber1 threw');
     };
@@ -720,7 +720,7 @@ describe('_handleDockerEventForTesting', () => {
   });
 });
 
-describe('subscribe — error handling (data handler catch path)', () => {
+describe('subscribe: error handling (data handler catch path)', () => {
   test('logs error when handleDockerEvent rejects inside data handler', async () => {
     const eventsEmitter = new EventEmitter();
     const containers = [makeContainer('c1', 'app1')];
@@ -749,7 +749,7 @@ describe('subscribe — error handling (data handler catch path)', () => {
   });
 });
 
-describe('subscribe — pause and unpause events (Fix 2)', () => {
+describe('subscribe: pause and unpause events (Fix 2)', () => {
   test('pause event produces an upsert', async () => {
     const eventsEmitter = new EventEmitter();
     const containers = [makeContainer('c1', 'app1', 'running')];
@@ -823,7 +823,7 @@ describe('subscribe — pause and unpause events (Fix 2)', () => {
   });
 });
 
-describe('subscribe — reconnect fresh init (Fix 3)', () => {
+describe('subscribe: reconnect fresh init (Fix 3)', () => {
   test('after reconnect, subscribers receive a fresh init reflecting updated container state', async () => {
     const originalSetTimeout = globalThis.setTimeout;
     let capturedReconnectCallback: (() => void) | null = null;
@@ -872,7 +872,7 @@ describe('subscribe — reconnect fresh init (Fix 3)', () => {
       // Restore real setTimeout before firing the callback (it awaits async operations)
       globalThis.setTimeout = originalSetTimeout;
 
-      // Fire the reconnect — triggers startEventsSubscription(docker, true)
+      // Fire the reconnect; triggers startEventsSubscription(docker, true)
       // which calls listContainers (reconnect path) and broadcasts fresh init
       await (capturedReconnectCallback as unknown as () => Promise<void>)();
       await new Promise((r) => originalSetTimeout(r, 20));
@@ -894,7 +894,7 @@ describe('subscribe — reconnect fresh init (Fix 3)', () => {
   });
 });
 
-describe('subscribe — init enrichment via inspect', () => {
+describe('subscribe: init enrichment via inspect', () => {
   test('populates StartedAt/FinishedAt/ExitCode from inspect on first init', async () => {
     const eventsEmitter = new EventEmitter();
     const listEntry = makeContainer('c1', 'app1', 'exited');
@@ -1058,7 +1058,7 @@ describe('subscribe — init enrichment via inspect', () => {
     }
   });
 
-  test('inspect failure on ONE container does not crash init — others populated', async () => {
+  test('inspect failure on ONE container does not crash init, others populated', async () => {
     const eventsEmitter = new EventEmitter();
     const list = [
       makeContainer('c1', 'app1', 'running'),
@@ -1106,7 +1106,7 @@ describe('subscribe — init enrichment via inspect', () => {
   });
 });
 
-describe('_resetBroadcasterForTesting — with active reconnect timer', () => {
+describe('_resetBroadcasterForTesting: with active reconnect timer', () => {
   test('clears pending reconnect timer during reset', async () => {
     const originalSetTimeout = globalThis.setTimeout;
     const timerCallbacks: Array<() => void> = [];
@@ -1124,11 +1124,11 @@ describe('_resetBroadcasterForTesting — with active reconnect timer', () => {
     };
 
     try {
-      // Trigger a stream error — scheduleReconnect will capture a timer via mocked setTimeout
+      // Trigger a stream error; scheduleReconnect will capture a timer via mocked setTimeout
       eventsEmitter.emit('error', new Error('disconnect'));
       await new Promise((r) => originalSetTimeout(r, 10));
 
-      // Reset while the timer is pending — exercises lines 224-225
+      // Reset while the timer is pending; exercises lines 224-225
       _resetBroadcasterForTesting();
 
       // Timer callback was captured but should now be a no-op (state cleared)

--- a/agent/src/lib/docker-events-broadcaster.ts
+++ b/agent/src/lib/docker-events-broadcaster.ts
@@ -146,7 +146,7 @@ async function handleDockerEvent(event: DockerEventMessage): Promise<void> {
       state.containers.delete(containerId);
       broadcastToAll({ op: 'destroy', containerId });
     } else {
-      // Treat non-404 errors as transient — do not update state or broadcast.
+      // Treat non-404 errors as transient: do not update state or broadcast.
       // The next event for this container will retry naturally.
       const statusCode = (typeof err === 'object' && err !== null && 'statusCode' in err)
         ? (err as { statusCode: number }).statusCode
@@ -161,7 +161,7 @@ async function handleDockerEvent(event: DockerEventMessage): Promise<void> {
  * List all containers and enrich each with inspect() in parallel so we can
  * populate StartedAt/FinishedAt/ExitCode (not available from listContainers).
  * If an individual inspect fails, fall back to the listContainers fields for
- * that container with null timestamps/exit code — don't fail the whole init.
+ * that container with null timestamps/exit code, don't fail the whole init.
  */
 async function listAndEnrichContainers(docker: Dockerode): Promise<MinimalContainerInfo[]> {
   const listed = await docker.listContainers({ all: true });
@@ -352,7 +352,7 @@ export function _resetBroadcasterForTesting(): void {
 /**
  * Simulate a Docker event flowing through the broadcaster. Intended for tests only.
  * The docker parameter is accepted for API compatibility with callers that pass a
- * Dockerode instance — state.docker is used internally (already set by subscribe()).
+ * Dockerode instance; state.docker is used internally (already set by subscribe()).
  */
 export async function _handleDockerEventForTesting(
   _docker: Dockerode,

--- a/agent/src/middleware.ts
+++ b/agent/src/middleware.ts
@@ -34,7 +34,7 @@ export function authenticateRequest(
   }
 
   if (!expectedToken.trim()) {
-    console.error('AGENT_TOKEN is empty or whitespace — rejecting all requests');
+    console.error('AGENT_TOKEN is empty or whitespace, rejecting all requests');
     return Response.json({ error: 'Server misconfigured' }, { status: 500 });
   }
 

--- a/agent/src/routes/logs.ts
+++ b/agent/src/routes/logs.ts
@@ -147,7 +147,7 @@ export function handleLogStream(
 
         // Send periodic heartbeat to prevent idle socket timeouts from killing
         // the connection. Must be shorter than any intermediary timeout (Bun
-        // fetch, Nitro, reverse proxies) — 5 s is safe for typical defaults.
+        // fetch, Nitro, reverse proxies); 5 s is safe for typical defaults.
         controller.enqueue(encoder.encode(':\n\n'));
         const heartbeatInterval = setInterval(() => {
           if (closed) { clearInterval(heartbeatInterval); return; }

--- a/agent/src/routes/stacks.ts
+++ b/agent/src/routes/stacks.ts
@@ -191,7 +191,7 @@ export async function handleStackDeploy(
   const composeEnv = { ...process.env, COMPOSE_PROJECT_NAME: parsed.stack };
 
   // When force recreate is enabled, remove any containers with explicit
-  // container_name values that might conflict — they could belong to a
+  // container_name values that might conflict: they could belong to a
   // different compose project so `docker compose down` won't touch them.
   if (parsed.forceRecreate) {
     // Resolve env-var interpolations in the compose file (e.g. ${APP_NAME}-web)
@@ -213,7 +213,7 @@ export async function handleStackDeploy(
         resolvedContent = configResult.stdout;
       }
     } catch {
-      // Non-fatal — fall back to raw content
+      // Non-fatal: fall back to raw content
     } finally {
       try { unlinkSync(tmpFile); } catch { /* ignore */ }
     }
@@ -228,7 +228,7 @@ export async function handleStackDeploy(
           env: composeEnv,
         }, 10_000);
       } catch {
-        // Non-fatal — container may not exist
+        // Non-fatal: container may not exist
       }
     }
   }

--- a/agent/src/routes/stats.ts
+++ b/agent/src/routes/stats.ts
@@ -241,7 +241,7 @@ function openContainerStream(
 
     readable.on('error', (error: Error) => {
       if (isContainerGone(error)) {
-        // Container removed while streaming — normal lifecycle, not an error
+        // Container removed while streaming: normal lifecycle, not an error
         ctx.containerStreams.delete(id);
         return;
       }
@@ -254,7 +254,7 @@ function openContainerStream(
       ctx.containerStreams.delete(id);
     });
   }).catch((error: Error) => {
-    if (isContainerGone(error)) return; // Container removed between list and stats — race condition
+    if (isContainerGone(error)) return; // Container removed between list and stats (race condition)
     console.error(`Failed to open stats stream for container ${id}:`, error.message);
     sendErrorSSE(ctx, { containerId: id, error: error.message });
   });
@@ -385,11 +385,11 @@ async function runStatsLoop(
  * new containers and destroying stale ones.
  *
  * SSE event types emitted:
- * - `data` (default): `{ containerId, containerName, image, cpuPercent, memoryUsage, ... }` — pre-computed metrics
- * - `containers`: `{ ids: string[] }` — emitted after each container list refresh
- * - `container-error`: `{ containerId, error }` — per-container stream or open failure
- * - `container-error` with `type: "refresh_failed"`: `{ error, type }` — container list refresh failure
- * - `error`: `{ error }` — fatal stream-level failure (e.g. initial listContainers fails)
+ * - `data` (default): `{ containerId, containerName, image, cpuPercent, memoryUsage, ... }`, pre-computed metrics
+ * - `containers`: `{ ids: string[] }`, emitted after each container list refresh
+ * - `container-error`: `{ containerId, error }`, per-container stream or open failure
+ * - `container-error` with `type: "refresh_failed"`: `{ error, type }`, container list refresh failure
+ * - `error`: `{ error }`, fatal stream-level failure (e.g. initial listContainers fails)
  *
  * Clients MUST handle the `error` and `container-error` SSE events since the HTTP
  * status is always 200 (the Response is returned before async start() runs).

--- a/agent/src/routes/zfs.ts
+++ b/agent/src/routes/zfs.ts
@@ -1,7 +1,7 @@
 import type { ZfsCapabilities } from '../lib/zfs-capabilities';
 
 /**
- * GET /zfs/stats/stream — SSE endpoint that streams `zpool iostat -v 1` output.
+ * GET /zfs/stats/stream: SSE endpoint that streams `zpool iostat -v 1` output.
  *
  * Each non-empty line from the subprocess is emitted as an SSE event with
  * `{ line, timestamp }`. The subprocess is killed when the client disconnects.
@@ -94,7 +94,7 @@ export function handleZfsStatsStream(
 }
 
 /**
- * GET /zfs/pools — Returns parsed pool data from `zpool list -Hp`.
+ * GET /zfs/pools: Returns parsed pool data from `zpool list -Hp`.
  *
  * Response: `{ pools: Array<{ name, size, allocated, free, fragmentation, capacity, dedup, health }> }`
  */

--- a/agent/src/types/protocol.ts
+++ b/agent/src/types/protocol.ts
@@ -47,7 +47,7 @@ export const zInventorySnapshotContainer = z.object({
 export type InventorySnapshotContainer = z.infer<typeof zInventorySnapshotContainer>;
 
 /**
- * Update shape: emitted on `op: 'upsert'`. Labels are intentionally absent —
+ * Update shape: emitted on `op: 'upsert'`. Labels are intentionally absent:
  * the Docker event stream does not deliver them, and the NOTIFY payload
  * downstream omits them (8 kB cap). Callers that need labels must fetch from
  * the snapshot path (init / DB).

--- a/dev/openbao/entrypoint.sh
+++ b/dev/openbao/entrypoint.sh
@@ -20,7 +20,7 @@ for _ in $(seq 1 30); do
     SERVER_READY=true
     break
   fi
-  # 501=not initialized, 503=sealed — both mean "server is up"
+  # 501=not initialized, 503=sealed (both mean "server is up")
   if wget -q -O /dev/null "$BAO_ADDR/v1/sys/seal-status" 2>/dev/null; then
     SERVER_READY=true
     break
@@ -34,7 +34,7 @@ if [ "$SERVER_READY" != "true" ]; then
 fi
 
 if [ ! -f "$INIT_FILE" ]; then
-  echo "[openbao-init] First start — initializing..."
+  echo "[openbao-init] First start: initializing..."
 
   # Initialize via HTTP API
   wget -q -O "$INIT_FILE" --post-data '{"secret_shares":1,"secret_threshold":1}' \
@@ -63,7 +63,7 @@ if [ ! -f "$INIT_FILE" ]; then
     --header="Content-Type: application/json" \
     --header="X-Vault-Token: $ROOT_TOKEN" \
     "$BAO_ADDR/v1/auth/token/create-orphan" 2>&1) || {
-    # Token may already exist from a prior run — check for known error patterns
+    # Token may already exist from a prior run; check for known error patterns
     case "$TOKEN_RESPONSE" in
       *"already exists"*|*"token already"*)
         echo "[openbao-init] Dev root token already exists, continuing." ;;
@@ -75,7 +75,7 @@ if [ ! -f "$INIT_FILE" ]; then
 
   echo "[openbao-init] Initialization complete."
 else
-  echo "[openbao-init] Existing data — unsealing..."
+  echo "[openbao-init] Existing data: unsealing..."
   UNSEAL_KEY=$(sed -n 's/.*"keys_base64":\["\([^"]*\)".*/\1/p' "$INIT_FILE")
 
   if [ -z "$UNSEAL_KEY" ]; then

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,7 +70,7 @@ flowchart LR
     Agent --> SSE --> WK --> DB
 ```
 
-The worker connects to agent sidecars on each managed host via SSE. For Docker stats, the agent pre-computes metrics (CPU%, memory%, network/block I/O rates) before streaming — the worker receives ready-to-insert rows. For ZFS, the agent streams raw `zpool iostat` output which the worker parses and rate-calculates. Proxmox is a direct REST API poll (no agent).
+The worker connects to agent sidecars on each managed host via SSE. For Docker stats, the agent pre-computes metrics (CPU%, memory%, network/block I/O rates) before streaming, so the worker receives ready-to-insert rows. For ZFS, the agent streams raw `zpool iostat` output which the worker parses and rate-calculates. Proxmox is a direct REST API poll (no agent).
 
 ### Stage 2: Real-Time Streaming (Server -> Browser)
 
@@ -109,7 +109,7 @@ Proxmox uses a single wide `proxmox_stats` hypertable with an `entity_type` disc
 
 ## Docker Stack Management
 
-GitOps-style Docker stack management. Users define stacks as docker-compose files in a git repository managed by homelab-manager. Changes — via an in-app editor or `git push` — trigger deployments to Docker hosts through lightweight agent containers.
+GitOps-style Docker stack management. Users define stacks as docker-compose files in a git repository managed by homelab-manager. Changes (via an in-app editor or `git push`) trigger deployments to Docker hosts through lightweight agent containers.
 
 ### High-Level Flow
 
@@ -143,9 +143,9 @@ User's Browser --UI edit--> homelab-manager commits ----------------> Deploy Pip
 Hosts are registered via the Settings UI and stored in the `managed_hosts` database table with agent connection details and capabilities (docker, zfs).
 
 **Collector creation** (`src/worker/collector-factory.ts`):
-- `createCollectors()` — env-configured collectors (Proxmox only; Docker and ZFS always go through managed hosts)
-- `createCollectorsForManagedHosts()` — agent-based collectors for registered hosts (Docker stats + ZFS)
-- `createContainerInventoryCollectors()` — container inventory from agent `/containers/events` SSE, writing to `docker_container_events`
+- `createCollectors()`: env-configured collectors (Proxmox only; Docker and ZFS always go through managed hosts)
+- `createCollectorsForManagedHosts()`: agent-based collectors for registered hosts (Docker stats + ZFS)
+- `createContainerInventoryCollectors()`: container inventory from agent `/containers/events` SSE, writing to `docker_container_events`
 
 **Token resolution**: Agent tokens are stored in OpenBao and resolved via a `getToken(hostname)` callback. Hosts with missing tokens are skipped with a logged warning.
 
@@ -203,14 +203,14 @@ DeployRequest -> Validate -> Resolve Secrets -> Dispatch to Agent -> Record Resu
 ```
 
 - **Change detection:** Content hashing to skip no-op deploys
-- **Secret resolution:** Pluggable interface — no-op by default, OpenBao when configured. Resolves `${SECRET:path/key}` variable references in compose files
+- **Secret resolution:** Pluggable interface (no-op by default, OpenBao when configured). Resolves `${SECRET:path/key}` variable references in compose files
 - **Concurrency control:** PostgreSQL partial unique index prevents concurrent deploys to the same stack+host
 - **Agent client:** HTTP wrapper for communicating with agents (deploy/teardown/restart)
 
 **Database tables:**
-- `managed_hosts` — registered Docker hosts with agent connection details and capabilities
-- `deploy_history` — deploy records with status tracking (pending -> in_progress -> succeeded/failed/no_change)
-- `docker_container_events` — per-host container inventory events from agent `/containers/events`
+- `managed_hosts`: registered Docker hosts with agent connection details and capabilities
+- `deploy_history`: deploy records with status tracking (pending -> in_progress -> succeeded/failed/no_change)
+- `docker_container_events`: per-host container inventory events from agent `/containers/events`
 
 ### Stack Status Pipeline
 
@@ -287,7 +287,7 @@ flowchart TD
     N --> O[Record result in deploy_history]
 ```
 
-Pipeline errors do not block the git push — they are caught and logged.
+Pipeline errors do not block the git push; they are caught and logged.
 
 **Manifest format** (`manifest.yaml`):
 
@@ -303,8 +303,8 @@ stacks:
 
 **In-app editor operations** (`src/lib/git/editor-operations.ts`):
 
-- `saveAndCommitFile` — save a compose file and create a commit
-- `updateManifest` — add/update a stack entry in manifest.yaml
+- `saveAndCommitFile`: save a compose file and create a commit
+- `updateManifest`: add/update a stack entry in manifest.yaml
 
 **Concurrency safety:** Commits are serialized per-repo via an async mutex to prevent lost updates from concurrent writes.
 
@@ -327,7 +327,7 @@ stacks:
 Secret management via [OpenBao](https://openbao.org/) (open-source Vault fork).
 
 - KV v2 HTTP client for secret CRUD (`src/lib/clients/openbao-client.ts`)
-- Pluggable `SecretResolver` interface — auto-detects OpenBao when `OPENBAO_URL` is set, falls back to no-op
+- Pluggable `SecretResolver` interface: auto-detects OpenBao when `OPENBAO_URL` is set, falls back to no-op
 - Deploy pipeline resolves `${SECRET:path/key}` variable references in compose files before dispatching to agents
 - Agent tokens stored and retrieved from OpenBao KV v2
 - OpenBao dev server in docker-compose for local development (management profile)

--- a/docs/development.md
+++ b/docs/development.md
@@ -38,7 +38,7 @@ POSTGRES_PASSWORD="changeme"
 POSTGRES_PORT="5432"
 POSTGRES_POOL_SIZE="10"
 
-# Worker — enable Docker collection
+# Worker: enable Docker collection
 WORKER_ENABLED="true"
 WORKER_DOCKER_ENABLED="true"
 WORKER_COLLECTION_INTERVAL_MS="1000"
@@ -77,17 +77,17 @@ bun dev
 ```
 
 This starts:
-- **PostgreSQL** — database
-- **Worker** — background stats collector
-- **OpenBao** — secrets manager (file backend, auto-initializes on first start with root token `dev-root-token`, data persists across restarts)
-- **Socket proxy** — safe Docker API access
-- **Agent** — sidecar that streams container stats and handles deploys
+- **PostgreSQL**: database
+- **Worker**: background stats collector
+- **OpenBao**: secrets manager (file backend, auto-initializes on first start with root token `dev-root-token`, data persists across restarts)
+- **Socket proxy**: safe Docker API access
+- **Agent**: sidecar that streams container stats and handles deploys
 
 ### Step 3: Add Sample Containers via the Stacks Repo
 
 The stacks feature uses an in-app git repo to store Docker Compose files. Clone it and add some sample containers so the dashboard has data to display:
 
-**Docker monitoring:** The local compose file seeds a localhost agent (via `DEV_AGENT_TOKEN`) that reaches Docker through a socket proxy on the internal `agent-internal` network. The worker subscribes to the agent's SSE streams — it does not connect to Docker directly. No host port is needed for the Docker socket.
+**Docker monitoring:** The local compose file seeds a localhost agent (via `DEV_AGENT_TOKEN`) that reaches Docker through a socket proxy on the internal `agent-internal` network. The worker subscribes to the agent's SSE streams; it does not connect to Docker directly. No host port is needed for the Docker socket.
 
 ```bash
 git clone http://x:dev-git-token@localhost:3000/api/git/stacks ~/stacks
@@ -238,7 +238,7 @@ bun build               # Production build (runs typecheck first)
 
 ## TLS Setup (Agent Communication)
 
-Agent sidecars can optionally serve over HTTPS. This is not required for local network use — agents work over plain HTTP by default. For production or untrusted networks, use OpenBao's PKI secrets engine to issue short-lived certificates.
+Agent sidecars can optionally serve over HTTPS. This is not required for local network use; agents work over plain HTTP by default. For production or untrusted networks, use OpenBao's PKI secrets engine to issue short-lived certificates.
 
 ### Enable the PKI secrets engine
 
@@ -276,4 +276,4 @@ bao write pki/issue/agent \
 - The agent reads the certificate and key from `TLS_CERT_PATH` and `TLS_KEY_PATH` env vars.
 - Set `NODE_EXTRA_CA_CERTS` on the web server and worker to trust the internal CA.
 - Certificates have short TTLs (30 days) and should be renewed before expiry.
-- The PKI engine acts as an internal CA — no external certificate authority is required.
+- The PKI engine acts as an internal CA, so no external certificate authority is required.

--- a/docs/git-stacks-repo.md
+++ b/docs/git-stacks-repo.md
@@ -1,6 +1,6 @@
 # Git Stacks Repository
 
-homelab-manager stores Docker Compose stack definitions in an in-app bare git repository. This repo is managed by isomorphic-git inside the web server container — you don't need an external git server.
+homelab-manager stores Docker Compose stack definitions in an in-app bare git repository. This repo is managed by isomorphic-git inside the web server container, so you don't need an external git server.
 
 ## How It Works
 
@@ -31,7 +31,7 @@ When prompted for credentials, use any username and the `GIT_SERVER_TOKEN` value
 git clone http://x:dev-git-token@localhost:3000/api/git/stacks ~/stacks
 ```
 
-> **Note:** The `x` username is ignored — only the password (token) matters.
+> **Note:** The `x` username is ignored; only the password (token) matters.
 
 ### Adding a Stack
 
@@ -70,7 +70,7 @@ git commit -m "Add my-app stack"
 git push
 ```
 
-The push triggers the post-receive hook, which dispatches to the deploy pipeline. If `autoDeploy: true`, the pipeline resolves secrets and sends the compose file to the agent on the specified host. If `autoDeploy: false`, the stack appears on the stacks page as "pending" and can be deployed manually from the UI. Pipeline errors do not block the push — check server logs for deploy failures.
+The push triggers the post-receive hook, which dispatches to the deploy pipeline. If `autoDeploy: true`, the pipeline resolves secrets and sends the compose file to the agent on the specified host. If `autoDeploy: false`, the stack appears on the stacks page as "pending" and can be deployed manually from the UI. Pipeline errors do not block the push; check server logs for deploy failures.
 
 ### Manifest Format
 
@@ -86,7 +86,7 @@ stacks:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GIT_REPOS_DIR` | `/data/repos` | Directory for bare git repos (inside the container) |
-| `GIT_SERVER_TOKEN` | — | Bearer token for git HTTP authentication (required) |
+| `GIT_SERVER_TOKEN` | (none) | Bearer token for git HTTP authentication (required) |
 
 Both must be set in your `.env`.
 

--- a/scripts/test-perf.sh
+++ b/scripts/test-perf.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Test performance profiler — shows slowest test suites and individual tests
+# Test performance profiler: shows slowest test suites and individual tests
 # Usage: ./scripts/test-perf.sh [threshold_ms]
 #
 # Runs bun test with JUnit output, parses timing data, and reports:

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -37,7 +37,7 @@ POSTGRES_USER=homelab
 POSTGRES_PASSWORD=changeme   # change this
 
 # OpenBao (secrets storage for managed host agent tokens)
-OPENBAO_TOKEN=changeme       # change this — use a long random string
+OPENBAO_TOKEN=changeme       # change this; use a long random string
 ```
 
 See [Configuration](#configuration) for all available options.
@@ -88,7 +88,7 @@ All configuration is done via environment variables in your `.env` file.
 | `POSTGRES_DB` | Database name |
 | `POSTGRES_USER` | Database user |
 | `POSTGRES_PASSWORD` | Database password |
-| `OPENBAO_TOKEN` | Root token for OpenBao secrets storage — use a long random string |
+| `OPENBAO_TOKEN` | Root token for OpenBao secrets storage (use a long random string) |
 
 ### Web Server
 
@@ -106,13 +106,13 @@ Any reverse proxy works. [Caddy](https://caddyserver.com/docs/) is a popular hom
 
 ### Docker Monitoring
 
-Docker monitoring works through agent sidecars. Deploy the agent container on each host you want to monitor, then register the host in **Settings → Managed Hosts** with the `docker` capability enabled. The worker subscribes to the agent's SSE streams for stats and container inventory — no direct Docker socket access is required on the dashboard host.
+Docker monitoring works through agent sidecars. Deploy the agent container on each host you want to monitor, then register the host in **Settings → Managed Hosts** with the `docker` capability enabled. The worker subscribes to the agent's SSE streams for stats and container inventory; no direct Docker socket access is required on the dashboard host.
 
 > **Setup:** See the [Docker Stack Management](#docker-stack-management) section below for the agent deploy flow. The same agent serves both monitoring and deploy operations.
 
 ### ZFS Monitoring
 
-ZFS monitoring works through agent sidecars — the same agents used for Docker management. When you register a managed host with ZFS capability, the worker connects to the agent's `/zfs/stats/stream` SSE endpoint to receive real-time `zpool iostat` data. No SSH configuration is needed.
+ZFS monitoring works through agent sidecars (the same agents used for Docker management). When you register a managed host with ZFS capability, the worker connects to the agent's `/zfs/stats/stream` SSE endpoint to receive real-time `zpool iostat` data. No SSH configuration is needed.
 
 > **Setup:** Deploy the agent container on a host with ZFS pools, then register the host in **Settings → Managed Hosts** with the `zfs` capability enabled. The agent auto-detects ZFS by checking for the `zpool` binary at startup.
 
@@ -130,7 +130,7 @@ ZFS monitoring works through agent sidecars — the same agents used for Docker 
 
 ### Docker Stack Management
 
-Stack management lets you deploy and manage Docker Compose stacks on your hosts via the dashboard. Agent tokens are stored in OpenBao — no `.env` file or token file is distributed to hosts.
+Stack management lets you deploy and manage Docker Compose stacks on your hosts via the dashboard. Agent tokens are stored in OpenBao, so no `.env` file or token file is distributed to hosts.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -140,7 +140,7 @@ Stack management lets you deploy and manage Docker Compose stacks on your hosts 
 >
 > **Adding a host:** Deploy the agent on your Docker host, then register it in **Settings → Managed Hosts** by providing the agent's URL and token. The dashboard verifies connectivity before saving.
 >
-> **Agent setup:** Use **Settings → Managed Hosts → Add Host** in the dashboard. The wizard generates a compose file, a `.env`, and a token file (`agent-token`) for the agent host. The same token is stored in OpenBao by the dashboard when you complete the wizard — it is never embedded in the compose environment directly.
+> **Agent setup:** Use **Settings → Managed Hosts → Add Host** in the dashboard. The wizard generates a compose file, a `.env`, and a token file (`agent-token`) for the agent host. The same token is stored in OpenBao by the dashboard when you complete the wizard; it is never embedded in the compose environment directly.
 >
 > The wizard-generated compose mounts the token from a local file rather than an env var:
 >
@@ -158,7 +158,7 @@ Stack management lets you deploy and manage Docker Compose stacks on your hosts 
 >   restart: unless-stopped
 > ```
 >
-> Run `chmod 600 agent-token` after creating the token file. Once the agent is running, provide its URL in the wizard's Verify step — the dashboard verifies connectivity and stores the token in OpenBao.
+> Run `chmod 600 agent-token` after creating the token file. Once the agent is running, provide its URL in the wizard's Verify step; the dashboard verifies connectivity and stores the token in OpenBao.
 
 ### Worker Behavior
 
@@ -187,10 +187,10 @@ OPENBAO_TOKEN=a-long-random-string-here
 # Web Server
 # WEB_PORT=3000
 
-# Docker — no env vars needed; register hosts with the Docker capability
+# Docker: no env vars needed; register hosts with the Docker capability
 # in Settings → Managed Hosts after deploying an agent sidecar.
 
-# ZFS — no env vars needed; register hosts with ZFS capability
+# ZFS: no env vars needed; register hosts with ZFS capability
 # in Settings → Managed Hosts after deploying an agent sidecar
 
 # Proxmox VE
@@ -243,4 +243,4 @@ docker compose up -d
 **OpenBao fails to start**
 - Ensure `OPENBAO_TOKEN` is set in your `.env`.
 - Check logs: `docker compose logs openbao`
-- The `openbao-data` volume persists the init keys — do not delete it unless you intend to reinitialize.
+- The `openbao-data` volume persists the init keys; do not delete it unless you intend to reinitialize.

--- a/self-hosting/openbao-entrypoint.sh
+++ b/self-hosting/openbao-entrypoint.sh
@@ -21,7 +21,7 @@ for _ in $(seq 1 30); do
     SERVER_READY=true
     break
   fi
-  # 501=not initialized, 503=sealed — both mean "server is up"
+  # 501=not initialized, 503=sealed (both mean "server is up")
   if wget -q -O /dev/null "$BAO_ADDR/v1/sys/seal-status" 2>/dev/null; then
     SERVER_READY=true
     break
@@ -34,12 +34,12 @@ if [ "$SERVER_READY" != "true" ]; then
   exit 1
 fi
 
-# Query init status before deciding to initialize — avoids re-init if INIT_FILE
+# Query init status before deciding to initialize: avoids re-init if INIT_FILE
 # was lost but the server was already initialized (which would fail anyway).
 ALREADY_INITIALIZED=$(wget -q -O - "$BAO_ADDR/v1/sys/init" 2>/dev/null | sed -n 's/.*"initialized":\(true\|false\).*/\1/p')
 
 if [ "$ALREADY_INITIALIZED" = "false" ]; then
-  echo "[openbao-init] First start — initializing..."
+  echo "[openbao-init] First start: initializing..."
 
   # Write to a temp file, validate, then atomically persist only the unseal key.
   # The root_token is used only during bootstrap and must not be stored on disk.
@@ -97,7 +97,7 @@ POLICY
 
   echo "[openbao-init] Initialization complete."
 else
-  echo "[openbao-init] Existing data — unsealing..."
+  echo "[openbao-init] Existing data: unsealing..."
 
   if [ ! -f "$INIT_FILE" ]; then
     echo "[openbao-init] ERROR: Server is initialized but $INIT_FILE is missing. Cannot unseal."

--- a/src/App.css
+++ b/src/App.css
@@ -56,7 +56,7 @@ html {
 }
 
 
-/* Themed scrollbar for drawer panels — uses MUI palette for theme adaptation */
+/* Themed scrollbar for drawer panels: uses MUI palette for theme adaptation */
 .themed-scrollbar {
   &::-webkit-scrollbar {
     width: 14px;
@@ -91,7 +91,7 @@ html {
   background-color: var(--mui-palette-background-default);
 }
 
-/* page-content has its own animation per type — disable the default crossfade */
+/* page-content has its own animation per type: disable the default crossfade */
 ::view-transition-old(page-content),
 ::view-transition-new(page-content) {
   animation: none;
@@ -146,7 +146,7 @@ html {
   from { opacity: 0; }
 }
 
-/* Sparkline loading shimmer — sweeps left to right */
+/* Sparkline loading shimmer: sweeps left to right */
 @keyframes sparkline-shimmer {
   0% { transform: translateX(-100%); opacity: 0; }
   30% { opacity: 0.4; }

--- a/src/components/docker/ContainerHistoryPage.tsx
+++ b/src/components/docker/ContainerHistoryPage.tsx
@@ -187,7 +187,7 @@ export default function ContainerHistoryPage({
       {/* Sticky panel header */}
       <div className="sticky top-0 z-10 !bg-[var(--mui-palette-background-level1)] border-b border-[var(--mui-palette-divider)] px-6 pt-4 pb-3 select-none">
         <div className="relative">
-          {/* Real content — always in flow, determines height */}
+          {/* Real content: always in flow, determines height */}
           <div className={`flex items-center gap-3 transition-opacity duration-300 ${infoQuery.isLoading ? 'opacity-0' : 'opacity-100'}`}>
             <img
               src={iconError ? FALLBACK_ICON_URL : iconUrl}
@@ -213,7 +213,7 @@ export default function ContainerHistoryPage({
               </IconButton>
             )}
           </div>
-          {/* Skeleton overlay — always absolute, fades out */}
+          {/* Skeleton overlay: always absolute, fades out */}
           <div className={`absolute inset-0 flex items-center gap-3 transition-opacity duration-300 ${infoQuery.isLoading ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
             <Skeleton variant="rounded" width={32} height={32} className="flex-shrink-0" />
             <div className="min-w-0 flex-1">

--- a/src/components/docker/ContainerStateChip.tsx
+++ b/src/components/docker/ContainerStateChip.tsx
@@ -54,7 +54,7 @@ function StateIndicator({ state }: { state: ContainerState }) {
     );
   }
 
-  // created, removing, unknown — outlined dot
+  // created, removing, unknown: outlined dot
   return (
     <span
       className="inline-block w-2 h-2 rounded-full border border-[var(--mui-palette-action-disabled)]"

--- a/src/components/docker/ContainerTable.tsx
+++ b/src/components/docker/ContainerTable.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/hooks/toastAtom';
 import { StaleDataAlert } from '@/components/shared-table/StaleDataAlert';
 import { DataTable, type MetricGroup } from '@/components/shared-table/DataTable';
 import { metricColumn, nameColumn } from '@/components/shared-table/columns';
+import { EMPTY_METRIC } from '@/components/shared-table/MetricCell';
 import { formatAsPercentParts, formatBytesParts, formatBitsSIUnitsParts } from '@/formatters/metrics';
 import type {
   DockerStatsRow,
@@ -214,7 +215,7 @@ export default function ContainerTable({
           if (row.type === 'host') {
             return formatAsPercentParts(row.aggregated.cpuPercent / 100, docker.decimals.cpu);
           }
-          if (!row.stats) return { value: '—', unit: '' };
+          if (!row.stats) return { value: EMPTY_METRIC, unit: '' };
           return formatAsPercentParts(row.stats.rates.cpuPercent / 100, docker.decimals.cpu);
         },
         getSparklineData: (row) => (row.type === 'container' ? (row.sparklineData?.cpu ?? []) : []),
@@ -233,7 +234,7 @@ export default function ContainerTable({
               ? formatBytesParts(row.aggregated.memoryUsage, false, docker.decimals.memory)
               : formatAsPercentParts(row.aggregated.memoryPercent / 100, docker.decimals.memory);
           }
-          if (!row.stats) return { value: '—', unit: '' };
+          if (!row.stats) return { value: EMPTY_METRIC, unit: '' };
           return docker.memoryDisplayMode === 'bytes'
             ? formatBytesParts(row.stats.memory_stats.usage, false, docker.decimals.memory)
             : formatAsPercentParts(row.stats.rates.memoryPercent / 100, docker.decimals.memory);
@@ -252,7 +253,7 @@ export default function ContainerTable({
           if (row.type === 'host') {
             return formatBytesParts(row.aggregated.blockIoReadBytesPerSec, true, docker.decimals.diskSpeed);
           }
-          if (!row.stats) return { value: '—', unit: '' };
+          if (!row.stats) return { value: EMPTY_METRIC, unit: '' };
           return formatBytesParts(row.stats.rates.blockIoReadBytesPerSec, true, docker.decimals.diskSpeed);
         },
         getSparklineData: (row) => (row.type === 'container' ? (row.sparklineData?.blockRead ?? []) : []),
@@ -269,7 +270,7 @@ export default function ContainerTable({
           if (row.type === 'host') {
             return formatBytesParts(row.aggregated.blockIoWriteBytesPerSec, true, docker.decimals.diskSpeed);
           }
-          if (!row.stats) return { value: '—', unit: '' };
+          if (!row.stats) return { value: EMPTY_METRIC, unit: '' };
           return formatBytesParts(row.stats.rates.blockIoWriteBytesPerSec, true, docker.decimals.diskSpeed);
         },
         getSparklineData: (row) => (row.type === 'container' ? (row.sparklineData?.blockWrite ?? []) : []),
@@ -286,7 +287,7 @@ export default function ContainerTable({
           if (row.type === 'host') {
             return formatBitsSIUnitsParts(row.aggregated.networkRxBytesPerSec * 8, true, docker.decimals.networkSpeed);
           }
-          if (!row.stats) return { value: '—', unit: '' };
+          if (!row.stats) return { value: EMPTY_METRIC, unit: '' };
           return formatBitsSIUnitsParts(row.stats.rates.networkRxBytesPerSec * 8, true, docker.decimals.networkSpeed);
         },
         getSparklineData: (row) => (row.type === 'container' ? (row.sparklineData?.networkRx ?? []) : []),
@@ -303,7 +304,7 @@ export default function ContainerTable({
           if (row.type === 'host') {
             return formatBitsSIUnitsParts(row.aggregated.networkTxBytesPerSec * 8, true, docker.decimals.networkSpeed);
           }
-          if (!row.stats) return { value: '—', unit: '' };
+          if (!row.stats) return { value: EMPTY_METRIC, unit: '' };
           return formatBitsSIUnitsParts(row.stats.rates.networkTxBytesPerSec * 8, true, docker.decimals.networkSpeed);
         },
         getSparklineData: (row) => (row.type === 'container' ? (row.sparklineData?.networkTx ?? []) : []),
@@ -554,7 +555,7 @@ function buildCountLabel(a: HostAggregatedStats): string {
 }
 
 /**
- * Name cell for container rows — shows icon, pulse indicator, state chip, name,
+ * Name cell for container rows: shows icon, pulse indicator, state chip, name,
  * settings and history buttons. Uses hooks for pulse animation and icon picker.
  */
 function ContainerNameCell({
@@ -609,7 +610,7 @@ function ContainerNameCell({
           className={`flex-shrink-0 transition-transform duration-200 ${expanded ? 'rotate-90' : ''}`}
         />
 
-        {/* Pulse indicator — for running and restarting containers with data */}
+        {/* Pulse indicator: for running and restarting containers with data */}
         {(inventory.state === 'running' || inventory.state === 'restarting') && (
           <div
             ref={indicatorRef}

--- a/src/components/docker/IconGrid.tsx
+++ b/src/components/docker/IconGrid.tsx
@@ -2,7 +2,7 @@ import { memo, useState, useMemo, useRef, useCallback, useEffect, createContext,
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { ButtonBase, Skeleton } from '@mui/material';
 
-/** Row-level AbortController context — aborts all in-flight icon loads when the row unmounts. */
+/** Row-level AbortController context: aborts all in-flight icon loads when the row unmounts. */
 const AbortContext = createContext<AbortSignal | null>(null);
 
 const IconCell = memo(function IconCell({ slug, selected, onSelect }: { slug: string; selected: boolean; onSelect: (slug: string) => void }) {

--- a/src/components/docker/__tests__/DockerStatusSummary.test.tsx
+++ b/src/components/docker/__tests__/DockerStatusSummary.test.tsx
@@ -110,7 +110,7 @@ describe('DockerStatusSummary', () => {
       ['server1/c2', makeContainer({ host: 'server1', containerId: 'c2', state: 'exited' })],
     ]);
     renderSummary(inventory);
-    // Both running and stopped are shown — dots should be present
+    // Both running and stopped are shown, dots should be present
     const dots = screen.getAllByText('·');
     expect(dots.length).toBeGreaterThan(0);
   });

--- a/src/components/docker/__tests__/IconGrid.test.tsx
+++ b/src/components/docker/__tests__/IconGrid.test.tsx
@@ -26,7 +26,7 @@ afterEach(() => {
     if (desc) {
       Object.defineProperty(HTMLElement.prototype, prop, desc);
     } else {
-      // Descriptor didn't exist originally — delete the test-installed getter so it doesn't leak to other tests.
+      // Descriptor didn't exist originally: delete the test-installed getter so it doesn't leak to other tests.
       delete (HTMLElement.prototype as unknown as Record<string, unknown>)[prop];
     }
   }

--- a/src/components/docker/__tests__/IconPickerDialog.test.tsx
+++ b/src/components/docker/__tests__/IconPickerDialog.test.tsx
@@ -46,7 +46,7 @@ afterEach(() => {
     if (desc) {
       Object.defineProperty(HTMLElement.prototype, prop, desc);
     } else {
-      // Descriptor didn't exist originally — delete the test-installed getter so it doesn't leak to other tests.
+      // Descriptor didn't exist originally: delete the test-installed getter so it doesn't leak to other tests.
       delete (HTMLElement.prototype as unknown as Record<string, unknown>)[prop];
     }
   }

--- a/src/components/settings/__tests__/HostDialogs.test.tsx
+++ b/src/components/settings/__tests__/HostDialogs.test.tsx
@@ -156,7 +156,7 @@ describe('EditDialog', () => {
   it('does not call onConfirm when host is null', () => {
     const onConfirm = mock(() => {})
     render(<EditDialog {...defaultProps} host={null} onConfirm={onConfirm} />)
-    // Fields will have empty values, Save is disabled — clicking it does nothing
+    // Fields will have empty values, Save is disabled, clicking it does nothing
     const saveBtn = screen.getByRole('button', { name: 'Save' })
     expect(saveBtn.hasAttribute('disabled')).toBe(true)
   })

--- a/src/components/settings/__tests__/ManagedHostsCard.test.tsx
+++ b/src/components/settings/__tests__/ManagedHostsCard.test.tsx
@@ -217,7 +217,7 @@ describe('ManagedHostsCard', () => {
 
     it('Next button advances to compose step (no ZFS)', () => {
       render(<ManagedHostsCardView {...makeProps()} />)
-      // Docker is checked by default, ZFS is not — skip ZFS Setup
+      // Docker is checked by default, ZFS is not, skip ZFS Setup
       fireEvent.click(screen.getByRole('button', { name: 'Next' }))
       expect(screen.getByTestId('step-compose')).toBeDefined()
     })
@@ -309,7 +309,7 @@ describe('ManagedHostsCard', () => {
 
     it('Verify Connection button is disabled while isAdding', () => {
       render(<ManagedHostsCardView {...makeProps({ isAdding: true })} />)
-      // Navigate to verify step — capabilities -> compose -> configuration -> verify
+      // Navigate to verify step: capabilities -> compose -> configuration -> verify
       // The Next button is not disabled by isAdding, only Back and Verify are
       fireEvent.click(screen.getByRole('button', { name: 'Next' }))
       fireEvent.click(screen.getByRole('button', { name: 'Next' }))

--- a/src/components/shared-table/DataTable.tsx
+++ b/src/components/shared-table/DataTable.tsx
@@ -73,7 +73,7 @@ const DEFAULT_ROW_HEIGHT = 41;
 const DEFAULT_OVERSCAN = 20;
 /** Tables below this threshold use `contentVisibility: 'auto'` instead of virtualization,
  * letting the browser natively skip layout/paint for off-screen rows. This also preserves
- * Collapse animations on nested detail panels — virtualized rows use instant show/hide
+ * Collapse animations on nested detail panels. Virtualized rows use instant show/hide
  * to avoid layout conflicts with `contain: layout style`. */
 const VIRTUALIZATION_THRESHOLD = 150;
 
@@ -254,9 +254,9 @@ export function DataTable<TRow>({
     <div ref={containerRef} className="flex flex-col flex-1 min-h-0">
       {toolbar}
 
-      {/* Scrollable container — header + body scroll horizontally together */}
+      {/* Scrollable container: header + body scroll horizontally together */}
       <div ref={scrollRef} className="overflow-y-auto overflow-x-auto flex-1 min-h-0" style={{ scrollbarGutter: isVirtualized || maxHeight ? 'stable' : undefined, maxHeight: maxHeight ?? undefined }}>
-        {/* Sticky header — inside scroll container so it tracks horizontal scroll */}
+        {/* Sticky header: inside scroll container so it tracks horizontal scroll */}
         {showHeader && (
           <div
             className="grid border-b border-neutral-200 dark:border-neutral-700 bg-[var(--mui-palette-background-default)] sticky top-0 z-10"

--- a/src/components/shared-table/SparklineCanvas.tsx
+++ b/src/components/shared-table/SparklineCanvas.tsx
@@ -56,7 +56,7 @@ export default memo(function SparklineCanvas({
     areaStartColorRef.current = colors.areaStart;
     areaEndColorRef.current = colors.areaEnd;
 
-    // Rebuild cached gradient — skip if CSS vars unresolved
+    // Rebuild cached gradient, skip if CSS vars unresolved
     const ctx = gradientCtxRef.current;
     if (ctx && areaStartColorRef.current && areaEndColorRef.current) {
       const gradient = ctx.createLinearGradient(0, PADDING, 0, height - PADDING);
@@ -112,7 +112,7 @@ export default memo(function SparklineCanvas({
     canvas.height = height * dpr;
     ctx.scale(dpr, dpr);
 
-    // Build initial gradient — guard against empty color refs (CSS vars may not yet be resolved)
+    // Build initial gradient, guarding against empty color refs (CSS vars may not yet be resolved)
     if (areaStartColorRef.current && areaEndColorRef.current) {
       const gradient = ctx.createLinearGradient(0, PADDING, 0, height - PADDING);
       gradient.addColorStop(0, areaStartColorRef.current);
@@ -126,7 +126,7 @@ export default memo(function SparklineCanvas({
     const pxBuf = pointsXRef.current;
     const pyBuf = pointsYRef.current;
 
-    // Throttle interval when idle (pulse done) — ~4fps keeps the time-axis
+    // Throttle interval when idle (pulse done): ~4fps keeps the time-axis
     // sliding smoothly without burning GPU on 60fps draws per sparkline.
     const IDLE_INTERVAL_MS = 250;
     let lastDrawTime = 0;

--- a/src/components/shared-table/SparklineCell.tsx
+++ b/src/components/shared-table/SparklineCell.tsx
@@ -31,7 +31,7 @@ export default memo(function SparklineCell({ data, color }: SparklineCellProps) 
   const maxTsRef = useRef(0);
   // 'pending' = first mount, 'waiting' = skipped stale data, 'seeded' = ready
   const stateRef = useRef<'pending' | 'waiting' | 'seeded'>('pending');
-  // Render-time ref mutation — intentional and safe.
+  // Render-time ref mutation: intentional and safe.
   //
   // These refs (stateRef, accRef, maxTsRef) are mutated during render instead of
   // using useState/useEffect. This is safe because updates are idempotent and fully

--- a/src/components/shared-table/__tests__/DataTable.test.tsx
+++ b/src/components/shared-table/__tests__/DataTable.test.tsx
@@ -270,7 +270,7 @@ describe('DataTable', () => {
   it('uses normal flow when row count is at or below virtualization threshold', () => {
     const { container } = render(<DataTable {...defaultProps()} />);
 
-    // 3 rows is well below threshold — should NOT have absolute-positioned wrappers
+    // 3 rows is well below threshold, should NOT have absolute-positioned wrappers
     const absoluteRows = container.querySelectorAll('[style*="position: absolute"]');
     expect(absoluteRows.length).toBe(0);
 

--- a/src/components/shared-table/__tests__/SparklineCanvas.test.tsx
+++ b/src/components/shared-table/__tests__/SparklineCanvas.test.tsx
@@ -47,7 +47,7 @@ function clearCssColorVars(base: string) {
   root.style.removeProperty(`${base}-area-end`);
 }
 
-// Named color constants — avoid bare hex literals while keeping values Happy-DOM can read
+// Named color constants: avoid bare hex literals while keeping values Happy-DOM can read
 const CPU_LINE = 'rgb(255, 0, 0)';
 const CPU_AREA_START = 'rgba(255,0,0,0.3)';
 const CPU_AREA_END = 'rgba(255,0,0,0)';
@@ -245,7 +245,7 @@ describe('SparklineCanvas', () => {
 
     let result: RenderResult;
 
-    // Mount with initial color — canvas setup effect stores gradientCtxRef.current
+    // Mount with initial color: canvas setup effect stores gradientCtxRef.current
     act(() => {
       result = render(<SparklineCanvas data={[]} color="--chart-cpu" />);
     });
@@ -256,7 +256,7 @@ describe('SparklineCanvas', () => {
     const callsAfterMount = (mockCtx.createLinearGradient as Mock<typeof mockCtx.createLinearGradient>).mock.calls.length;
     expect(callsAfterMount).toBeGreaterThan(0);
 
-    // Re-render with a different color — the color/height effect runs again and
+    // Re-render with a different color: the color/height effect runs again and
     // now gradientCtxRef.current is set, so lines 62-65 execute
     act(() => {
       result!.rerender(<SparklineCanvas data={[]} color="--chart-memory" />);

--- a/src/components/shared-table/__tests__/SparklineCell.test.tsx
+++ b/src/components/shared-table/__tests__/SparklineCell.test.tsx
@@ -50,7 +50,7 @@ describe('SparklineCell', () => {
     it('renders PulseLine when data is empty', () => {
       const { container } = render(<SparklineCell data={[]} color="--chart-cpu" />);
 
-      // No canvas rendered — should show PulseLine placeholder
+      // No canvas rendered, should show PulseLine placeholder
       expect(container.querySelector('canvas')).toBeNull();
 
       const outerDiv = container.firstElementChild as HTMLElement;

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -6,7 +6,7 @@ interface ErrorBoundaryProps {
   fallback?: ReactNode | ((reset: () => void) => ReactNode);
   /** Optional label for identifying which boundary caught the error */
   name?: string;
-  /** Called when the boundary resets, use for external state cleanup */
+  /** Called when the boundary resets; use for external state cleanup */
   onReset?: () => void;
 }
 

--- a/src/components/shared/ErrorBoundary.tsx
+++ b/src/components/shared/ErrorBoundary.tsx
@@ -6,7 +6,7 @@ interface ErrorBoundaryProps {
   fallback?: ReactNode | ((reset: () => void) => ReactNode);
   /** Optional label for identifying which boundary caught the error */
   name?: string;
-  /** Called when the boundary resets — use for external state cleanup */
+  /** Called when the boundary resets, use for external state cleanup */
   onReset?: () => void;
 }
 

--- a/src/components/stacks/ComposeEditor.tsx
+++ b/src/components/stacks/ComposeEditor.tsx
@@ -122,7 +122,7 @@ export default function ComposeEditor({ stackName, content, variables: initialVa
         </Button>
       </div>
 
-      {/* Editor + resizable variables panel — use calc() so Monaco gets an explicit width */}
+      {/* Editor + resizable variables panel: use calc() so Monaco gets an explicit width */}
       <div className="relative min-h-[400px]">
         <div
           className="absolute inset-y-0 left-0 overflow-hidden"

--- a/src/components/stacks/VariablesPanel.tsx
+++ b/src/components/stacks/VariablesPanel.tsx
@@ -18,7 +18,7 @@ interface VariablesPanelProps {
 
 /**
  * Side panel showing variables stored in OpenBao for a stack.
- * Source of truth is OpenBao — compose file variables drive initial creation only.
+ * Source of truth is OpenBao; compose file variables drive initial creation only.
  */
 export default function VariablesPanel({ stackName, composeVariables }: Readonly<VariablesPanelProps>) {
   const queryClient = useQueryClient();
@@ -44,7 +44,7 @@ export default function VariablesPanel({ stackName, composeVariables }: Readonly
     ensurePending.current = true;
     ensureVariablesExist({ data: { stackName, variableNames: missing } })
       .then(() => queryClient.invalidateQueries({ queryKey: ['stack-variables', stackName] }))
-      .catch(() => { /* OpenBao unreachable — error already shown by the query */ })
+      .catch(() => { /* OpenBao unreachable, error already shown by the query */ })
       .finally(() => { ensurePending.current = false; });
   }, [variables, composeVariables, stackName, queryClient]);
 

--- a/src/components/stacks/__tests__/ComposeEditor.test.tsx
+++ b/src/components/stacks/__tests__/ComposeEditor.test.tsx
@@ -19,7 +19,7 @@ const saveComposeStub = mockSaveCompose as unknown as typeof saveComposeFile;
  * to provide a simple textarea stand-in. This lets us test the toolbar,
  * save button, VariablesPanel integration, and dirty-state logic.
  *
- * monaco-setup uses Vite ?worker imports that Bun can't resolve — must be
+ * monaco-setup uses Vite ?worker imports that Bun can't resolve, so it must be
  * mocked before ComposeEditor is imported.
  */
 /** Stored onChange callback from the most recent mock editor render */

--- a/src/components/stacks/__tests__/DeployHistoryList.test.tsx
+++ b/src/components/stacks/__tests__/DeployHistoryList.test.tsx
@@ -162,7 +162,7 @@ describe('DeployHistoryList', () => {
       { wrapper: createWrapper() },
     );
 
-    // Click the "Succeeded" toggle button — no records have status 'succeeded', so none match
+    // Click the "Succeeded" toggle button: no records have status 'succeeded', so none match
     const succeededButton = screen.getByRole('button', { name: 'Succeeded' });
     fireEvent.click(succeededButton);
     expect(screen.getByText('No deploys match the selected filters.')).toBeDefined();

--- a/src/components/stacks/__tests__/VariablesPanel.test.tsx
+++ b/src/components/stacks/__tests__/VariablesPanel.test.tsx
@@ -275,7 +275,7 @@ describe('VariablesPanel', () => {
   });
 
   it('silently catches error when ensureVariablesExist rejects', async () => {
-    // OpenBao has DB_URL but compose also references NEW_VAR — triggers ensureVariablesExist
+    // OpenBao has DB_URL but compose also references NEW_VAR, triggers ensureVariablesExist
     mockListSecrets.mockImplementationOnce(() => Promise.resolve(['DB_URL']));
     mockEnsureVariablesExist.mockImplementationOnce(() => Promise.reject(new Error('OpenBao unreachable')));
 
@@ -284,7 +284,7 @@ describe('VariablesPanel', () => {
     await waitFor(() => {
       expect(mockEnsureVariablesExist).toHaveBeenCalledTimes(1);
     });
-    // The catch callback silences the error — no throw, no error UI for this path
+    // The catch callback silences the error: no throw, no error UI for this path
   });
 
   it('save button is disabled when field has not been fetched yet', async () => {
@@ -328,7 +328,7 @@ describe('VariablesPanel', () => {
       expect(screen.getByText('Failed to retrieve value from OpenBao.')).toBeDefined();
     });
 
-    // Hide then reveal again — retry should clear the error
+    // Hide then reveal again, retry should clear the error
     fireEvent.click(screen.getByLabelText('Hide value'));
     fireEvent.click(screen.getByLabelText('Reveal value'));
     await waitFor(() => {

--- a/src/components/zfs/ZFSPoolsTable.tsx
+++ b/src/components/zfs/ZFSPoolsTable.tsx
@@ -41,7 +41,7 @@ const METRIC_GROUPS: MetricGroup[] = [
   { label: 'Throughput', columnIds: ['readBytes', 'writeBytes', 'utilization'] },
 ];
 
-/** Cell renderer for ZFS entity names — extracted to satisfy component-definition rules */
+/** Cell renderer for ZFS entity names, extracted to satisfy component-definition rules */
 function ZFSNameCell({ row }: Readonly<{ row: { original: ZFSTableRow; getIsExpanded: () => boolean } }>) {
   const data = row.original;
   return (
@@ -423,7 +423,7 @@ const VdevDiskSubTable = memo(function VdevDiskSubTable({
 
 /**
  * Leaf-level DataTable for disk rows within an expanded vdev.
- * No expansion — just renders disk rows.
+ * No expansion, just renders disk rows.
  */
 const DiskSubTable = memo(function DiskSubTable({
   disks,

--- a/src/data/hosts/__tests__/handlers.test.ts
+++ b/src/data/hosts/__tests__/handlers.test.ts
@@ -450,7 +450,7 @@ describe('handleAddHost', () => {
     await expect(
       handleAddHost(deps, { name: 'new', socketProxyUrl: 'tcp://x:2375', agentPort: 9090 })
     ).rejects.toThrow(/health check failed/);
-    // deleteToken threw but the error was caught — the rollback error is the one that propagates
+    // deleteToken threw but the error was caught; the rollback error is the one that propagates
     expect(deps.deleteToken).toHaveBeenCalledWith('new');
     expect(deps.repo.delete).toHaveBeenCalledWith(1);
   });

--- a/src/data/hosts/handlers.ts
+++ b/src/data/hosts/handlers.ts
@@ -236,7 +236,7 @@ export async function handleUpdateHost(
 }
 
 /**
- * Register an existing agent that's already running. No container provisioning —
+ * Register an existing agent that's already running. No container provisioning:
  * just creates the DB record, stores the token in OpenBao, and health-checks.
  */
 export async function handleRegisterExistingHost(
@@ -376,7 +376,7 @@ async function rollbackPostProvision(
   const containerCleaned = await tryRemoveAgent(deps.removeAgent, data.socketProxyUrl, hostId, containerContext);
   const suffix = containerCleaned
     ? 'Host record and container have been cleaned up.'
-    : 'Host record deleted but agent container cleanup failed — manual removal may be required.';
+    : 'Host record deleted but agent container cleanup failed; manual removal may be required.';
   throw new Error(`Failed to finalize host after provisioning: ${errorMessage(err)}. ${suffix}`);
 }
 
@@ -389,7 +389,7 @@ async function rollbackHealthCheckFailure(
   await deps.repo.delete(hostId);
   const suffix = containerCleaned
     ? 'Host record, token, and container have been cleaned up.'
-    : 'Host record and token deleted but agent container cleanup failed — manual removal may be required.';
+    : 'Host record and token deleted but agent container cleanup failed; manual removal may be required.';
   throw new Error(`Agent provisioned but health check failed after 3 attempts: ${healthError}. ${suffix}`);
 }
 
@@ -406,7 +406,7 @@ async function finalizeHostRecord(
     await deps.repo.delete(hostId);
     const suffix = containerCleaned
       ? 'Host record, token, and container have been cleaned up.'
-      : 'Host record and token deleted but agent container cleanup failed — manual removal may be required.';
+      : 'Host record and token deleted but agent container cleanup failed; manual removal may be required.';
     console.error(`[addHost] Agent is healthy but failed to finalize host record for ${data.name}:`, errorMessage(err), suffix);
     throw new Error(`Agent is healthy but failed to finalize host record: ${errorMessage(err)}. ${suffix}`);
   }

--- a/src/data/stacks/functions.tsx
+++ b/src/data/stacks/functions.tsx
@@ -70,7 +70,7 @@ export const getDeployHistory = createServerFn()
 /**
  * Save compose file content (creates a git commit).
  * After a successful commit, ensures OpenBao entries exist for all detected variables.
- * Returns warnings if OpenBao is unavailable — the save itself still succeeds.
+ * Returns warnings if OpenBao is unavailable; the save itself still succeeds.
  */
 export const saveComposeFile = createServerFn()
   .inputValidator(saveComposeFileSchema)
@@ -206,7 +206,7 @@ const deleteStackSchema = z.object({
 
 /**
  * Delete a stack from the git repo. If `teardown` is true, queues an async
- * teardown via the deploy pipeline and returns immediately — the pipeline's
+ * teardown via the deploy pipeline and returns immediately; the pipeline's
  * postSuccess hook removes the manifest entry once the agent reports success.
  * If `teardown` is false, removes the stack from the manifest synchronously.
  */

--- a/src/data/stacks/schemas.ts
+++ b/src/data/stacks/schemas.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 import { SAFE_PATH_SEGMENT_PATTERN } from '@/lib/constants/openbao';
 
-/** Allowed stack name pattern — must match SAFE_PATH_SEGMENT_PATTERN used by OpenBao client. No dots, slashes, or path traversal. */
+/** Allowed stack name pattern: must match SAFE_PATH_SEGMENT_PATTERN used by OpenBao client. No dots, slashes, or path traversal. */
 const stackNameField = z.string().min(1).regex(SAFE_PATH_SEGMENT_PATTERN, 'Stack name must contain only letters, numbers, hyphens, and underscores');
 
 export const getStackDetailSchema = z.object({

--- a/src/hooks/__tests__/useEventSource.test.ts
+++ b/src/hooks/__tests__/useEventSource.test.ts
@@ -36,7 +36,7 @@ describe('useEventSource', () => {
         useEventSource({ url: '/api/test', onData: () => {} })
       );
 
-      // Exhaust reconnect attempts — error on the latest instance each time
+      // Exhaust reconnect attempts: error on the latest instance each time
       // since stale instances are correctly ignored after reconnection
       act(() => {
         for (let i = 0; i <= 5; i++) {
@@ -47,7 +47,7 @@ describe('useEventSource', () => {
 
       expect(result.current.error).not.toBeNull();
 
-      // Tab becomes visible — should create a new connection
+      // Tab becomes visible: should create a new connection
       act(() => simulateVisibilityChange('visible'));
 
       expect(MockEventSource.instances.length).toBeGreaterThanOrEqual(2);
@@ -135,7 +135,7 @@ describe('useEventSource', () => {
       });
       expect(result.current.error).not.toBeNull();
 
-      // Switch to a new URL — should reset error and create a fresh connection
+      // Switch to a new URL: should reset error and create a fresh connection
       act(() => { rerender({ url: '/api/second' }); });
 
       expect(result.current.error).toBeNull();

--- a/src/hooks/__tests__/usePulseIndicator.test.ts
+++ b/src/hooks/__tests__/usePulseIndicator.test.ts
@@ -135,7 +135,7 @@ describe('usePulseIndicator', () => {
       // Reset captured timer state from the first trigger
       timerCallbacks.clear();
 
-      // Second render with the SAME timestamp — must be a no-op
+      // Second render with the SAME timestamp: must be a no-op
       act(() => { rerender({ val: ts }); });
 
       expect(timerCallbacks.size).toBe(0);
@@ -279,7 +279,7 @@ describe('usePulseIndicator', () => {
         lateEntry![1].fn();
       });
 
-      // DOM should be unchanged — cancelled flag blocks timer callbacks from writing
+      // DOM should be unchanged: cancelled flag blocks timer callbacks from writing
       expect(ping.style.backgroundColor).toBe(bgAfterStart);
       expect(dot.style.backgroundColor).toBe(bgAfterStart);
       // animate-ping was added by the initial trigger; pulse timer is the one that removes it,

--- a/src/hooks/__tests__/useTimeSeriesStream.test.ts
+++ b/src/hooks/__tests__/useTimeSeriesStream.test.ts
@@ -307,7 +307,7 @@ describe('useTimeSeriesStream SSE flush', () => {
       await act(async () => { await new Promise(r => setTimeout(r, 50)); });
       expect(result.current.error?.message).toBe('DB down');
 
-      // SSE data arrives — should clear the preload error
+      // SSE data arrives: should clear the preload error
       const es = MockEventSource.instances[0];
       const now = Date.now();
       act(() => {
@@ -395,7 +395,7 @@ describe('useTimeSeriesStream periodic refresh', () => {
     // Wait for periodic refresh that fails
     await act(async () => { await new Promise(r => setTimeout(r, 150)); });
 
-    // Error should not propagate — data should still be intact
+    // Error should not propagate; data should still be intact
     expect(result.current.rows.length).toBeGreaterThan(0);
   });
 });
@@ -455,7 +455,7 @@ describe('useTimeSeriesStream stale initialData', () => {
 
     await act(async () => { await new Promise(r => setTimeout(r, 50)); });
 
-    // preloadFn should NOT have been called — initialData was fresh
+    // preloadFn should NOT have been called; initialData was fresh
     expect(preloadFn).toHaveBeenCalledTimes(0);
   });
 });
@@ -482,7 +482,7 @@ describe('useTimeSeriesStream cutoff-only eviction', () => {
     await act(async () => { await new Promise(r => setTimeout(r, 50)); });
     expect(result.current.rows).toHaveLength(2);
 
-    // Send a duplicate row — triggers flush with pending > 0, but newRows is empty after dedup.
+    // Send a duplicate row: triggers flush with pending > 0, but newRows is empty after dedup.
     // This exercises the cutoff-only branch (hasCutoff && !hasNew).
     const es = MockEventSource.instances[0];
     act(() => {
@@ -557,7 +557,7 @@ describe('useTimeSeriesStream latestByEntity stability', () => {
     const firstMap = result.current.latestByEntity;
     expect(firstMap.size).toBe(2);
 
-    // Send a duplicate row (same key as existing) — should be deduped, no latest change
+    // Send a duplicate row (same key as existing): should be deduped, no latest change
     const es = MockEventSource.instances[0];
     act(() => {
       es.onmessage?.({ data: JSON.stringify([{ key: 'a-1', time: now - 10000, entity: 'a' }]) });
@@ -565,7 +565,7 @@ describe('useTimeSeriesStream latestByEntity stability', () => {
 
     await act(async () => { await new Promise(r => setTimeout(r, 100)); });
 
-    // Map reference should be identical — no entity's latest changed
+    // Map reference should be identical: no entity's latest changed
     expect(result.current.latestByEntity).toBe(firstMap);
   });
 });

--- a/src/hooks/settingsAtom.ts
+++ b/src/hooks/settingsAtom.ts
@@ -214,7 +214,7 @@ export const settingsAtom = atom<Settings>((get) => parseSettings(get(rawSetting
 export const proxmoxLastUpdateAtom = atom<number>(0);
 
 /**
- * Shallow set equality — compares two Sets by size and membership.
+ * Shallow set equality: compares two Sets by size and membership.
  * parseSettings creates fresh Set instances on every raw change, so plain
  * identity equality would always re-render domain subscribers. Using a
  * structural comparison lets selectAtom short-circuit when the parsed
@@ -299,7 +299,7 @@ function developerEqual(a: Settings['developer'], b: Settings['developer']): boo
  * Domain-scoped derived atoms. Each selects one slice of `settingsAtom` and
  * re-emits only when that slice differs structurally from the previous value.
  * Components subscribing via useGeneralSettings/useDockerSettings/etc. only
- * re-render when their own domain changes — e.g. toggling a Docker host
+ * re-render when their own domain changes: e.g. toggling a Docker host
  * expansion no longer re-renders ZFS or Proxmox components.
  */
 export const generalSettingsAtom = selectAtom(settingsAtom, (s) => s.general, generalEqual);

--- a/src/hooks/useContainerLogs.ts
+++ b/src/hooks/useContainerLogs.ts
@@ -22,8 +22,8 @@ interface UseContainerLogsResult {
  * Streams container logs from the SSE endpoint and writes them to an xterm.js Terminal.
  *
  * The agent streams logs in two phases:
- * 1. **Backlog** — last 200 lines, written to the terminal immediately
- * 2. **Live** — new lines as they arrive, after a `backlog_done` event
+ * 1. **Backlog**: last 200 lines, written to the terminal immediately
+ * 2. **Live**: new lines as they arrive, after a `backlog_done` event
  *
  * Clears the terminal on reconnection to prevent duplicate backlog lines.
  * Reconnects with exponential backoff (1s, 2s, 4s, 8s, 16s) up to
@@ -99,7 +99,7 @@ export function useContainerLogs({
         }
       };
 
-      // Intentionally empty — both backlog and live phases write to the terminal
+      // Intentionally empty: both backlog and live phases write to the terminal
       // identically, so no state transition is needed. The listener must be registered
       // to prevent the event from hitting the default onmessage handler.
       eventSource.addEventListener('backlog_done', () => {});

--- a/src/hooks/useDockerSettings.ts
+++ b/src/hooks/useDockerSettings.ts
@@ -27,7 +27,7 @@ export interface DockerSettingsValue {
 /**
  * Docker-dashboard settings: memory display, decimals, chart window, and host
  * / container / stack expansion state. Subscribes only to the docker and
- * stacks slices — ZFS/Proxmox/General changes do not re-render consumers.
+ * stacks slices: ZFS/Proxmox/General changes do not re-render consumers.
  */
 export function useDockerSettings(): DockerSettingsValue {
   const docker = useAtomValue(dockerSettingsAtom);

--- a/src/hooks/useEventSource.ts
+++ b/src/hooks/useEventSource.ts
@@ -104,7 +104,7 @@ export function useEventSource<T>({
         if (eventSource !== eventSourceRef.current) return;
         setIsConnected(false);
 
-        // Close current connection — we manage reconnection manually with backoff
+        // Close current connection: we manage reconnection manually with backoff
         eventSource.close();
         eventSourceRef.current = null;
 

--- a/src/hooks/useGeneralSettings.ts
+++ b/src/hooks/useGeneralSettings.ts
@@ -28,7 +28,7 @@ export interface GeneralSettingsValue {
 /**
  * Cross-cutting app settings: theme/time format, data update cadence, unit
  * formatting, retention windows, and developer debug toggles. Subscribes only
- * to the general/retention/developer slices — Docker, ZFS, and Proxmox
+ * to the general/retention/developer slices: Docker, ZFS, and Proxmox
  * changes do not re-render consumers.
  */
 export function useGeneralSettings(): GeneralSettingsValue {

--- a/src/hooks/useTimeSeriesStream.ts
+++ b/src/hooks/useTimeSeriesStream.ts
@@ -110,7 +110,7 @@ export function useTimeSeriesStream<TRow>({
   // Track last refresh time for visibility cooldown
   const lastRefreshRef = useRef(0);
 
-  // Atomic buffer refresh — re-fetches bucketed history and swaps the buffer in one state update.
+  // Atomic buffer refresh: re-fetches bucketed history and swaps the buffer in one state update.
   // Declared before the preload effect so both the preload effect and later effects can reference it.
   // Stored as a ref so effects always invoke the latest closure without recreating intervals.
   const doRefreshRef = useRef<() => Promise<void>>(async () => {});
@@ -213,7 +213,7 @@ export function useTimeSeriesStream<TRow>({
   const pendingRef = useRef<TRow[]>([]);
 
   // Each SSE message queues rows for the next flush; also clears any prior errors (DB recovered).
-  // Uses refs to avoid calling setState when errors are already null — those no-op setState calls
+  // Uses refs to avoid calling setState when errors are already null; those no-op setState calls
   // still enter the reconciler and produce an extra React commit per SSE tick.
   const preloadErrorRef = useRef<Error | null>(null);
   const serviceErrorRef = useRef<Error | null>(null);
@@ -348,7 +348,7 @@ export function useTimeSeriesStream<TRow>({
     return prev;
   }, [sortedRows]);
 
-  // Stale detection via interval — uses lastDataTimeRef (declared above) to
+  // Stale detection via interval: uses lastDataTimeRef (declared above) to
   // avoid tearing down/recreating the interval every time new data arrives.
   const [isStale, setIsStale] = useState(false);
   useEffect(() => {

--- a/src/lib/__tests__/rate-calculator.test.ts
+++ b/src/lib/__tests__/rate-calculator.test.ts
@@ -10,7 +10,7 @@ import {
   computeBlockIoRates,
 } from '../rate-calculator';
 
-// Narrow fixture builders — each returns a partial Dockerode.ContainerStats with only
+// Narrow fixture builders: each returns a partial Dockerode.ContainerStats with only
 // the fields the helper under test actually reads. Casting to ContainerStats keeps the
 // helper signatures simple while letting tests stay focused on what matters.
 

--- a/src/lib/charts/__tests__/y-axis.test.ts
+++ b/src/lib/charts/__tests__/y-axis.test.ts
@@ -154,7 +154,7 @@ describe('calculateCleanYAxis', () => {
     });
 
     it('should use bps-scale for low throughput', () => {
-      // 400 bps — stays in bps range
+      // 400 bps stays in bps range
       const result = calculateCleanYAxis(400, 'bits');
       expect(result.max).toBeGreaterThanOrEqual(400);
       expect(result.interval).toBeLessThan(1000);

--- a/src/lib/clients/__tests__/agent-client.test.ts
+++ b/src/lib/clients/__tests__/agent-client.test.ts
@@ -75,7 +75,7 @@ describe('AgentClient', () => {
     });
 
     it('throws AgentClientError on fetch failure (network error)', async () => {
-      // Network errors retry up to 3 times — reject all attempts so we see the final error.
+      // Network errors retry up to 3 times: reject all attempts so we see the final error.
       fetchMock.mockRejectedValue(new Error('Connection refused'));
 
       await expect(client.deploy({
@@ -140,7 +140,7 @@ describe('AgentClient', () => {
     });
 
     it('throws AgentClientError when agent is unreachable', async () => {
-      // Network errors retry up to 3 times — reject all attempts.
+      // Network errors retry up to 3 times: reject all attempts.
       fetchMock.mockRejectedValue(new Error('ECONNREFUSED'));
 
       await expect(client.health()).rejects.toThrow(AgentClientError);

--- a/src/lib/clients/agent-client.ts
+++ b/src/lib/clients/agent-client.ts
@@ -52,7 +52,7 @@ export interface AgentHealthResponse {
  * All requests include the bearer token and a timeout via AbortSignal.
  * Adapts the raw agent JSON into the internal AgentDeployResponse / AgentHealthResponse shapes.
  *
- * HTTPS is supported natively — use https:// in the agent URL.
+ * HTTPS is supported natively: use https:// in the agent URL.
  * For self-signed certs (e.g., from OpenBao PKI), set NODE_EXTRA_CA_CERTS
  * env var to the CA certificate path.
  *
@@ -186,7 +186,7 @@ export class AgentClient {
     // Never retry our own per-attempt timeout: the in-flight operation (e.g.
     // `docker compose up`) may still be running on the agent.
     if (err.wasTimeout) return false;
-    // Network-layer failures (fetch threw) have no statusCode — retry.
+    // Network-layer failures (fetch threw) have no statusCode, retry.
     if (err.statusCode === undefined) return true;
     // Transient gateway errors are retryable; everything else is not.
     return err.statusCode === 502 || err.statusCode === 503 || err.statusCode === 504;
@@ -221,7 +221,7 @@ export class AgentClient {
     } catch (err) {
       // Distinguish our own per-attempt timeout from a genuine network failure.
       // DOMException('...', 'TimeoutError') is the canonical AbortSignal.timeout()
-      // rejection, but some runtimes surface a plain AbortError — treat both as
+      // rejection, but some runtimes surface a plain AbortError, treat both as
       // "our timeout" to be safe.
       const wasTimeout =
         err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError');

--- a/src/lib/clients/database-client.ts
+++ b/src/lib/clients/database-client.ts
@@ -12,8 +12,8 @@ export interface DatabaseConfig {
   /**
    * Whether to verify the server's TLS certificate when `ssl` is true.
    * Defaults to `true` (secure) when unset. Set to `false` only for
-   * self-signed cert setups where proper CA plumbing isn't yet available —
-   * doing so exposes the connection to MITM attacks.
+   * self-signed cert setups where proper CA plumbing isn't yet available.
+   * Doing so exposes the connection to MITM attacks.
    */
   sslRejectUnauthorized: boolean;
 }

--- a/src/lib/clients/openbao-client-factory.ts
+++ b/src/lib/clients/openbao-client-factory.ts
@@ -14,7 +14,7 @@ let cachedClient: OpenBaoClient | null = null;
 /**
  * Get the shared OpenBaoClient singleton. Throws if OpenBao is not configured
  * (missing OPENBAO_URL or OPENBAO_TOKEN). Runs initializeOpenBao on first use
- * to ensure the KV v2 engine is enabled — subsequent calls reuse the cached
+ * to ensure the KV v2 engine is enabled. Subsequent calls reuse the cached
  * client and the init guard in initializeOpenBao makes repeat calls cheap.
  */
 export async function getOpenBaoClient(): Promise<OpenBaoClient> {

--- a/src/lib/clients/openbao-client.ts
+++ b/src/lib/clients/openbao-client.ts
@@ -3,7 +3,7 @@ import { SAFE_PATH_SEGMENT_PATTERN } from '@/lib/constants/openbao';
 
 /**
  * Thin wrapper around OpenBao HTTP API (KV v2 secrets engine).
- * Uses native fetch() — no SDK dependency.
+ * Uses native fetch(), no SDK dependency.
  *
  * Secret path convention: secret/stacks/<stack-name>/<key>
  */
@@ -51,7 +51,7 @@ export class OpenBaoClient {
 
   /**
    * Parse a JSON response body, wrapping parse failures with OpenBao context.
-   * Proxies or load balancers may return HTML with a 200 status — this ensures
+   * Proxies or load balancers may return HTML with a 200 status: this ensures
    * the error is actionable instead of a raw SyntaxError.
    */
   private async parseJsonResponse(
@@ -83,7 +83,7 @@ export class OpenBaoClient {
       const body = await response.json();
       if (body.errors) detail = `: ${(body.errors as string[]).join(', ')}`;
     } catch {
-      // Response body not JSON — ignore
+      // Response body not JSON, ignore
     }
     throw new Error(
       `OpenBao ${operation} failed for ${context} (HTTP ${response.status})${detail}`,
@@ -312,7 +312,7 @@ export class OpenBaoClient {
    * single-path-per-stack in v2 if needed.
    *
    * Fetches all secrets concurrently. If any fetch fails with a non-404 error,
-   * the entire operation fails — partial secrets are worse than no deploy.
+   * the entire operation fails: partial secrets are worse than no deploy.
    * Individual 404s (race with deletion) are silently skipped.
    */
   async getAllSecrets(stack: string): Promise<Record<string, string>> {
@@ -353,7 +353,7 @@ export class OpenBaoClient {
 
   /**
    * Ensure the KV v2 secrets engine is enabled at the `secret/` path.
-   * Safe to call multiple times — checks existing mounts first.
+   * Safe to call multiple times: checks existing mounts first.
    */
   async ensureSecretsEngine(): Promise<void> {
     const mountsResponse = await this.request(

--- a/src/lib/database/__tests__/subscription-service.test.ts
+++ b/src/lib/database/__tests__/subscription-service.test.ts
@@ -68,7 +68,7 @@ describe('StatsPollService', () => {
   });
 
   afterEach(async () => {
-    // Ensure polling state is fully reset between tests — the service is a
+    // Ensure polling state is fully reset between tests. The service is a
     // module-level singleton, so lingering subscribers would leak across cases.
     await statsPollService.stop();
     getClientSpy?.mockRestore();
@@ -147,7 +147,7 @@ describe('StatsPollService', () => {
 
     const tick = harness.intervals[0].cb;
 
-    // Threshold is 3 consecutive failures — first two ticks stay silent, the
+    // Threshold is 3 consecutive failures: first two ticks stay silent, the
     // third trips the onError callback exactly once.
     await tick();
     expect(errorFired).toBe(0);

--- a/src/lib/database/repositories/__tests__/docker-container-event-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/docker-container-event-repository.test.ts
@@ -91,8 +91,8 @@ describe('DockerContainerEventRepository', () => {
       const result = await repo.insert(destroyEvent);
 
       expect(result.eventType).toBe('destroy');
-      // Destroy variant omits state/composeProject — enforced by the SQL CHECK constraint
-      // and the discriminated union type.
+      // Destroy variant omits state/composeProject (enforced by the SQL CHECK constraint
+      // and the discriminated union type).
       expect(Object.keys(result)).not.toContain('state');
       expect(Object.keys(result)).not.toContain('composeProject');
     });

--- a/src/lib/database/repositories/deploy-repository.ts
+++ b/src/lib/database/repositories/deploy-repository.ts
@@ -178,7 +178,7 @@ export class DeployRepository {
   /**
    * Fails ALL pending/in_progress deploy_history rows unconditionally, overwriting
    * `logs` with `logMessage` (any partial agent output is lost). Safe only for
-   * single-instance/single-worker startup recovery — do not call in multi-process
+   * single-instance/single-worker startup recovery: do not call in multi-process
    * deployments where another instance may own active rows. Returns the recovered rows.
    */
   async recoverStuckDeploys(logMessage: string): Promise<StuckDeployRow[]> {

--- a/src/lib/database/repositories/host-repository.ts
+++ b/src/lib/database/repositories/host-repository.ts
@@ -25,7 +25,7 @@ export interface CreateHostInput {
   capabilities?: HostCapabilities;
 }
 
-// No separate mapping needed — SERIAL (INT4) returns JavaScript numbers
+// No separate mapping needed: SERIAL (INT4) returns JavaScript numbers
 // from node-postgres, unlike BIGINT which returns strings. The query result
 // rows match ManagedHostRow directly.
 

--- a/src/lib/deploy/__tests__/pipeline.test.ts
+++ b/src/lib/deploy/__tests__/pipeline.test.ts
@@ -286,7 +286,7 @@ describe('DeployPipeline', () => {
     });
 
     it('strips outer quotes from existing env values even when followed by CR', async () => {
-      // FOO="bar"\r — windows line ending or stray CR after a quoted value.
+      // FOO="bar"\r (windows line ending or stray CR after a quoted value).
       // The quote check must ignore trailing CR/LF so the outer quotes get stripped,
       // otherwise we'd end up with FOO='"bar"' (double-quoted) in the rendered env.
       // Compose must reference a variable so the pipeline routes through buildEnvContent.
@@ -436,7 +436,7 @@ describe('DeployPipeline', () => {
       });
 
       const result = await pipeline.execute(rollbackRequest);
-      // Change detection is bypassed — deploy should proceed even though hashes match
+      // Change detection is bypassed: deploy should proceed even though hashes match
       expect(result.status).toBe('succeeded');
       expect(deployRepo.getLatestSuccessful).not.toHaveBeenCalled();
     });

--- a/src/lib/deploy/__tests__/stack-repo-writer.test.ts
+++ b/src/lib/deploy/__tests__/stack-repo-writer.test.ts
@@ -94,7 +94,7 @@ describe('createStackRepoWriter', () => {
     ]);
 
     const writer = createStackRepoWriter();
-    // Remove a stack that is not in the manifest — should not throw
+    // Remove a stack that is not in the manifest: should not throw
     const result = await writer.removeStackFromManifest('traefik');
 
     expect(typeof result.commitSha).toBe('string');

--- a/src/lib/deploy/__tests__/startup-recovery.test.ts
+++ b/src/lib/deploy/__tests__/startup-recovery.test.ts
@@ -176,7 +176,7 @@ describe('performStartupRecovery', () => {
       });
       const removeStackFromManifest = mock();
       const manifestReader = {
-        listStackNames: mock().mockResolvedValue(new Set<string>()), // empty — ghost isn't there
+        listStackNames: mock().mockResolvedValue(new Set<string>()), // empty: ghost isn't there
       };
 
       await performStartupRecovery(repo, createWatchdog(), {
@@ -295,7 +295,7 @@ describe('performStartupRecovery', () => {
 
   it('passes the signal option through to retry() so shutdown short-circuits the loop', async () => {
     const controller = new AbortController();
-    controller.abort(); // pre-aborted — retry() will bail after the first attempt's sleep
+    controller.abort(); // pre-aborted: retry() will bail after the first attempt's sleep
     const recoverStuckDeploys = mock().mockRejectedValue(new Error('boom'));
     const repo = createRepo({
       recoverStuckDeploys: recoverStuckDeploys as unknown as StartupRecoveryRepo['recoverStuckDeploys'],

--- a/src/lib/deploy/deploy-watchdog.ts
+++ b/src/lib/deploy/deploy-watchdog.ts
@@ -14,8 +14,8 @@ const DEFAULT_THRESHOLD_MINUTES = 10;
 const FAILURE_ESCALATION_THRESHOLD = 3;
 
 /**
- * Defaults: 2 min interval / 10 min threshold — ~2× the agent's 5-min compose
- * subprocess cap, so deploys still in_progress past this point mean the
+ * Defaults: 2 min interval / 10 min threshold (~2x the agent's 5-min compose
+ * subprocess cap), so deploys still in_progress past this point mean the
  * failure path itself got lost.
  */
 export function loadDeployWatchdogConfig(): DeployWatchdogConfig {
@@ -49,7 +49,7 @@ export class DeployWatchdog {
     this.config = config;
   }
 
-  /** Idempotent — extra calls are no-ops. */
+  /** Idempotent: extra calls are no-ops. */
   start(deployRepo: WatchdogRepo): void {
     if (this.timer !== null) return;
     this.timer = setInterval(() => {
@@ -57,7 +57,7 @@ export class DeployWatchdog {
     }, this.config.intervalMs);
   }
 
-  /** Idempotent — safe to call before start. */
+  /** Idempotent: safe to call before start. */
   stop(): void {
     if (this.timer !== null) {
       clearInterval(this.timer);
@@ -65,21 +65,21 @@ export class DeployWatchdog {
     }
   }
 
-  /** Exposed for observability — number of consecutive tick failures. Resets to 0 on success. */
+  /** Exposed for observability: number of consecutive tick failures. Resets to 0 on success. */
   getConsecutiveFailures(): number {
     return this.consecutiveFailures;
   }
 
-  /** Exposed for observability — total ticks dropped because a prior tick was still running. */
+  /** Exposed for observability: total ticks dropped because a prior tick was still running. */
   getSkippedTicks(): number {
     return this.skippedTicks;
   }
 
-  /** Reentrancy-guarded — if a previous tick is still running, logs and returns. */
+  /** Reentrancy-guarded: if a previous tick is still running, logs and returns. */
   async tick(deployRepo: WatchdogRepo): Promise<void> {
     if (this.running) {
       this.skippedTicks += 1;
-      console.info(`[DeployWatchdog] Skipped tick — already running (skipped=${this.skippedTicks})`);
+      console.info(`[DeployWatchdog] Skipped tick (already running, skipped=${this.skippedTicks})`);
       return;
     }
     this.running = true;
@@ -105,7 +105,7 @@ export class DeployWatchdog {
     } catch (err) {
       this.consecutiveFailures += 1;
       const prefix = this.consecutiveFailures >= FAILURE_ESCALATION_THRESHOLD
-        ? `[DeployWatchdog] Tick failed (${this.consecutiveFailures} consecutive failures — watchdog degraded)`
+        ? `[DeployWatchdog] Tick failed (${this.consecutiveFailures} consecutive failures, watchdog degraded)`
         : '[DeployWatchdog] Tick failed';
       console.error(`${prefix}:`, err);
     } finally {
@@ -115,5 +115,5 @@ export class DeployWatchdog {
 }
 
 function buildTimeoutMessage(minutes: number): string {
-  return `Deploy marked failed by watchdog — no completion signal received after ${minutes} minutes. The deploy may still be running on the host; check the agent before re-triggering.`;
+  return `Deploy marked failed by watchdog: no completion signal received after ${minutes} minutes. The deploy may still be running on the host; check the agent before re-triggering.`;
 }

--- a/src/lib/deploy/pipeline-factory.ts
+++ b/src/lib/deploy/pipeline-factory.ts
@@ -41,7 +41,7 @@ export async function createDeployPipeline(): Promise<DeployPipelineBundle> {
 
   // DeployRepository and ManagedHostsRepository are lightweight pool wrappers.
   // The pool itself is cached by databaseConnectionManager, so per-call allocation
-  // is negligible — no singleton needed here.
+  // is negligible, so no singleton is needed here.
   const deployRepo = new DeployRepository(pool);
 
   const { createStackRepoWriter } = await import('@/lib/deploy/stack-repo-writer');
@@ -56,7 +56,7 @@ export async function createDeployPipeline(): Promise<DeployPipelineBundle> {
       async resolve(stack: string, variables: string[]): Promise<Record<string, string>> {
         if (variables.length === 0) return {};
         if (!baoClient) {
-          console.info(`[deploy] OpenBao not configured — skipping secrets for stack "${stack}": ${variables.join(', ')}`);
+          console.info(`[deploy] OpenBao not configured, skipping secrets for stack "${stack}": ${variables.join(', ')}`);
           return {};
         }
         const entries = await Promise.all(
@@ -73,7 +73,7 @@ export async function createDeployPipeline(): Promise<DeployPipelineBundle> {
       },
     },
     tokenResolver: async (host) => {
-      if (!baoClient) throw new Error('OpenBao not configured — cannot resolve agent token');
+      if (!baoClient) throw new Error('OpenBao not configured, cannot resolve agent token');
       const token = await baoClient.getHostSecret(host.name, 'agent_token');
       if (!token) throw new Error(`No agent token found in OpenBao for host "${host.name}"`);
       return token;

--- a/src/lib/deploy/pipeline.ts
+++ b/src/lib/deploy/pipeline.ts
@@ -127,7 +127,7 @@ export class DeployPipeline {
       }
     }
 
-    // 3. Atomic insert — the partial unique index rejects if an active deploy exists
+    // 3. Atomic insert: the partial unique index rejects if an active deploy exists
     const deployId = await this.deployRepo.insertDeployIfNoActive({
       stack: request.stack,
       host: request.host,
@@ -274,7 +274,7 @@ export class DeployPipeline {
       return { status: 'failed', logs: errorMsg, deployId };
     }
 
-    // Record result outside try — a DB failure here must not be misattributed to the agent
+    // Record result outside try: a DB failure here must not be misattributed to the agent
     const finalStatus: DeployStatus = result.success ? 'succeeded' : 'failed';
     try {
       await this.deployRepo.updateStatus(deployId, finalStatus, result.logs);
@@ -285,7 +285,7 @@ export class DeployPipeline {
       );
     }
 
-    // Post-success hook — runs after status update so a later crash can still
+    // Post-success hook: runs after status update so a later crash can still
     // recover via startup sweep of rows with postSuccess set.
     // `no_change` is treated as success (teardown of a stack with nothing running).
     const treatAsSuccess = finalStatus === 'succeeded';

--- a/src/lib/deploy/startup-recovery.ts
+++ b/src/lib/deploy/startup-recovery.ts
@@ -23,14 +23,14 @@ export interface ManifestReader {
 export interface StartupRecoveryOptions {
   /** Aborts the retry loop during graceful shutdown. */
   signal?: AbortSignal;
-  /** Optional — enables the orphaned manifest-delete sweep. */
+  /** Optional: enables the orphaned manifest-delete sweep. */
   manifestReader?: ManifestReader;
-  /** Optional — writer used by the orphaned sweep to remove manifest entries. */
+  /** Optional: writer used by the orphaned sweep to remove manifest entries. */
   stackRepoWriter?: StackRepoWriter;
 }
 
 export const STARTUP_RECOVERY_MESSAGE =
-  'Deploy interrupted — server restarted while this deploy was in progress. The actual outcome on the host is unknown. Please verify stack status and re-trigger if needed.';
+  'Deploy interrupted: server restarted while this deploy was in progress. The actual outcome on the host is unknown. Please verify stack status and re-trigger if needed.';
 
 const MAX_ATTEMPTS = 3;
 
@@ -69,12 +69,12 @@ export async function performStartupRecovery(
     }
   } catch (err) {
     console.error(
-      `[Server] Startup recovery exhausted after ${MAX_ATTEMPTS} attempts — watchdog will keep retrying:`,
+      `[Server] Startup recovery exhausted after ${MAX_ATTEMPTS} attempts, watchdog will keep retrying:`,
       err,
     );
   }
 
-  // Second pass — orphaned manifest-delete sweep. Runs best-effort; a failure
+  // Second pass: orphaned manifest-delete sweep. Runs best-effort; a failure
   // here must not prevent the watchdog from starting.
   if (options.manifestReader && options.stackRepoWriter) {
     try {
@@ -91,7 +91,7 @@ export async function performStartupRecovery(
  * Finds rows where teardown succeeded with postSuccess='removeFromManifest'
  * but the stack is still in the manifest (process crashed between the
  * agent ACK and the manifest delete). Runs the manifest delete for each.
- * Idempotent — skips stacks that are no longer in the manifest.
+ * Idempotent: skips stacks that are no longer in the manifest.
  */
 async function sweepOrphanedManifestDeletes(
   repo: StartupRecoveryRepo,
@@ -101,7 +101,7 @@ async function sweepOrphanedManifestDeletes(
   const orphaned = await repo.findSucceededPostSuccessDeploys('removeFromManifest');
   if (orphaned.length === 0) return;
 
-  // Deduplicate — a stack may have multiple succeeded teardown rows over time.
+  // Deduplicate: a stack may have multiple succeeded teardown rows over time.
   const seen = new Set<string>();
   const uniqueStacks: PostSuccessDeployRow[] = [];
   for (const row of orphaned) {
@@ -114,13 +114,13 @@ async function sweepOrphanedManifestDeletes(
   try {
     manifestStacks = await manifestReader.listStackNames();
   } catch (err) {
-    console.error('[Server] Failed to read manifest during orphaned-sweep — aborting sweep:', err);
+    console.error('[Server] Failed to read manifest during orphaned-sweep, aborting sweep:', err);
     return;
   }
 
   let removed = 0;
   for (const row of uniqueStacks) {
-    if (!manifestStacks.has(row.stack)) continue; // already gone — skip
+    if (!manifestStacks.has(row.stack)) continue; // already gone, skip
     try {
       await stackRepoWriter.removeStackFromManifest(row.stack);
       removed += 1;

--- a/src/lib/deploy/types.ts
+++ b/src/lib/deploy/types.ts
@@ -12,7 +12,7 @@ export type DeployTrigger = 'git_push' | 'ui' | 'manual_rollback';
 /**
  * Action to run inside the pipeline after a deploy reaches a terminal-success
  * state (`succeeded` or `no_change`). Currently only `removeFromManifest` is
- * supported — used by async teardown to delete the stack entry from the git
+ * supported, used by async teardown to delete the stack entry from the git
  * manifest once the agent reports teardown complete.
  */
 export type DeployPostSuccess = 'removeFromManifest';

--- a/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
+++ b/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
@@ -583,7 +583,7 @@ describe('notifyPayloadToInventory', () => {
   });
 });
 
-describe('DockerInventoryBroadcastService — malformed NOTIFY does not crash', () => {
+describe('DockerInventoryBroadcastService: malformed NOTIFY does not crash', () => {
   it('logs and continues when NOTIFY upsert payload is missing required fields', async () => {
     const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
     const poolClient = createMockPoolClient();
@@ -661,7 +661,7 @@ describe('zDockerInventoryBroadcastEvent', () => {
           finishedAt: null,
           exitCode: null,
           updatedAt: new Date(),
-          // labels intentionally missing — snapshot requires it
+          // labels intentionally missing; snapshot requires it
         },
       ],
     };
@@ -673,7 +673,7 @@ describe('zDockerInventoryBroadcastEvent', () => {
   });
 });
 
-describe('DockerInventoryBroadcastService — connection failure retry', () => {
+describe('DockerInventoryBroadcastService: connection failure retry', () => {
   it('retries after getPoolClient throws, resolving via the setTimeout-based await', async () => {
     const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
 
@@ -714,7 +714,7 @@ describe('DockerInventoryBroadcastService — connection failure retry', () => {
   });
 });
 
-describe('DockerInventoryBroadcastService — zod validation at NOTIFY boundary', () => {
+describe('DockerInventoryBroadcastService: zod validation at NOTIFY boundary', () => {
   it('drops malformed NOTIFY frames before fanning out to subscribers', async () => {
     const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
     const poolClient = createMockPoolClient();
@@ -729,7 +729,7 @@ describe('DockerInventoryBroadcastService — zod validation at NOTIFY boundary'
     const flushLocal = () => new Promise<void>((r) => setTimeout(r, 0));
     await flushLocal();
 
-    // NOTIFY payload with event_type 'upsert' but an invalid state value —
+    // NOTIFY payload with event_type 'upsert' but an invalid state value:
     // notifyPayloadToInventory builds an object, then zod rejects it.
     poolClient.emit('notification', {
       channel: 'docker_container_change',

--- a/src/lib/docker/docker-inventory-broadcast-service.ts
+++ b/src/lib/docker/docker-inventory-broadcast-service.ts
@@ -98,11 +98,11 @@ export interface DockerInventoryBroadcastServiceDeps {
  *
  * Listens on PostgreSQL NOTIFY channel 'docker_container_change'. On subscribe,
  * sends an init snapshot from the DB. On each NOTIFY, forwards the event directly
- * without a round-trip DB read — the NOTIFY payload carries the full event minus labels.
+ * without a round-trip DB read: the NOTIFY payload carries the full event minus labels.
  *
  * Ordering: LISTEN is issued before sendInit is called, so no NOTIFYs are lost
  * while the snapshot loads. However, a NOTIFY that fires during snapshot load
- * can be fanned out to subscribers before the init event — subscribers must be
+ * can be fanned out to subscribers before the init event, so subscribers must be
  * tolerant of receiving an upsert for a container already present in the init.
  *
  * Auto-starts on first subscriber, auto-stops on last unsubscribe.
@@ -180,7 +180,7 @@ export class DockerInventoryBroadcastService {
         currentClient.on('error', (err) => {
           console.error('[DockerInventoryBroadcastService] Listener client error:', err);
           if (this.listenerClient !== currentClient) {
-            // Stale handler for a replaced client — do not touch shared state.
+            // Stale handler for a replaced client: do not touch shared state.
             return;
           }
           this.cleanupListenerClient();
@@ -246,7 +246,7 @@ export class DockerInventoryBroadcastService {
         const at = new Date(parsed.at as string);
         candidate = { type: 'destroy', host, containerId, at };
       } else {
-        // Unknown event_type — drop silently; NOTIFY channel is tightly scoped.
+        // Unknown event_type: drop silently; NOTIFY channel is tightly scoped.
         return;
       }
 

--- a/src/lib/git/__tests__/post-receive-handler-pipeline.test.ts
+++ b/src/lib/git/__tests__/post-receive-handler-pipeline.test.ts
@@ -83,12 +83,12 @@ describe('processPostReceive (pipeline paths)', () => {
     // This prevents the real env var (OPENBAO_URL) from triggering real HTTP requests.
     isConfiguredSpy = spyOn(openbaoConfig, 'isOpenBaoConfigured').mockReturnValue(false);
 
-    // Database connection — return a mock client with an empty pool object
+    // Database connection: return a mock client with an empty pool object
     getClientSpy = spyOn(databaseConnectionManager, 'getClient').mockResolvedValue(
       mockDbClient as never,
     );
 
-    // Spy on repository prototype methods — applies to all instances created by processPostReceive
+    // Spy on repository prototype methods: applies to all instances created by processPostReceive
     insertDeployIfNoActiveSpy = spyOn(
       DeployRepository.prototype,
       'insertDeployIfNoActive',
@@ -114,13 +114,13 @@ describe('processPostReceive (pipeline paths)', () => {
       'getByName',
     ).mockResolvedValue(TEST_HOST as never);
 
-    // Agent deploy — returns success by default
+    // Agent deploy: returns success by default
     agentDeploySpy = spyOn(AgentClient.prototype, 'deploy').mockResolvedValue({
       success: true,
       logs: 'deployed ok',
     } as never);
 
-    // OpenBaoClient.getHostSecret — used by tokenResolver; return a valid token by default
+    // OpenBaoClient.getHostSecret: used by tokenResolver; return a valid token by default
     getHostSecretSpy = spyOn(
       OpenBaoClient.prototype,
       'getHostSecret',
@@ -165,7 +165,7 @@ describe('processPostReceive (pipeline paths)', () => {
       expect.stringContaining('[PostReceive] Failed to read compose file for stack "plex"'),
       expect.anything(),
     );
-    // Pipeline never initialized — getClient should not have been called
+    // Pipeline never initialized: getClient should not have been called
     expect(getClientSpy).not.toHaveBeenCalled();
   });
 
@@ -192,7 +192,7 @@ describe('processPostReceive (pipeline paths)', () => {
 
     await expect(processPostReceive(repoPath, sha1, sha2)).resolves.toBeUndefined();
 
-    // Pipeline was set up — DB was accessed
+    // Pipeline was set up; DB was accessed
     expect(getClientSpy).toHaveBeenCalledTimes(1);
     // Execute was called (pipeline ran)
     expect(insertDeployIfNoActiveSpy).toHaveBeenCalledTimes(1);

--- a/src/lib/git/__tests__/post-receive-handler.test.ts
+++ b/src/lib/git/__tests__/post-receive-handler.test.ts
@@ -101,7 +101,7 @@ describe('processPostReceive', () => {
         { path: 'manifest.yaml', content: 'stacks:\n  plex:\n    host: homeserver\n    autoDeploy: true\n' },
         { path: 'plex/README.md', content: 'v1' },
       ],
-      message: 'initial — has README but no docker-compose.yml',
+      message: 'initial: has README but no docker-compose.yml',
       author: { name: 'test', email: 'test@test.com' },
     }));
 
@@ -112,7 +112,7 @@ describe('processPostReceive', () => {
     }));
 
     await processPostReceive(repoPath, sha1, sha2);
-    // plex changed but has no docker-compose.yml — should be excluded (logged as error)
+    // plex changed but has no docker-compose.yml: should be excluded (logged as error)
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('[PostReceive] Failed to read compose file'),
       expect.anything(),

--- a/src/lib/git/__tests__/repo.test.ts
+++ b/src/lib/git/__tests__/repo.test.ts
@@ -275,7 +275,7 @@ describe('commitFiles callback runs inside lock (issue #98)', () => {
 
   it('concurrent manifest-merging commits for different stacks both end up in manifest', async () => {
     // Simulates createStackInRepo's pattern: read manifest from HEAD, add a new stack,
-    // write updated manifest + a new compose file — all inside the commit callback.
+    // write updated manifest + a new compose file, all inside the commit callback.
     //
     // Before the #98 fix: readers outside the lock both saw manifest = {} and
     // then serialized their pre-built plans, clobbering each other's manifest entries
@@ -307,13 +307,13 @@ describe('commitFiles callback runs inside lock (issue #98)', () => {
     ]);
 
     const manifest = await readFileFromRepo(repoPath, 'manifest.yaml');
-    // Both stacks' entries must be present — neither overwrote the other.
+    // Both stacks' entries must be present; neither overwrote the other.
     expect(manifest).toContain('alpha:');
     expect(manifest).toContain('beta:');
     expect(manifest).toContain('host: host-a');
     expect(manifest).toContain('host: host-b');
 
-    // Both compose files must survive in HEAD — no orphan, no lost entry.
+    // Both compose files must survive in HEAD: no orphan, no lost entry.
     const alphaCompose = await readFileFromRepo(repoPath, 'alpha/docker-compose.yml');
     const betaCompose = await readFileFromRepo(repoPath, 'beta/docker-compose.yml');
     expect(alphaCompose).toContain('alpha compose');

--- a/src/lib/git/git-server.ts
+++ b/src/lib/git/git-server.ts
@@ -12,10 +12,10 @@ import { withRepoLock } from '@/lib/git/repo';
 
 const VALID_SERVICES = ['git-upload-pack', 'git-receive-pack'] as const;
 
-/** 50 MB — git pack files for compose files and manifests should be well under this. */
+/** 50 MB: git pack files for compose files and manifests should be well under this. */
 const MAX_GIT_BODY_SIZE = 50 * 1024 * 1024;
 
-/** 60 seconds — git operations on compose files should complete in milliseconds. */
+/** 60 seconds: git operations on compose files should complete in milliseconds. */
 const GIT_PROCESS_TIMEOUT_MS = 60_000;
 
 /**

--- a/src/lib/git/post-receive-handler.ts
+++ b/src/lib/git/post-receive-handler.ts
@@ -78,13 +78,13 @@ export async function processPostReceive(
   }
 
   // Set up pipeline dependencies and dispatch deploy requests.
-  // Wrap in try/catch so pipeline failures never propagate — the post-receive
+  // Wrap in try/catch so pipeline failures never propagate; the post-receive
   // hook must always complete so the git push is not blocked.
   try {
     const { createDeployPipeline } = await import('@/lib/deploy/pipeline-factory');
     const { pipeline } = await createDeployPipeline();
 
-    // Group deploys by host — sequential within each host, parallel across hosts
+    // Group deploys by host: sequential within each host, parallel across hosts
     const byHost = new Map<string, typeof deployRequests>();
     for (const request of deployRequests) {
       const hostRequests = byHost.get(request.host) ?? [];

--- a/src/lib/git/post-receive.ts
+++ b/src/lib/git/post-receive.ts
@@ -52,7 +52,7 @@ export async function buildDeployRequests(
   for (const stackName of changedStacks) {
     const stackConfig = manifest.stacks[stackName];
     if (!stackConfig) {
-      console.info(`[PostReceive] Stack "${stackName}" changed but not in manifest — skipping`);
+      console.info(`[PostReceive] Stack "${stackName}" changed but not in manifest, skipping`);
       continue;
     }
 

--- a/src/lib/git/repo.ts
+++ b/src/lib/git/repo.ts
@@ -55,7 +55,7 @@ export async function repoExists(repoPath: string): Promise<boolean> {
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     if (message.includes('Could not resolve') || message.includes('resolve ref') || message.includes('Could not find')) {
-      // HEAD doesn't resolve to a commit yet (empty repo) — check for HEAD file
+      // HEAD doesn't resolve to a commit yet (empty repo): check for HEAD file
       return existsSync(`${repoPath}/HEAD`) && existsSync(`${repoPath}/objects`) && existsSync(`${repoPath}/refs`);
     }
     console.error('[Git] Unexpected error checking repo:', message);
@@ -76,7 +76,7 @@ export interface CommitPlan {
   author: { name: string; email: string };
 }
 
-/** Runs inside the repo lock with a HEAD snapshot — guarantees mutations derive from current state, not a stale pre-lock read. */
+/** Runs inside the repo lock with a HEAD snapshot, guaranteeing mutations derive from current state, not a stale pre-lock read. */
 export type CommitCallback = (
   existingFiles: ReadonlyMap<string, string>,
 ) => Promise<CommitPlan> | CommitPlan;
@@ -106,7 +106,7 @@ export async function commitFiles(
     try {
       parentCommit = await git.resolveRef({ fs, gitdir: repoPath, ref: 'HEAD' });
     } catch {
-      // No HEAD yet — first commit, existingFiles stays empty
+      // No HEAD yet (first commit), existingFiles stays empty
     }
 
     if (parentCommit) {

--- a/src/lib/mock/functions/hosts.functions.ts
+++ b/src/lib/mock/functions/hosts.functions.ts
@@ -30,7 +30,7 @@ const mockHosts: readonly HostListItem[] = [
 
 let nextMockId = mockHosts.length + 1;
 
-/** Intentionally stateless — returns a plausible result without mutating mockHosts. Demo mode shows a fixed set of hosts. */
+/** Intentionally stateless: returns a plausible result without mutating mockHosts. Demo mode shows a fixed set of hosts. */
 export async function verifyHost(_data: {
   name: string;
   agentUrl: string;
@@ -51,7 +51,7 @@ export async function verifyHost(_data: {
   return { host: newHost };
 }
 
-/** Intentionally stateless — returns success without mutating mockHosts. */
+/** Intentionally stateless: returns success without mutating mockHosts. */
 export async function removeHost(_data: {
   hostId: number;
 }): Promise<{ success: boolean }> {

--- a/src/lib/mock/mock-event-source.ts
+++ b/src/lib/mock/mock-event-source.ts
@@ -168,7 +168,7 @@ export class MockEventSource {
     const history = generateContainerLogHistory(containerName, new Date());
     this._dispatchEvent('message', new MessageEvent('message', { data: JSON.stringify(history) }));
 
-    // Signal backlog complete — matches the real agent's SSE protocol
+    // Signal backlog complete: matches the real agent's SSE protocol
     this._dispatchEvent('backlog_done', new MessageEvent('backlog_done', { data: '{}' }));
 
     // Emit new log batches every 3 seconds

--- a/src/lib/mock/patterns.ts
+++ b/src/lib/mock/patterns.ts
@@ -194,7 +194,7 @@ export interface ActivityProfile {
   noise: number;
   /**
    * How long the transition between two states lasts (ms).
-   * 0 = instant step (NVMe). 2000–3000 = brief HDD spin-up.
+   * 0 = instant step (NVMe). 2000-3000 = brief HDD spin-up.
    * Must be less than `stateDurationMs`.
    */
   transitionMs: number;

--- a/src/lib/server-functions/openbao-server-functions.ts
+++ b/src/lib/server-functions/openbao-server-functions.ts
@@ -77,7 +77,7 @@ export const listStackSecrets = createServerFn({ method: 'GET' })
 
 /**
  * Get a single secret value (for reveal in UI).
- * Returns the value directly — the frontend should display it briefly and discard.
+ * Returns the value directly: the frontend should display it briefly and discard.
  */
 export const getStackSecret = createServerFn({ method: 'POST' })
   .middleware([openBaoMiddleware])

--- a/src/lib/server-init.ts
+++ b/src/lib/server-init.ts
@@ -27,7 +27,7 @@ async function startDeployRecovery(): Promise<void> {
         const content = await readFileFromRepo(repoPath, 'manifest.yaml');
         return new Set(Object.keys(parseManifest(content).stacks));
       } catch {
-        // No repo, no manifest — nothing to orphan-sweep against.
+        // No repo, no manifest, nothing to orphan-sweep against.
         return new Set();
       }
     },

--- a/src/lib/services/__tests__/agent-provisioning-service.test.ts
+++ b/src/lib/services/__tests__/agent-provisioning-service.test.ts
@@ -157,7 +157,7 @@ describe('AgentProvisioningService', () => {
     it('handles already-stopped container', async () => {
       mockDocker.setContainerExists(true);
       mockDocker.setContainerRunning(false);
-      // stop() will be called but that's fine — Dockerode handles it
+      // stop() will be called but that's fine, Dockerode handles it
       await service.removeAgent(mockDocker.docker, 1);
       expect(mockDocker.removedContainers).toHaveLength(1);
     });

--- a/src/lib/services/__tests__/docker-image-utils.test.ts
+++ b/src/lib/services/__tests__/docker-image-utils.test.ts
@@ -75,7 +75,7 @@ describe('pullImage', () => {
     const docker = {
       pull: async () => stream,
       modem: {
-        // Never call the callback — simulates a stalled pull
+        // Never call the callback (simulates a stalled pull)
         followProgress: () => {},
       },
     } as any;

--- a/src/lib/services/__tests__/openbao-init.test.ts
+++ b/src/lib/services/__tests__/openbao-init.test.ts
@@ -10,7 +10,7 @@ describe('OpenBao initialization', () => {
   test('ensureSecretsEngine is idempotent', async () => {
     const mockFetch = mock();
 
-    // First call: check mounts — engine already exists
+    // First call: check mounts (engine already exists)
     mockFetch.mockResolvedValueOnce(
       new Response(
         JSON.stringify({
@@ -32,7 +32,7 @@ describe('OpenBao initialization', () => {
   test('ensureSecretsEngine enables engine when missing', async () => {
     const mockFetch = mock();
 
-    // First call: check mounts — no secret/ engine
+    // First call: check mounts (no secret/ engine)
     mockFetch.mockResolvedValueOnce(
       new Response(JSON.stringify({ 'sys/': { type: 'system' } }), {
         status: 200,
@@ -55,7 +55,7 @@ describe('OpenBao initialization', () => {
   test('initializeOpenBao calls ensureSecretsEngine once (singleton)', async () => {
     const mockFetch = mock();
 
-    // Only one mount check needed — engine exists
+    // Only one mount check needed (engine exists)
     mockFetch.mockResolvedValue(
       new Response(
         JSON.stringify({

--- a/src/lib/services/agent-health-service.ts
+++ b/src/lib/services/agent-health-service.ts
@@ -35,7 +35,7 @@ export async function verifyAgentToken(
   }
 
   if (response.status === 401) {
-    throw new Error('The provided agent token is invalid — the agent rejected authentication');
+    throw new Error('The provided agent token is invalid: the agent rejected authentication');
   }
 
   if (!response.ok) {
@@ -46,7 +46,7 @@ export async function verifyAgentToken(
 /**
  * Check the health of an agent by calling its /health endpoint.
  * Returns a result object indicating health status and version info.
- * Never throws — all errors are captured in the result.
+ * Never throws: all errors are captured in the result.
  *
  * @param fetchFn - Injectable fetch function for testing (defaults to globalThis.fetch)
  */

--- a/src/lib/services/agent-provisioning-service.ts
+++ b/src/lib/services/agent-provisioning-service.ts
@@ -106,7 +106,7 @@ export class AgentProvisioningService {
       }
       await container.remove();
     } catch (err: unknown) {
-      // 404 means container doesn't exist — that's fine
+      // 404 means container doesn't exist, that's fine
       if (
         err &&
         typeof err === 'object' &&

--- a/src/lib/services/openbao-init.ts
+++ b/src/lib/services/openbao-init.ts
@@ -5,7 +5,7 @@ let initPromise: Promise<void> | null = null;
 /**
  * Initialize OpenBao for first use.
  * Ensures the KV v2 secrets engine is enabled at the `secret/` path.
- * Safe to call multiple times — uses a promise-based singleton to prevent
+ * Safe to call multiple times: uses a promise-based singleton to prevent
  * race conditions when concurrent requests arrive simultaneously.
  * The first call creates the initialization promise; subsequent calls await it.
  */

--- a/src/lib/services/secret-resolver.ts
+++ b/src/lib/services/secret-resolver.ts
@@ -17,7 +17,7 @@ export interface SecretResolver {
 
 /**
  * No-op implementation used when OpenBao is not configured.
- * Returns empty secrets — stacks use whatever .env files already exist on the host.
+ * Returns empty secrets: stacks use whatever .env files already exist on the host.
  */
 export class NoOpSecretResolver implements SecretResolver {
   async resolveSecrets(_stack: string): Promise<Record<string, string>> {

--- a/src/lib/settings/__tests__/settings-broadcast-service.test.ts
+++ b/src/lib/settings/__tests__/settings-broadcast-service.test.ts
@@ -236,7 +236,7 @@ describe('SettingsBroadcastService', () => {
         expect(connectCount).toBeGreaterThanOrEqual(2);
 
         // After the successful reconnect on client2, a second disconnect should
-        // again start from the base 500ms — if the counter weren't reset it
+        // again start from the base 500ms; if the counter weren't reset it
         // would continue from 1000ms.
         capturedDelays.length = 0;
         client2.emit('error', new Error('second disconnect'));

--- a/src/lib/settings/settings-broadcast-service.ts
+++ b/src/lib/settings/settings-broadcast-service.ts
@@ -192,11 +192,11 @@ export class SettingsBroadcastService {
         const ok = await this.startListening();
         if (ok) {
           this.reconnecting = false;
-          // Settings may have changed during the disconnect window — push the
+          // Settings may have changed during the disconnect window; push the
           // current state to all subscribers so their cached view is fresh.
           await this.resyncAllSubscribers();
         } else {
-          // Still reconnecting — retry again after the next backoff step.
+          // Still reconnecting: retry again after the next backoff step.
           // Note: startListening() may have already scheduled a retry via its
           // own catch block; scheduleReconnect() is idempotent thanks to the
           // reconnectTimer guard, so calling it again is safe.
@@ -232,7 +232,7 @@ export class SettingsBroadcastService {
       await client.query('UNLISTEN *');
       client.release();
     } catch {
-      // UNLISTEN failed (connection broken) — release with error flag so the
+      // UNLISTEN failed (connection broken): release with error flag so the
       // pool discards this connection rather than returning it for reuse.
       try { client.release(true); } catch { /* best-effort */ }
     }

--- a/src/lib/sse/create-stats-sse-handler.ts
+++ b/src/lib/sse/create-stats-sse-handler.ts
@@ -2,7 +2,7 @@ import type { StatsSource } from '@/lib/database/subscription-service';
 
 /**
  * Factory for stats SSE route handlers.
- * All three stats endpoints (docker, zfs, proxmox) share identical logic —
+ * All three stats endpoints (docker, zfs, proxmox) share identical logic;
  * only the source string differs.
  */
 export function createStatsSseHandler(source: StatsSource) {

--- a/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
@@ -81,7 +81,7 @@ const composeContainer2: DockerInventorySnapshotContainer = {
   updatedAt: new Date('2026-04-16T10:01:00Z'),
 };
 
-/** A container with no compose project — should always be excluded from stack output. */
+/** A container with no compose project; should always be excluded from stack output. */
 const nonComposeContainer: DockerInventorySnapshotContainer = {
   host: 'server1',
   containerId: 'standalone999',
@@ -574,8 +574,8 @@ describe('StackStatusBroadcastService', () => {
     service.subscribe((e) => received.push(e));
     await flush();
 
-    // Real Docker destroy events carry labels: {} so compose_project is null
-    // — removal must still find the container via its in-memory stack entry.
+    // Real Docker destroy events carry labels: {} so compose_project is null,
+    // so removal must still find the container via its in-memory stack entry.
     poolClient.emit('notification', {
       channel: 'docker_container_change',
       payload: JSON.stringify({
@@ -768,7 +768,7 @@ describe('StackStatusBroadcastService', () => {
 
       await service.stop();
 
-      // Captured timers should be no-ops — stop() cleared them in stopListening.
+      // Captured timers should be no-ops: stop() cleared them in stopListening.
       for (const fn of capturedTimers) {
         fn();
       }

--- a/src/lib/stacks/stack-mappers.ts
+++ b/src/lib/stacks/stack-mappers.ts
@@ -93,7 +93,7 @@ export interface DeployDeps {
   executePipeline: (request: DeployRequest) => Promise<{ deployId?: number; logs?: string }>;
 }
 
-/** Testable deploy handler — takes deps instead of importing them. */
+/** Testable deploy handler: takes deps instead of importing them. */
 export async function handleTriggerDeploy(
   deps: DeployDeps,
   params: { stack: string; host: string; action: 'deploy' | 'teardown' | 'restart'; forceRecreate?: boolean },

--- a/src/lib/stacks/stack-service.ts
+++ b/src/lib/stacks/stack-service.ts
@@ -1,5 +1,5 @@
 /**
- * Stack service — integration layer between git management and deploy pipeline.
+ * Stack service: integration layer between git management and deploy pipeline.
  * Called by server functions in src/data/stacks/functions.tsx.
  */
 
@@ -200,7 +200,7 @@ export async function createStackInRepo(
   const repoPath = getRepoPath();
 
   if (!SAFE_PATH_SEGMENT_PATTERN.test(stackName)) {
-    throw new Error(`Invalid stack name "${stackName}" — must contain only letters, numbers, hyphens, and underscores`);
+    throw new Error(`Invalid stack name "${stackName}": must contain only letters, numbers, hyphens, and underscores`);
   }
 
   // Validate host exists in managed_hosts
@@ -268,7 +268,7 @@ export async function deleteStackFromRepo(
   const deployRepo = new DeployRepository(pool);
   const hasActive = await deployRepo.hasActiveDeployForStack(stackName, host);
   if (hasActive) {
-    throw new Error(`Stack "${stackName}" has an active deploy in progress — cannot delete`);
+    throw new Error(`Stack "${stackName}" has an active deploy in progress, cannot delete`);
   }
 
   return resolveDeleteStack(stackName, host, teardown, {

--- a/src/lib/stacks/stack-status-broadcast-service.ts
+++ b/src/lib/stacks/stack-status-broadcast-service.ts
@@ -43,7 +43,7 @@ function toStackEntry(host: string, stack: string, containers: DockerInventorySn
 
 /**
  * Returns a stable map key for a (host, composeProject) pair.
- * Using '/' separator — same convention as entity IDs throughout the codebase.
+ * Using '/' separator: same convention as entity IDs throughout the codebase.
  */
 function stackKey(host: string, composeProject: string): string {
   return `${host}/${composeProject}`;
@@ -74,7 +74,7 @@ async function defaultLoadSnapshot(): Promise<DockerInventorySnapshotContainer[]
 
 /**
  * Group a flat list of container inventory items into stack entries.
- * Containers with null composeProject are excluded — they belong to no stack.
+ * Containers with null composeProject are excluded (they belong to no stack).
  */
 function inventoryToStackEntries(containers: DockerInventorySnapshotContainer[]): StackStatusEntry[] {
   const byStack = new Map<string, DockerInventorySnapshotContainer[]>();
@@ -98,8 +98,8 @@ function inventoryToStackEntries(containers: DockerInventorySnapshotContainer[])
  *
  * Derives stack state from docker_container_events grouped by compose_project.
  * Listens on two PostgreSQL NOTIFY channels:
- *   - 'docker_container_change' — triggers stack snapshot re-derivation for the affected stack.
- *   - 'deploy_change' — forwards deploy lifecycle events as-is (written directly by the deploy pipeline).
+ *   - 'docker_container_change': triggers stack snapshot re-derivation for the affected stack.
+ *   - 'deploy_change': forwards deploy lifecycle events as-is (written directly by the deploy pipeline).
  *
  * Auto-starts on first subscriber, auto-stops on last unsubscribe.
  */
@@ -223,7 +223,7 @@ export class StackStatusBroadcastService {
         currentClient.on('error', (err) => {
           console.error('[StackStatusBroadcastService] Listener client error:', err);
           if (this.listenerClient !== currentClient) {
-            // Stale handler for a replaced client — do not touch shared state.
+            // Stale handler for a replaced client: do not touch shared state.
             return;
           }
           this.cleanupListenerClient();
@@ -316,7 +316,7 @@ export class StackStatusBroadcastService {
       const containerId = parsed.container_id as string;
       const eventAt = new Date(parsed.at as string).toISOString();
 
-      // Handle destroy BEFORE the null-compose guard — destroy events have labels: {}
+      // Handle destroy BEFORE the null-compose guard: destroy events have labels: {}
       // which produces compose_project: null. We must scan stackContainers to find the entry.
       if (eventType === 'destroy') {
         for (const [sk, byContainer] of this.stackContainers) {
@@ -332,14 +332,14 @@ export class StackStatusBroadcastService {
             return;
           }
         }
-        // Non-compose container destroyed — nothing to broadcast
+        // Non-compose container destroyed: nothing to broadcast
         return;
       }
 
       const composeProject = (parsed.compose_project as string | null) ?? null;
 
       if (composeProject === null) {
-        // Non-compose container upsert — not part of any stack, ignore
+        // Non-compose container upsert: not part of any stack, ignore
         return;
       }
 

--- a/src/lib/utils/backoff.ts
+++ b/src/lib/utils/backoff.ts
@@ -5,7 +5,7 @@ export interface BackoffOpts {
   baseMs?: number;
   /** Hard ceiling on the returned delay in milliseconds (default: 30_000). */
   capMs?: number;
-  /** Maximum exponent applied to 2^attempt before the cap (default: Infinity — cap alone bounds the result). */
+  /** Maximum exponent applied to 2^attempt before the cap (default: Infinity, cap alone bounds the result). */
   maxExponent?: number;
 }
 
@@ -29,7 +29,7 @@ export interface RetryOpts extends BackoffOpts {
   maxAttempts: number;
   /** Return true if the error should trigger another attempt. */
   isRetryable: (err: unknown) => boolean;
-  /** Optional abort signal — aborting rejects the current sleep with AbortError. */
+  /** Optional abort signal: aborting rejects the current sleep with AbortError. */
   signal?: AbortSignal;
   /** Called before each sleep with the attempt number just completed (1-indexed) and the delay about to elapse. */
   onRetry?: (err: unknown, attempt: number, delayMs: number) => void;

--- a/src/lib/utils/docker-hierarchy-builder.ts
+++ b/src/lib/utils/docker-hierarchy-builder.ts
@@ -96,7 +96,7 @@ export function bucketContainerState(
   }
 }
 
-/** Total container count derived from bucket counts — no separate field to drift. */
+/** Total container count derived from bucket counts (no separate field to drift). */
 export function totalContainers(agg: HostAggregatedStats): number {
   return agg.runningCount + agg.stoppedCount + agg.restartingCount + agg.pausedCount + agg.otherCount;
 }
@@ -244,7 +244,7 @@ export function buildDockerTableHierarchy(
     const hostName = inv.host;
     // Use the pre-computed serviceKey stored on inventory (written by the worker from labels at
     // write time). This avoids re-deriving the key from labels which are omitted on streaming
-    // upsert NOTIFY events — falling back to inv.name there would shift the dedup identity.
+    // upsert NOTIFY events, where falling back to inv.name would shift the dedup identity.
     const sk = inv.serviceKey || inv.name;
     const dedupKey = `${hostName}/${sk}`;
 

--- a/src/middleware/__tests__/database-middleware.test.ts
+++ b/src/middleware/__tests__/database-middleware.test.ts
@@ -103,7 +103,7 @@ describe('databaseMiddleware', () => {
       await serverHandler({ next: mock(() => Promise.resolve()) });
       await serverHandler({ next: mock(() => Promise.resolve()) });
 
-      // Same config object passed to getClient on both invocations — proves the
+      // Same config object passed to getClient on both invocations, proving the
       // module-scoped cache, not a re-load per request.
       expect(getClientSpy).toHaveBeenCalledTimes(2);
       expect(getClientSpy.mock.calls[0][0]).toBe(getClientSpy.mock.calls[1][0]);

--- a/src/middleware/database-middleware.ts
+++ b/src/middleware/database-middleware.ts
@@ -4,7 +4,7 @@ import type { DatabaseConfig } from '@/lib/clients/database-client';
 let cachedConfig: DatabaseConfig | null = null;
 
 /**
- * Database middleware — injects a pg Pool into the server function context.
+ * Database middleware: injects a pg Pool into the server function context.
  *
  * All server-only modules (`database-client`, `database-config`) are imported
  * inside the `.server()` callback so they never enter the client bundle. The
@@ -13,7 +13,7 @@ let cachedConfig: DatabaseConfig | null = null;
  *
  * Bootstrap failures (bad env, DB unreachable) are logged with a
  * `[databaseMiddleware]` prefix and re-thrown. The server function's RPC call
- * will reject on the client — callers that previously relied on the handler's
+ * will reject on the client. Callers that previously relied on the handler's
  * `try/catch` returning `[]`/`{}`/`null` on DB outage will now receive an
  * error (intentional: silent empty fallbacks hid outages).
  *

--- a/src/middleware/openbao-middleware.ts
+++ b/src/middleware/openbao-middleware.ts
@@ -5,7 +5,7 @@ import {
 } from '@/lib/clients/openbao-client-factory';
 
 /**
- * OpenBao middleware — injects an OpenBaoClient into the server function context.
+ * OpenBao middleware: injects an OpenBaoClient into the server function context.
  * Delegates to the shared client factory so the cache is unified with any
  * server functions that call getOpenBaoClient() directly.
  */

--- a/src/routes/api/git.$.ts
+++ b/src/routes/api/git.$.ts
@@ -30,7 +30,7 @@ function authenticateRequest(request: Request): Response | null {
   if (authHeader.startsWith('Bearer ')) {
     providedToken = authHeader.slice('Bearer '.length);
   } else if (authHeader.startsWith('Basic ')) {
-    // Git sends Basic auth as base64(username:password) — the token is the password
+    // Git sends Basic auth as base64(username:password); the token is the password
     let decoded: string;
     try {
       decoded = atob(authHeader.slice('Basic '.length));

--- a/src/routes/stacks/$stackName.tsx
+++ b/src/routes/stacks/$stackName.tsx
@@ -96,7 +96,7 @@ function StackEditorView() {
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY })
       if (result.status === 'teardown-pending') {
-        showToast(`Teardown queued for ${stackName} — the stack will be removed when the agent finishes.`, 'success')
+        showToast(`Teardown queued for ${stackName}: the stack will be removed when the agent finishes.`, 'success')
       }
     },
     onError: (err) => {
@@ -105,7 +105,7 @@ function StackEditorView() {
   })
 
   function handleDeleteConfirm(teardown: boolean) {
-    // Fire the mutation without awaiting — for teardown the server returns
+    // Fire the mutation without awaiting; for teardown the server returns
     // immediately with a deployId and the pipeline handles the manifest delete
     // asynchronously. Close the dialog and navigate right away so the user
     // isn't held up waiting for the agent.

--- a/src/types/docker-inventory.ts
+++ b/src/types/docker-inventory.ts
@@ -60,7 +60,7 @@ export const zDockerInventorySnapshotContainer = zInventoryContainerBase.extend(
 export type DockerInventorySnapshotContainer = z.infer<typeof zDockerInventorySnapshotContainer>;
 
 /**
- * Update shape emitted on `type: 'upsert'`. Labels are intentionally absent —
+ * Update shape emitted on `type: 'upsert'`. Labels are intentionally absent:
  * the NOTIFY trigger in migration 018 omits them (8 kB cap on PG NOTIFY).
  * Consumers that need labels must narrow to the snapshot shape and fetch from
  * the init / DB path.

--- a/src/types/docker.ts
+++ b/src/types/docker.ts
@@ -116,7 +116,7 @@ export interface DockerHostTableRow extends DockerTableRowBase {
 export interface DockerContainerTableRow extends DockerTableRowBase {
   type: 'container';
   hostName: string;
-  /** Always present — provides state, name, image, timestamps */
+  /** Always present: provides state, name, image, timestamps */
   inventory: DockerInventorySnapshotContainer;
   /** Present only when live metrics are available */
   stats?: DockerStatsFromDB;

--- a/src/types/stacks.ts
+++ b/src/types/stacks.ts
@@ -42,7 +42,7 @@ export interface StackDeployRecord {
   createdAt: string;
 }
 
-/** Request to trigger a deploy from the UI — reuses canonical DeployAction. */
+/** Request to trigger a deploy from the UI; reuses canonical DeployAction. */
 export interface UIDeployRequest {
   stack: string;
   host: string;

--- a/src/worker/collector-factory.ts
+++ b/src/worker/collector-factory.ts
@@ -107,7 +107,7 @@ export async function createCollectorsForManagedHosts(
 
     const resolvedHost = { ...host, agent_url: resolveAgentUrl(host.agent_url) };
 
-    // Respect per-host capabilities declared in managed_hosts — skip collectors
+    // Respect per-host capabilities declared in managed_hosts: skip collectors
     // for capabilities the host didn't opt into, even if the global worker
     // config enables them. Matches the capability check in
     // createContainerInventoryCollectors below.

--- a/src/worker/collector.ts
+++ b/src/worker/collector.ts
@@ -108,7 +108,7 @@ async function main() {
       // Also start AgentStatsCollectors for managed hosts
       const hostRepo = new HostRepository(db.getPool());
       let getToken: ((hostname: string) => Promise<string | null>) = () => {
-        throw new Error('OpenBao client is not available — initialization failed at startup');
+        throw new Error('OpenBao client is not available: initialization failed at startup');
       };
 
       try {

--- a/src/worker/collectors/__tests__/agent-stats-collector.test.ts
+++ b/src/worker/collectors/__tests__/agent-stats-collector.test.ts
@@ -121,7 +121,7 @@ describe('AgentStatsCollector', () => {
     );
     mockDb.patchRepository(collector);
 
-    // Run collection — the stream closes after one event, so collect() returns
+    // Run collection: the stream closes after one event, so collect() returns
     await (collector as any).collect();
 
     expect(mockDb.insertedRows).toHaveLength(1);
@@ -380,7 +380,7 @@ describe('AgentStatsCollector', () => {
   });
 });
 
-describe('AgentStatsCollector — reconnection', () => {
+describe('AgentStatsCollector: reconnection', () => {
   let mockDb: ReturnType<typeof createMockDb>;
   let abortController: AbortController;
 
@@ -513,9 +513,9 @@ describe('AgentStatsCollector — reconnection', () => {
     const encoder = new TextEncoder();
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
-        // Named "containers" event — should be skipped
+        // Named "containers" event: should be skipped
         controller.enqueue(encoder.encode(`event: containers\ndata: {"ids":["abc123"]}\n\n`));
-        // Named "container-error" event — should be skipped
+        // Named "container-error" event: should be skipped
         controller.enqueue(encoder.encode(`event: container-error\ndata: {"containerId":"abc123","error":"stream died"}\n\n`));
         // Valid stats event (no event: prefix)
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(sampleAgentEvent)}\n\n`));

--- a/src/worker/collectors/__tests__/container-inventory-collector.test.ts
+++ b/src/worker/collectors/__tests__/container-inventory-collector.test.ts
@@ -75,7 +75,7 @@ function createNeverEndingStream(events: unknown[]): ReadableStream<Uint8Array> 
       for (const event of events) {
         controller.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
       }
-      // Never close — collector runs until aborted
+      // Never close; collector runs until aborted
     },
   });
 }
@@ -98,7 +98,7 @@ function spyImmediateTimeout() {
   );
 }
 
-describe('ContainerInventoryCollector — state-change dedup', () => {
+describe('ContainerInventoryCollector: state-change dedup', () => {
   let abortController: AbortController;
   let setTimeoutSpy: ReturnType<typeof spyOn>;
 
@@ -193,7 +193,7 @@ describe('ContainerInventoryCollector — state-change dedup', () => {
   });
 });
 
-describe('ContainerInventoryCollector — flap dampening', () => {
+describe('ContainerInventoryCollector: flap dampening', () => {
   let abortController: AbortController;
 
   beforeEach(() => {
@@ -260,7 +260,7 @@ describe('ContainerInventoryCollector — flap dampening', () => {
     (collector as any).scheduleWrite(makeContainer({ state: 'exited' }), 'upsert');
     expect(timers).toHaveLength(1);
 
-    // B→A (running) — cancels prior timer, schedules new one
+    // B→A (running): cancels prior timer, schedules new one
     (collector as any).scheduleWrite(makeContainer({ state: 'running' }), 'upsert');
     expect(timers).toHaveLength(1);
 
@@ -308,7 +308,7 @@ describe('ContainerInventoryCollector — flap dampening', () => {
   });
 });
 
-describe('ContainerInventoryCollector — init reconciliation', () => {
+describe('ContainerInventoryCollector: init reconciliation', () => {
   let abortController: AbortController;
   let setTimeoutSpy: ReturnType<typeof spyOn>;
 
@@ -402,7 +402,7 @@ describe('ContainerInventoryCollector — init reconciliation', () => {
   });
 });
 
-describe('ContainerInventoryCollector — reconnection and abort', () => {
+describe('ContainerInventoryCollector: reconnection and abort', () => {
   let abortController: AbortController;
 
   beforeEach(() => {
@@ -527,7 +527,7 @@ describe('ContainerInventoryCollector — reconnection and abort', () => {
   });
 });
 
-describe('ContainerInventoryCollector — reconcileInit clears pending writes (Fix 6)', () => {
+describe('ContainerInventoryCollector: reconcileInit clears pending writes (Fix 6)', () => {
   let abortController: AbortController;
 
   beforeEach(() => {
@@ -639,7 +639,7 @@ describe('ContainerInventoryCollector — reconcileInit clears pending writes (F
   });
 });
 
-describe('ContainerInventoryCollector — DB-write failure triggers reconnect', () => {
+describe('ContainerInventoryCollector: DB-write failure triggers reconnect', () => {
   let abortController: AbortController;
 
   beforeEach(() => {
@@ -700,7 +700,7 @@ describe('ContainerInventoryCollector — DB-write failure triggers reconnect', 
     const pending: Map<string, unknown> = (collector as any).pendingWrites;
     expect(pending.size).toBe(0);
 
-    // Failed write must not poison the cache — reconcileInit needs the pre-failure state.
+    // Failed write must not poison the cache; reconcileInit needs the pre-failure state.
     const cache: Map<string, { state: string | null }> = (collector as any).stateCache;
     expect(cache.get('abc123')?.state).toBe('running');
 

--- a/src/worker/collectors/agent-stats-collector.ts
+++ b/src/worker/collectors/agent-stats-collector.ts
@@ -25,7 +25,7 @@ interface AgentStatsEvent {
 type FetchFn = (url: string, init?: RequestInit) => Promise<Response>;
 
 /** Extract the JSON payload from an SSE message, returning null if invalid.
- *  Skips named events (e.g. "event: containers") — only default events carry stats data. */
+ *  Skips named events (e.g. "event: containers"): only default events carry stats data. */
 function extractDataLine(message: string): string | null {
   if (!message.trim()) return null;
   const lines = message.split('\n');

--- a/src/worker/collectors/container-inventory-collector.ts
+++ b/src/worker/collectors/container-inventory-collector.ts
@@ -42,7 +42,7 @@ export class ContainerInventoryCollector extends BaseCollector {
   override readonly signal: AbortSignal;
   /**
    * Per-cycle controller for the in-flight SSE fetch. Distinct from BaseCollector's
-   * lifecycle `signal` so a DB-write failure can abort just the current cycle —
+   * lifecycle `signal` so a DB-write failure can abort just the current cycle.
    * run()'s catch path then drives reconnect via the base backoff.
    */
   private collectAbort: AbortController | null = null;
@@ -58,7 +58,7 @@ export class ContainerInventoryCollector extends BaseCollector {
   private readonly stateCache = new Map<string, CachedContainerState>();
   /**
    * Pending write timers keyed by containerId. Each value is the latest container
-   * snapshot. Accepts either event shape — `InventorySnapshotContainer` (from init)
+   * snapshot. Accepts either event shape: `InventorySnapshotContainer` (from init)
    * carries labels; `InventoryUpdateContainer` (from upsert) does not.
    */
   private readonly pendingWrites = new Map<string, { container: InventorySnapshotContainer | InventoryUpdateContainer | null; eventType: 'upsert' | 'destroy'; timer: ReturnType<typeof setTimeout> }>();
@@ -188,7 +188,7 @@ export class ContainerInventoryCollector extends BaseCollector {
    * fails from a flap-window timer so reconcileInit can re-sync state from the agent.
    */
   private triggerReconnect(reason: string): void {
-    // Drop pending flap-window timers — reconcileInit will reassess state from the
+    // Drop pending flap-window timers; reconcileInit will reassess state from the
     // post-reconnect snapshot, so racing more stale writes is pointless.
     for (const { timer } of this.pendingWrites.values()) {
       clearTimeout(timer);
@@ -200,10 +200,10 @@ export class ContainerInventoryCollector extends BaseCollector {
 
   private async handleEvent(event: AgentContainerEvent): Promise<void> {
     if (event.op === 'init') {
-      // Narrowed to InventorySnapshotContainer[] — labels are authoritative here.
+      // Narrowed to InventorySnapshotContainer[]; labels are authoritative here.
       await this.reconcileInit(event.containers);
     } else if (event.op === 'upsert') {
-      // Narrowed to InventoryUpdateContainer — labels intentionally absent; the
+      // Narrowed to InventoryUpdateContainer; labels intentionally absent. The
       // writer fills an empty map. reconcileInit() re-supplies labels on reconnect.
       this.scheduleWrite(event.container, 'upsert');
     } else if (event.op === 'destroy') {
@@ -217,7 +217,7 @@ export class ContainerInventoryCollector extends BaseCollector {
    * that disappeared while offline.
    */
   private async reconcileInit(containers: InventorySnapshotContainer[]): Promise<void> {
-    // Cancel pending flap-window timers — they captured stale pre-reconnect state.
+    // Cancel pending flap-window timers; they captured stale pre-reconnect state.
     for (const { timer } of this.pendingWrites.values()) {
       clearTimeout(timer);
     }
@@ -292,7 +292,7 @@ export class ContainerInventoryCollector extends BaseCollector {
     eventType: 'upsert',
   ): Promise<void> {
     // Snapshot containers carry labels; update containers (streaming upserts) do not.
-    // When labels are absent, serviceKey falls back to container name — the next
+    // When labels are absent, serviceKey falls back to container name; the next
     // reconcileInit will re-derive the full key from the snapshot labels.
     const labels = 'labels' in container ? container.labels : {};
     const serviceKey = computeServiceKey(labels, container.name);

--- a/src/worker/dev-seed.ts
+++ b/src/worker/dev-seed.ts
@@ -20,7 +20,7 @@ function getDevHostName(): string {
 /**
  * Auto-seed a managed host for local development.
  * Uses the first Docker config host name so entity IDs align.
- * Gated by DEV_AGENT_TOKEN env var — never runs in production.
+ * Gated by DEV_AGENT_TOKEN env var: never runs in production.
  * Idempotent: skips if any managed hosts already exist.
  */
 export async function seedDevAgent(db: DatabaseClient): Promise<void> {
@@ -31,7 +31,7 @@ export async function seedDevAgent(db: DatabaseClient): Promise<void> {
   const hostRepo = new HostRepository(db.getPool());
   const existingHosts = await hostRepo.findAll();
   if (existingHosts.length > 0) {
-    // Host exists — ensure token is stored and agent URL is up to date
+    // Host exists; ensure token is stored and agent URL is up to date
     await ensureTokenStored(devHostName, devToken);
     const devHost = existingHosts.find((h) => h.name === devHostName);
     if (devHost && devHost.agent_url !== DEV_AGENT_URL) {
@@ -52,7 +52,7 @@ export async function seedDevAgent(db: DatabaseClient): Promise<void> {
   // Store dev token in OpenBao (retries until OpenBao is ready)
   await ensureTokenStored(devHostName, devToken);
 
-  // Health check with retries — agent may still be starting
+  // Health check with retries; agent may still be starting
   for (let attempt = 1; attempt <= HEALTH_CHECK_ATTEMPTS; attempt++) {
     try {
       const response = await fetch(`${DEV_HEALTH_CHECK_URL}/health`);
@@ -71,7 +71,7 @@ export async function seedDevAgent(db: DatabaseClient): Promise<void> {
     }
   }
 
-  console.info(`[DevSeed] Agent health check failed after ${HEALTH_CHECK_ATTEMPTS} attempts — host remains in "pending" status. Agent may start later.`);
+  console.info(`[DevSeed] Agent health check failed after ${HEALTH_CHECK_ATTEMPTS} attempts; host remains in "pending" status. Agent may start later.`);
 }
 
 /**
@@ -96,7 +96,7 @@ async function ensureTokenStored(hostname: string, token: string): Promise<void>
       return;
     }
   } catch {
-    // OpenBao not ready or secret doesn't exist — proceed to store
+    // OpenBao not ready or secret doesn't exist; proceed to store
   }
 
   for (let attempt = 1; attempt <= OPENBAO_RETRY_ATTEMPTS; attempt++) {

--- a/src/worker/dev-seed.ts
+++ b/src/worker/dev-seed.ts
@@ -31,7 +31,7 @@ export async function seedDevAgent(db: DatabaseClient): Promise<void> {
   const hostRepo = new HostRepository(db.getPool());
   const existingHosts = await hostRepo.findAll();
   if (existingHosts.length > 0) {
-    // Host exists; ensure token is stored and agent URL is up to date
+    // A managed host was found; ensure dev host token is stored and agent URL is up to date
     await ensureTokenStored(devHostName, devToken);
     const devHost = existingHosts.find((h) => h.name === devHostName);
     if (devHost && devHost.agent_url !== DEV_AGENT_URL) {


### PR DESCRIPTION
## Summary
- replace em and en dashes across comments, docs, tests, and user-facing strings to match the no-claudisms rule
- clean up follow-up wording and punctuation nits from the dash-removal pass

## Verification
- `bun run typecheck` ✅
- `bun test` ❌
  - `src/components/stacks/__tests__/stacks-context.test.ts`: `useStackListContext returns default empty values outside a provider`
  - `src/lib/git/__tests__/git-server.test.ts`: `handleUploadPack > should return 200 with correct Content-Type on success`

These test failures were present while preparing the PR; this branch does not touch those areas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated punctuation and formatting consistency throughout codebase documentation and comments (em-dashes replaced with colons, semicolons, or other appropriate punctuation for clarity).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->