### PR TITLE
feat(demo): seed pending deploy row so approval UX renders

### DIFF
--- a/src/lib/mock/functions/stacks.functions.tsx
+++ b/src/lib/mock/functions/stacks.functions.tsx
@@ -221,6 +221,19 @@ volumes:
 
 const MOCK_DEPLOY_HISTORY: StackDeployRecord[] = [
   {
+    id: 4,
+    stack: 'plex',
+    host: 'nas01',
+    commitSha: 'b2c3d4e',
+    envHash: 'jkl012',
+    status: 'pending',
+    trigger: 'git_push',
+    action: 'deploy',
+    forceRecreate: false,
+    logs: null,
+    createdAt: new Date(Date.now() - 3_600_000 / 2).toISOString(),
+  },
+  {
     id: 3,
     stack: 'plex',
     host: 'homeserver',
@@ -293,6 +306,18 @@ export async function triggerDeploy(_opts: {
   // Simulate a short delay
   await new Promise((resolve) => setTimeout(resolve, 500));
   return { deployId: MOCK_DEPLOY_HISTORY.length + 1 };
+}
+
+export async function resumeDeploy(opts: {
+  data: { deployId: number };
+}): Promise<{ deployId: number }> {
+  return { deployId: opts.data.deployId };
+}
+
+export async function rejectDeploy(opts: {
+  data: { deployId: number };
+}): Promise<{ deployId: number }> {
+  return { deployId: opts.data.deployId };
 }
 
 export async function getDeployHistory(opts: {


### PR DESCRIPTION
## Summary

Two-part change that also unblocks the `Deploy Demo to GitHub Pages` CI job.

- Adds `resumeDeploy` and `rejectDeploy` no-op exports to `src/lib/mock/functions/stacks.functions.tsx` so the demo build's module alias resolves (same root fix as #142).
- Seeds one `pending` `StackDeployRecord` at the top of `MOCK_DEPLOY_HISTORY` (id=4, stack=`plex`, host=`nas01`, createdAt 30 min ago) so demo visitors actually see the "Pending approval" chip with Approve/Reject buttons that 3b4286a added.

## Why this PR vs #142

#142 is the minimum fix to get CI green and can merge immediately. This PR also fixes CI but goes further by making the new approval UX demoable.

**Overlap:** both PRs add the same two export lines. Whichever merges second needs a trivial rebase (delete the duplicate exports).

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run build:demo` completes (5034 modules, no resolution errors)
- [x] `bun test` 2314/2315 pass. The one failing test is `stacks-context > useStackListContext returns default empty values outside a provider`, a known pre-existing flake from global mock pollution (documented in #131's description as a baseline failure; passes in isolation).
- [ ] Manual: visit the demo `/stacks/plex`, see the pending row render with Approve + Reject buttons, click both and confirm the handlers resolve (they are no-ops in demo mode, so the row state will not change on click).

🤖 Generated with [Claude Code](https://claude.com/claude-code)