### PR TITLE
chore(codex): add AGENTS entrypoint and repo skills

### DIFF
--- a/.codex/scripts/install-repo-skills.sh
+++ b/.codex/scripts/install-repo-skills.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+repo_skills_dir="$repo_root/.codex/skills"
+codex_home="${CODEX_HOME:-$HOME/.codex}"
+target_dir="$codex_home/skills"
+
+mkdir -p "$target_dir"
+
+for skill_path in "$repo_skills_dir"/*; do
+  [ -d "$skill_path" ] || continue
+
+  skill_name="$(basename "$skill_path")"
+  target_path="$target_dir/$skill_name"
+
+  if [ -L "$target_path" ]; then
+    rm "$target_path"
+  elif [ -e "$target_path" ]; then
+    echo "Skipping $skill_name: $target_path already exists and is not a symlink" >&2
+    continue
+  fi
+
+  ln -s "$skill_path" "$target_path"
+  echo "Linked $skill_name -> $target_path"
+done

--- a/.codex/scripts/install-repo-skills.sh
+++ b/.codex/scripts/install-repo-skills.sh
@@ -16,6 +16,11 @@ for skill_path in "$repo_skills_dir"/*; do
   target_path="$target_dir/$skill_name"
 
   if [ -L "$target_path" ]; then
+    existing_target="$(readlink "$target_path")"
+    if [ "$existing_target" != "$skill_path" ]; then
+      echo "Skipping $skill_name: $target_path already points to $existing_target" >&2
+      continue
+    fi
     rm "$target_path"
   elif [ -e "$target_path" ]; then
     echo "Skipping $skill_name: $target_path already exists and is not a symlink" >&2

--- a/.codex/skills/create-migration/SKILL.md
+++ b/.codex/skills/create-migration/SKILL.md
@@ -10,7 +10,7 @@ Use this when the user wants a new SQL migration in `migrations/`.
 Before editing:
 
 1. Read `CLAUDE.md` for project constraints and migration guidance.
-2. Inspect existing files in `migrations/` to determine the next zero-padded number.
+2. Inspect existing files in `migrations/` to verify numeric prefixes are unique, then determine the next zero-padded number. If duplicates exist, report the ordering conflict before creating a new migration.
 3. Read nearby migrations that touch the same table or domain so the new file matches local patterns.
 
 ## Required conventions
@@ -31,7 +31,7 @@ For new stats tables, the migration should normally include:
 3. `ALTER TABLE ... SET (timescaledb.compress, ...)`
 4. `SELECT add_compression_policy(..., if_not_exists => TRUE);`
 
-Segment compression by the columns used for typical host/entity filters, and order by `time DESC`.
+Segment compression by the columns used for typical host/entity filters, and order by the hypertable's actual time column descending (for example, `time DESC` or `at DESC`).
 
 ## Delivery
 

--- a/.codex/skills/create-migration/SKILL.md
+++ b/.codex/skills/create-migration/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: create-migration
+description: Create a new numbered SQL migration for this repo's TimescaleDB schema when the user asks for a migration or schema change; follow the repo's migration naming, hypertable, compression, and idempotency conventions.
+---
+
+# Create Migration
+
+Use this when the user wants a new SQL migration in `migrations/`.
+
+Before editing:
+
+1. Read `CLAUDE.md` for project constraints and migration guidance.
+2. Inspect existing files in `migrations/` to determine the next zero-padded number.
+3. Read nearby migrations that touch the same table or domain so the new file matches local patterns.
+
+## Required conventions
+
+- Name files `NNN_description_in_snake_case.sql`.
+- Use `IF NOT EXISTS` or `if_not_exists => TRUE` for idempotency.
+- Use `TIMESTAMPTZ` for time columns.
+- For new time-series tables, add hypertable creation, compression settings, and a 7-day compression policy.
+- Keep non-time-series tables simple; do not add hypertable/compression boilerplate unless the table stores time-series data.
+- If a new `BIGINT` column will be read through `pg`, add a short SQL comment when downstream code will need `Number(...)` coercion.
+
+## Hypertable checklist
+
+For new stats tables, the migration should normally include:
+
+1. `CREATE TABLE IF NOT EXISTS ...`
+2. `SELECT create_hypertable(..., if_not_exists => TRUE);`
+3. `ALTER TABLE ... SET (timescaledb.compress, ...)`
+4. `SELECT add_compression_policy(..., if_not_exists => TRUE);`
+
+Segment compression by the columns used for typical host/entity filters, and order by `time DESC`.
+
+## Delivery
+
+- Create the migration file rather than just drafting SQL in chat.
+- Report the created filename.
+- If the change implies code or docs updates outside `migrations/`, call that out explicitly.

--- a/.codex/skills/gen-test/SKILL.md
+++ b/.codex/skills/gen-test/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: gen-test
+description: Generate or extend tests for this repo when the user asks for test coverage on a source file, hook, component, or server module; follow the repo's bun:test, co-located __tests__, and anti-global-mock conventions.
+---
+
+# Generate Tests
+
+Use this when the user wants tests added or expanded.
+
+Before editing:
+
+1. Read `CLAUDE.md` for testing rules and coverage constraints.
+2. Read the source file and any existing co-located test file in `__tests__/`.
+3. Prefer extending an existing test file over creating a new pattern for the same module.
+
+## Required conventions
+
+- Use `bun:test`, not Jest or Vitest.
+- Put tests in a co-located `__tests__/` directory.
+- Use `@/` imports for source modules; only use relative imports for helpers inside the same test area.
+- Prefer dependency injection, `renderHook`, `spyOn`, and narrow mocks.
+- Do not use `mock.module()` on React, broad shared modules, or `functions.tsx` barrels.
+- Cover exported behavior, edge cases, and error paths.
+- Remember PostgreSQL `BIGINT` values arrive as strings.
+
+## Verification
+
+After editing, run the narrowest useful test command first, then broader verification if needed:
+
+1. `bun test <test-file>`
+2. `bun test --coverage <test-file>` when the task is focused on coverage for that module
+3. Repo-level verification required by `CLAUDE.md` after code changes
+
+If you cannot run the commands, say so clearly and explain why.

--- a/.codex/skills/gen-test/SKILL.md
+++ b/.codex/skills/gen-test/SKILL.md
@@ -17,9 +17,10 @@ Before editing:
 
 - Use `bun:test`, not Jest or Vitest.
 - Put tests in a co-located `__tests__/` directory.
-- Use `@/` imports for source modules; only use relative imports for helpers inside the same test area.
+- Use `@/` imports for shared `src` modules. Tests co-located in `__tests__/` may import the module under test with a relative path; helpers inside the same test area may also use relative imports.
 - Prefer dependency injection, `renderHook`, `spyOn`, and narrow mocks.
 - Do not use `mock.module()` on React, broad shared modules, or `functions.tsx` barrels.
+- When mocking a service module, provide every exported member (use stubs or pass-throughs for exports the current test does not exercise) so concurrent tests do not see `undefined` exports.
 - Cover exported behavior, edge cases, and error paths.
 - Remember PostgreSQL `BIGINT` values arrive as strings.
 

--- a/.codex/skills/review-docs-and-compose/SKILL.md
+++ b/.codex/skills/review-docs-and-compose/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: review-docs-and-compose
+description: Audit this repo's documentation and Docker Compose files when the user asks for a docs audit, release-readiness check, or stale compose validation; verify docs against the codebase and verify compose files against docs, env vars, and Dockerfiles.
+---
+
+# Review Docs And Compose
+
+Use this when documentation or compose files may be stale.
+
+Start by reading `CLAUDE.md`, then inspect only the files relevant to the request.
+
+## Primary targets
+
+- `README.md`
+- `self-hosting/README.md`
+- `docs/architecture.md`
+- `docs/development.md`
+- `docs/tech-stack.md`
+- `docs/project-structure.md`
+- `docs/git-stacks-repo.md`
+- `CLAUDE.md`
+- `docker-compose.yml`
+- `docker-compose.dev.yml`
+- `docker-compose.local.yml`
+- `docker-compose.agent.yml`
+- `self-hosting/docker-compose.yml`
+- `package.json`
+- `.env.example`
+- `Dockerfile`
+- `agent/Dockerfile`
+
+## Workflow
+
+1. Fact-check concrete claims in docs against the codebase.
+2. Identify gaps: undocumented services, env vars, commands, routes, tables, or operational behavior.
+3. Validate compose files against `.env.example`, Dockerfiles, package scripts, and the docs.
+4. Fix the highest-confidence issues directly when the user asked for remediation; otherwise report findings only.
+
+## What to verify
+
+- file paths, component names, and route names actually exist
+- package scripts and commands match `package.json`
+- documented env vars exist and match compose usage
+- compose build targets exist in the Dockerfiles
+- service names, ports, volumes, health checks, and network settings are internally consistent
+- docs accurately describe local-dev vs self-hosting behavior
+
+## Delegation
+
+If the user explicitly asks for sub-agents or parallel review, split the work into independent read-only audits. Otherwise do the review yourself in a single pass.
+
+## Output
+
+For review-only requests, present findings first with file references and severity. If no issues are found, say that explicitly and mention any remaining validation gaps.

--- a/.codex/skills/security-review/SKILL.md
+++ b/.codex/skills/security-review/SKILL.md
@@ -1,0 +1,47 @@
+---
+name: security-review
+description: Review this homelab-management codebase for security issues when the user asks for a security review, sensitive-code audit, or credential-handling check; focus on secrets exposure, SQL injection, unsafe Docker or SSH usage, server-only import leaks, and missing validation.
+---
+
+# Security Review
+
+Use this when the user asks for a security-oriented code review.
+
+Start with `CLAUDE.md`, then inspect the requested files or the relevant recent diff.
+
+## Focus areas
+
+1. Credential and secret exposure
+2. SQL injection
+3. SSH and Docker socket safety
+4. Server-side auth, abort handling, and server-only import leaks
+5. Input validation and path safety
+6. Timing and information leaks
+
+## Repo-specific checks
+
+- Only `VITE_*` env vars should be client-visible.
+- `createServerFn()` paths should use the expected middleware and validation.
+- SSE endpoints should respect `request.signal` and avoid leaking server-only imports into the client bundle.
+- Dynamic imports are required for server-only modules such as `pg`, `dockerode`, `ssh2`, subscription services, and database clients in the sensitive paths called out by `CLAUDE.md`.
+- Docker or entity operations should use validated host-prefixed IDs, not display names.
+
+## Search patterns
+
+Use targeted searches such as:
+
+- SQL construction in `client.query(...)`
+- console logging around `password`, `token`, `secret`, or `key`
+- static imports of `pg`, `dockerode`, or `ssh2` in route or mixed client/server code
+- user input flowing into commands, file paths, or privileged agent operations
+
+## Output
+
+Report findings with:
+
+- severity
+- file and line
+- risk
+- concrete remediation
+
+If no issues are found, say so explicitly rather than inventing findings.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Project Guidelines for Codex
+
+This repo's shared operating rules live in [CLAUDE.md](CLAUDE.md). Treat that file as the canonical source for:
+
+- workflow and verification requirements
+- commands and local-dev routines
+- architecture and data-flow notes
+- project conventions, gotchas, and testing rules
+
+Codex-specific notes:
+
+- Repo-local Codex skills live under `.codex/skills/`.
+- Those skills are versioned with the repo, but Codex only auto-discovers installed skills from `~/.codex/skills` (or `$CODEX_HOME/skills`).
+- To install the repo-local skills as symlinks, run `.codex/scripts/install-repo-skills.sh`.
+- `.claude/settings*.json`, `.claude/commands`, and `.claude/agents/` are Claude-specific references, not executable Codex config.
+
+When `AGENTS.md` and `CLAUDE.md` overlap, keep the shared project rules in `CLAUDE.md` and keep this file as the Codex entry point.


### PR DESCRIPTION
## Summary
- add `AGENTS.md` as the Codex entry point for this repo
- add repo-local Codex skills under `.codex/skills/`
- add `.codex/scripts/install-repo-skills.sh` to link those skills into `$CODEX_HOME/skills`

## Verification
- `bun run typecheck`
- `bun test`

## Notes
- `bun run typecheck` passed
- `bun test` hit existing failures outside this PR:
  - `src/components/stacks/__tests__/CreateStackDialog.test.tsx`: `calls onSubmit with correct data when submitted` timed out
  - `src/components/stacks/__tests__/stacks-context.test.ts`: `useStackListContext returns default empty values outside a provider`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated skill installation script enabling seamless integration of repository-specific workflows into the skills directory.

* **Documentation**
  * Introduced four comprehensive skill documentation files for database migrations, test generation, documentation review, and security audits with step-by-step procedures and verification checklists.
  * Added Codex agent documentation entry point with setup and configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->