### PR TITLE
feat(stacks): detect and resolve drift between repo and agent (#95)

### DIFF
--- a/agent/src/__tests__/stacks.test.ts
+++ b/agent/src/__tests__/stacks.test.ts
@@ -4,6 +4,8 @@ import {
   handleStackTeardown,
   handleStackRestart,
   handleStackStatus,
+  handleStackInventory,
+  handleGetStackCompose,
   parseContainerNames,
 } from '../routes/stacks';
 import { mkdirSync, rmSync, existsSync, readFileSync } from 'fs';
@@ -914,6 +916,126 @@ describe('handleStackStatus', () => {
     // If concurrent, both spawns start nearly simultaneously and total time ≈ 50ms
     // If sequential, total time ≈ 100ms
     expect(elapsed).toBeLessThan(90);
+  });
+});
+
+describe('handleStackInventory', () => {
+  test('returns compose hashes for valid stack directories', async () => {
+    mkdirSync(join(TEST_STACKS_DIR, 'plex'), { recursive: true });
+    mkdirSync(join(TEST_STACKS_DIR, 'grafana'), { recursive: true });
+    await Bun.write(join(TEST_STACKS_DIR, 'plex', 'docker-compose.yml'), 'services:\n  plex:\n    image: plexinc/pms-docker');
+    await Bun.write(join(TEST_STACKS_DIR, 'grafana', 'docker-compose.yml'), 'services:\n  grafana:\n    image: grafana/grafana');
+
+    const response = await handleStackInventory(TEST_STACKS_DIR);
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.stacks).toHaveLength(2);
+    expect(result.stacks).toEqual([
+      expect.objectContaining({
+        name: 'grafana',
+        hasComposeFile: true,
+        composeHash: expect.any(String),
+      }),
+      expect.objectContaining({
+        name: 'plex',
+        hasComposeFile: true,
+        composeHash: expect.any(String),
+      }),
+    ]);
+    expect(result.stacks[0].composeHash).not.toBe(result.stacks[1].composeHash);
+  });
+
+  test('skips invalid stack directories and directories without compose files', async () => {
+    mkdirSync(join(TEST_STACKS_DIR, '.hidden'), { recursive: true });
+    mkdirSync(join(TEST_STACKS_DIR, 'missing-compose'), { recursive: true });
+    mkdirSync(join(TEST_STACKS_DIR, 'valid-stack'), { recursive: true });
+    await Bun.write(join(TEST_STACKS_DIR, 'valid-stack', 'docker-compose.yml'), 'services: {}');
+
+    const response = await handleStackInventory(TEST_STACKS_DIR);
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.stacks).toHaveLength(1);
+    expect(result.stacks[0]).toEqual(
+      expect.objectContaining({
+        name: 'valid-stack',
+        hasComposeFile: true,
+      }),
+    );
+  });
+});
+
+describe('handleGetStackCompose', () => {
+  test('returns compose content and hash for an existing stack', async () => {
+    mkdirSync(join(TEST_STACKS_DIR, 'plex'), { recursive: true });
+    const composeContent = 'services:\n  plex:\n    image: plexinc/pms-docker';
+    await Bun.write(join(TEST_STACKS_DIR, 'plex', 'docker-compose.yml'), composeContent);
+
+    const request = new Request('http://localhost/stacks/compose?stack=plex');
+    const response = await handleGetStackCompose(request, TEST_STACKS_DIR);
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result).toEqual({
+      stack: 'plex',
+      composeContent,
+      composeHash: expect.any(String),
+    });
+  });
+
+  test('returns 404 when the stack compose file does not exist', async () => {
+    const request = new Request('http://localhost/stacks/compose?stack=missing');
+    const response = await handleGetStackCompose(request, TEST_STACKS_DIR);
+    const result = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(result.error).toContain("Stack 'missing' not found");
+  });
+
+  test('returns 400 for an invalid stack name', async () => {
+    const request = new Request('http://localhost/stacks/compose?stack=../etc');
+    const response = await handleGetStackCompose(request, TEST_STACKS_DIR);
+    expect(response.status).toBe(400);
+  });
+
+  test('returns 400 when the stack query parameter is missing', async () => {
+    const request = new Request('http://localhost/stacks/compose');
+    const response = await handleGetStackCompose(request, TEST_STACKS_DIR);
+    expect(response.status).toBe(400);
+  });
+});
+
+describe('handleStackInventory: resilience', () => {
+  test('returns an empty list when the stacks directory is empty', async () => {
+    const response = await handleStackInventory(TEST_STACKS_DIR);
+    const result = await response.json();
+    expect(response.status).toBe(200);
+    expect(result.stacks).toEqual([]);
+  });
+
+  test('skips stack directories whose docker-compose.yml cannot be read without aborting the inventory', async () => {
+    mkdirSync(join(TEST_STACKS_DIR, 'good'), { recursive: true });
+    await Bun.write(join(TEST_STACKS_DIR, 'good', 'docker-compose.yml'), 'services: {}');
+    // Stack directory where docker-compose.yml is actually a subdirectory, so readFileSync throws EISDIR.
+    mkdirSync(join(TEST_STACKS_DIR, 'bad', 'docker-compose.yml'), { recursive: true });
+
+    const response = await handleStackInventory(TEST_STACKS_DIR);
+    const result = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(result.stacks).toHaveLength(1);
+    expect(result.stacks[0].name).toBe('good');
+  });
+
+  test('returns 500 when the stacks directory cannot be read', async () => {
+    const filePath = join(TEST_STACKS_DIR, 'not-a-dir');
+    await Bun.write(filePath, 'file');
+
+    const response = await handleStackInventory(filePath);
+    const result = await response.json();
+    expect(response.status).toBe(500);
+    expect(result.error).toContain('Failed to read stacks directory');
   });
 });
 

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -3,7 +3,14 @@ import { authenticateRequest } from './middleware';
 import { handleHealth } from './routes/health';
 import { handleStatsStream } from './routes/stats';
 import { handleLogStream } from './routes/logs';
-import { handleStackDeploy, handleStackTeardown, handleStackRestart, handleStackStatus } from './routes/stacks';
+import {
+  handleStackDeploy,
+  handleStackTeardown,
+  handleStackRestart,
+  handleStackStatus,
+  handleStackInventory,
+  handleGetStackCompose,
+} from './routes/stacks';
 import { handleContainerEvents } from './routes/containers-events';
 import { handleZfsStatsStream, handleZfsPools } from './routes/zfs';
 import { detectZfsCapabilities } from './lib/zfs-capabilities';
@@ -99,6 +106,8 @@ function matchRoute(request: Request, url: URL): Promise<Response> | Response | 
     if (url.pathname === '/stacks/teardown' && request.method === 'POST') return handleStackTeardown(request, STACKS_DIR);
     if (url.pathname === '/stacks/restart' && request.method === 'POST') return handleStackRestart(request, STACKS_DIR);
     if (url.pathname === '/stacks/status' && request.method === 'GET') return handleStackStatus(STACKS_DIR);
+    if (url.pathname === '/stacks/inventory' && request.method === 'GET') return handleStackInventory(STACKS_DIR);
+    if (url.pathname === '/stacks/compose' && request.method === 'GET') return handleGetStackCompose(request, STACKS_DIR);
   }
 
   if (url.pathname === '/zfs/stats/stream' && request.method === 'GET') return handleZfsStatsStream(request, zfsCapabilities);

--- a/agent/src/routes/stacks.ts
+++ b/agent/src/routes/stacks.ts
@@ -1,5 +1,7 @@
-import { mkdirSync, existsSync, readdirSync, unlinkSync } from 'node:fs';
+import { Dirent, mkdirSync, existsSync, readdirSync, readFileSync, unlinkSync } from 'node:fs';
+import { createHash } from 'node:crypto';
 import { join } from 'node:path';
+import type { AgentStackComposeResponse, AgentStackInventoryEntry, AgentStackInventoryResponse } from '../types';
 
 const VALID_STACK_NAME = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/;
 const MAX_COMPOSE_SIZE_BYTES = 1_048_576; // 1 MB
@@ -31,6 +33,14 @@ function validateStackName(name: string): Response | null {
     );
   }
   return null;
+}
+
+function computeComposeHash(composeContent: string): string {
+  return createHash('sha256').update(composeContent).digest('hex');
+}
+
+function getComposePath(stacksDir: string, stackName: string): string {
+  return join(stacksDir, stackName, 'docker-compose.yml');
 }
 
 type SpawnFn = typeof Bun.spawn;
@@ -501,4 +511,70 @@ export async function handleStackStatus(
   const hasErrors = stacks.some(s => 'error' in s);
 
   return Response.json({ stacks, ...(hasErrors ? { hasErrors: true } : {}) });
+}
+
+export async function handleStackInventory(stacksDir: string): Promise<Response> {
+  if (!existsSync(stacksDir)) {
+    return Response.json({ stacks: [] } satisfies AgentStackInventoryResponse);
+  }
+
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(stacksDir, { withFileTypes: true });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Failed to read stacks directory '${stacksDir}':`, err);
+    return Response.json({ error: `Failed to read stacks directory: ${msg}` }, { status: 500 });
+  }
+
+  const stacks = entries
+    .filter((entry) => entry.isDirectory() && VALID_STACK_NAME.test(entry.name))
+    .map((entry): AgentStackInventoryEntry | null => {
+      const composePath = getComposePath(stacksDir, entry.name);
+      if (!existsSync(composePath)) return null;
+      // Skip entries we cannot read (EACCES, EIO, TOCTOU delete) rather than
+      // aborting the whole inventory. Hiding one bad directory is safer than
+      // making the scanner conclude the host has zero stacks.
+      let composeContent: string;
+      try {
+        composeContent = readFileSync(composePath, 'utf-8');
+      } catch (err) {
+        console.error(`Failed to read compose file for stack '${entry.name}':`, err);
+        return null;
+      }
+      return {
+        name: entry.name,
+        hasComposeFile: true,
+        composeHash: computeComposeHash(composeContent),
+      };
+    })
+    .filter((stack): stack is AgentStackInventoryEntry => stack !== null)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  return Response.json({ stacks } satisfies AgentStackInventoryResponse);
+}
+
+export async function handleGetStackCompose(request: Request, stacksDir: string): Promise<Response> {
+  const stack = new URL(request.url).searchParams.get('stack') ?? '';
+  const nameError = validateStackName(stack);
+  if (nameError) return nameError;
+
+  const composePath = getComposePath(stacksDir, stack);
+  if (!existsSync(composePath)) {
+    return Response.json({ error: `Stack '${stack}' not found` }, { status: 404 });
+  }
+
+  let composeContent: string;
+  try {
+    composeContent = readFileSync(composePath, 'utf-8');
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`Failed to read compose file for stack '${stack}':`, err);
+    return Response.json({ error: `Failed to read compose file: ${msg}` }, { status: 500 });
+  }
+  return Response.json({
+    stack,
+    composeContent,
+    composeHash: computeComposeHash(composeContent),
+  } satisfies AgentStackComposeResponse);
 }

--- a/agent/src/types.ts
+++ b/agent/src/types.ts
@@ -11,6 +11,25 @@ export interface AgentStackResponse {
   exitCode?: number;
 }
 
+/** One stack directory discovered on the agent filesystem. */
+export interface AgentStackInventoryEntry {
+  name: string;
+  hasComposeFile: true;
+  composeHash: string;
+}
+
+/** Successful /stacks/inventory response. */
+export interface AgentStackInventoryResponse {
+  stacks: AgentStackInventoryEntry[];
+}
+
+/** Successful /stacks/compose response. */
+export interface AgentStackComposeResponse {
+  stack: string;
+  composeContent: string;
+  composeHash: string;
+}
+
 /** Successful /health response (HTTP 200). */
 export interface AgentHealthyResponse {
   status: 'healthy';

--- a/src/components/stacks/StackDriftSummary.tsx
+++ b/src/components/stacks/StackDriftSummary.tsx
@@ -1,0 +1,88 @@
+import { Alert, Button, CircularProgress, Typography } from '@mui/material';
+import { RefreshCw } from 'lucide-react';
+import type { StackDriftItem, StackDriftReport, StackDriftResolution } from '@/types/stacks';
+import {
+  getAllowedStackDriftResolutions,
+  getStackDriftKindLabel,
+  getStackDriftResolutionLabel,
+} from '@/lib/stacks/stack-drift-service';
+
+interface StackDriftSummaryProps {
+  report: StackDriftReport | null | undefined;
+  isLoading: boolean;
+  isResolving: boolean;
+  onRefresh: () => void;
+  onResolve: (item: StackDriftItem, resolution: StackDriftResolution) => void;
+}
+
+export default function StackDriftSummary({
+  report,
+  isLoading,
+  isResolving,
+  onRefresh,
+  onResolve,
+}: StackDriftSummaryProps) {
+  if (!isLoading && (!report || (report.summary.total === 0 && report.scanErrors.length === 0))) {
+    return null;
+  }
+
+  const disableActions = isResolving || isLoading;
+
+  return (
+    <Alert
+      severity={report?.summary.total ? 'warning' : 'info'}
+      className="mb-4"
+      action={(
+        <Button
+          color="inherit"
+          size="small"
+          onClick={onRefresh}
+          startIcon={isLoading ? <CircularProgress size={14} color="inherit" /> : <RefreshCw size={14} />}
+        >
+          Refresh
+        </Button>
+      )}
+    >
+      <div className="flex flex-col gap-3">
+        <div>
+          <Typography variant="subtitle2">Stack Drift</Typography>
+          {report ? (
+            <Typography variant="body2">
+              {report.summary.ghost} ghost, {report.summary.untracked} untracked, {report.summary.content} content
+            </Typography>
+          ) : (
+            <Typography variant="body2">Checking agent stack state...</Typography>
+          )}
+        </div>
+
+        {report?.scanErrors.map((error) => (
+          <Typography key={error.host} variant="body2">
+            {error.host}: {error.message}
+          </Typography>
+        ))}
+
+        {report?.items.map((item) => (
+          <div key={`${item.host}/${item.stack}`} className="flex flex-wrap items-center gap-2">
+            <Typography variant="body2" className="font-medium">
+              {item.host}/{item.stack}
+            </Typography>
+            <Typography variant="caption" className="opacity-70">
+              {getStackDriftKindLabel(item.kind)}
+            </Typography>
+            {getAllowedStackDriftResolutions(item.kind).map((resolution) => (
+              <Button
+                key={resolution}
+                size="small"
+                variant="outlined"
+                disabled={disableActions}
+                onClick={() => onResolve(item, resolution)}
+              >
+                {getStackDriftResolutionLabel(resolution)}
+              </Button>
+            ))}
+          </div>
+        ))}
+      </div>
+    </Alert>
+  );
+}

--- a/src/components/stacks/StackDriftWarning.tsx
+++ b/src/components/stacks/StackDriftWarning.tsx
@@ -1,0 +1,38 @@
+import { Alert, Button, Typography } from '@mui/material';
+import type { StackDriftItem, StackDriftResolution } from '@/types/stacks';
+import {
+  getAllowedStackDriftResolutions,
+  getStackDriftKindLabel,
+  getStackDriftResolutionLabel,
+} from '@/lib/stacks/stack-drift-service';
+
+interface StackDriftWarningProps {
+  item: StackDriftItem | null;
+  isResolving: boolean;
+  onResolve: (item: StackDriftItem, resolution: StackDriftResolution) => void;
+}
+
+export default function StackDriftWarning({ item, isResolving, onResolve }: StackDriftWarningProps) {
+  if (!item) return null;
+
+  return (
+    <Alert severity="warning">
+      <div className="flex flex-col gap-2">
+        <Typography variant="subtitle2">This stack has {getStackDriftKindLabel(item.kind)} drift.</Typography>
+        <div className="flex flex-wrap gap-2">
+          {getAllowedStackDriftResolutions(item.kind).map((resolution) => (
+            <Button
+              key={resolution}
+              size="small"
+              variant="outlined"
+              disabled={isResolving}
+              onClick={() => onResolve(item, resolution)}
+            >
+              {getStackDriftResolutionLabel(resolution)}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </Alert>
+  );
+}

--- a/src/components/stacks/StackNav.tsx
+++ b/src/components/stacks/StackNav.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from '@tanstack/react-router';
 import { IconButton, Typography } from '@mui/material';
-import { Plus, Server } from 'lucide-react';
+import { AlertTriangle, Plus, Server } from 'lucide-react';
 import { useStackListContext, useStackStatusContext } from '@/components/stacks/stacks-context';
 import { getIconUrl } from '@/lib/utils/icon-resolver';
+import type { StackDriftItem } from '@/types/stacks';
 
 type NavItem =
   | { type: 'host'; host: string }
@@ -14,9 +15,10 @@ const STACK_ROW_HEIGHT = 32;
 
 interface StackNavProps {
   onCreateClick: () => void;
+  driftByKey?: Map<string, StackDriftItem>;
 }
 
-export default function StackNav({ onCreateClick }: StackNavProps) {
+export default function StackNav({ onCreateClick, driftByKey = new Map() }: StackNavProps) {
   const { stacks } = useStackListContext();
   const { statusMap } = useStackStatusContext();
   const listRef = useRef<HTMLDivElement>(null);
@@ -92,6 +94,7 @@ export default function StackNav({ onCreateClick }: StackNavProps) {
                   name={item.name}
                   icon={item.icon}
                   containerCount={item.containerCount}
+                  driftItem={driftByKey.get(`${item.host}/${item.name}`) ?? null}
                 />
               )}
             </div>
@@ -116,7 +119,17 @@ function HostNavItem({ host }: { host: string }) {
   );
 }
 
-function StackNavItem({ name, icon, containerCount }: { name: string; icon: string | null; containerCount: number }) {
+function StackNavItem({
+  name,
+  icon,
+  containerCount,
+  driftItem,
+}: {
+  name: string;
+  icon: string | null;
+  containerCount: number;
+  driftItem: StackDriftItem | null;
+}) {
   const iconUrl = icon ? getIconUrl(icon, '') : null;
 
   return (
@@ -134,6 +147,13 @@ function StackNavItem({ name, icon, containerCount }: { name: string; icon: stri
         </span>
       )}
       <span className="truncate flex-1">{name}</span>
+      {driftItem ? (
+        <AlertTriangle
+          size={12}
+          className="text-[var(--mui-palette-warning-main)]"
+          aria-label={`Drift detected for ${name}`}
+        />
+      ) : null}
       {containerCount > 0 && (
         <span className="text-[10px] opacity-50">{containerCount}</span>
       )}

--- a/src/components/stacks/__tests__/StackDriftSummary.test.tsx
+++ b/src/components/stacks/__tests__/StackDriftSummary.test.tsx
@@ -1,0 +1,150 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import StackDriftSummary from '../StackDriftSummary';
+import type { StackDriftReport } from '@/types/stacks';
+
+const report: StackDriftReport = {
+  items: [
+    {
+      host: 'alpha',
+      stack: 'plex',
+      kind: 'ghost',
+      repoComposeHash: 'repo-hash',
+      latestDeployStatus: 'succeeded',
+    },
+    {
+      host: 'alpha',
+      stack: 'grafana',
+      kind: 'untracked',
+      agentComposeHash: 'agent-hash',
+      latestDeployStatus: null,
+    },
+  ],
+  summary: {
+    total: 2,
+    ghost: 1,
+    untracked: 1,
+    content: 0,
+  },
+  scanErrors: [],
+};
+
+describe('StackDriftSummary', () => {
+  it('renders summary counts by drift kind', () => {
+    render(
+      <StackDriftSummary
+        report={report}
+        isLoading={false}
+        isResolving={false}
+        onRefresh={() => {}}
+        onResolve={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/1 ghost, 1 untracked, 0 content/i)).toBeDefined();
+  });
+
+  it('hides invalid actions for untracked items', () => {
+    render(
+      <StackDriftSummary
+        report={report}
+        isLoading={false}
+        isResolving={false}
+        onRefresh={() => {}}
+        onResolve={() => {}}
+      />,
+    );
+
+    const trustRepoButtons = screen.queryAllByRole('button', { name: 'Trust Repo' });
+    expect(trustRepoButtons).toHaveLength(1);
+  });
+
+  it('calls onResolve with the selected item and resolution', () => {
+    const onResolve = mock(() => {});
+    render(
+      <StackDriftSummary
+        report={report}
+        isLoading={false}
+        isResolving={false}
+        onRefresh={() => {}}
+        onResolve={onResolve}
+      />,
+    );
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Trust Agent' })[0]);
+    expect(onResolve).toHaveBeenCalledWith(report.items[0], 'trust_agent');
+  });
+
+  it('renders nothing when there is no drift and no scan errors', () => {
+    const { container } = render(
+      <StackDriftSummary
+        report={{ items: [], summary: { total: 0, ghost: 0, untracked: 0, content: 0 }, scanErrors: [] }}
+        isLoading={false}
+        isResolving={false}
+        onRefresh={() => {}}
+        onResolve={() => {}}
+      />,
+    );
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders the loading alert when the first scan is in flight', () => {
+    render(
+      <StackDriftSummary
+        report={null}
+        isLoading
+        isResolving={false}
+        onRefresh={() => {}}
+        onResolve={() => {}}
+      />,
+    );
+    expect(screen.getByText(/Checking agent stack state/i)).toBeDefined();
+  });
+
+  it('renders scan errors with host and message', () => {
+    render(
+      <StackDriftSummary
+        report={{
+          items: [],
+          summary: { total: 0, ghost: 0, untracked: 0, content: 0 },
+          scanErrors: [{ host: 'alpha', message: 'agent unreachable' }],
+        }}
+        isLoading={false}
+        isResolving={false}
+        onRefresh={() => {}}
+        onResolve={() => {}}
+      />,
+    );
+    expect(screen.getByText(/alpha: agent unreachable/i)).toBeDefined();
+  });
+
+  it('disables resolve buttons while a scan is in flight', () => {
+    render(
+      <StackDriftSummary
+        report={report}
+        isLoading
+        isResolving={false}
+        onRefresh={() => {}}
+        onResolve={() => {}}
+      />,
+    );
+    for (const btn of screen.getAllByRole('button', { name: 'Trust Agent' })) {
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    }
+  });
+
+  it('disables resolve buttons while a resolution is in flight', () => {
+    render(
+      <StackDriftSummary
+        report={report}
+        isLoading={false}
+        isResolving
+        onRefresh={() => {}}
+        onResolve={() => {}}
+      />,
+    );
+    for (const btn of screen.getAllByRole('button', { name: 'Trust Agent' })) {
+      expect((btn as HTMLButtonElement).disabled).toBe(true);
+    }
+  });
+});

--- a/src/components/stacks/__tests__/StackDriftWarning.test.tsx
+++ b/src/components/stacks/__tests__/StackDriftWarning.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, mock } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import StackDriftWarning from '../StackDriftWarning';
+import type { StackDriftItem } from '@/types/stacks';
+
+const item: StackDriftItem = {
+  host: 'alpha',
+  stack: 'plex',
+  kind: 'content',
+  repoComposeHash: 'repo-hash',
+  agentComposeHash: 'agent-hash',
+  latestDeployStatus: 'failed',
+};
+
+describe('StackDriftWarning', () => {
+  it('renders nothing when no drift item is provided', () => {
+    const { container } = render(
+      <StackDriftWarning item={null} isResolving={false} onResolve={() => {}} />,
+    );
+    expect(container.textContent).toBe('');
+  });
+
+  it('renders a warning with the drift kind', () => {
+    render(<StackDriftWarning item={item} isResolving={false} onResolve={() => {}} />);
+    expect(screen.getByText(/content drift/i)).toBeDefined();
+  });
+
+  it('calls onResolve for allowed actions', () => {
+    const onResolve = mock(() => {});
+    render(<StackDriftWarning item={item} isResolving={false} onResolve={onResolve} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Trust Repo' }));
+    expect(onResolve).toHaveBeenCalledWith(item, 'trust_repo');
+  });
+});

--- a/src/components/stacks/__tests__/StackNav.test.tsx
+++ b/src/components/stacks/__tests__/StackNav.test.tsx
@@ -1,21 +1,27 @@
 import { describe, it, expect, mock, beforeAll } from 'bun:test';
 import { render, screen, fireEvent } from '@testing-library/react';
-import type { ComponentType } from 'react';
+import type { ComponentType, ReactNode } from 'react';
+import type { StackDriftItem } from '@/types/stacks';
+import {
+  StackListContext,
+  StackStatusContext,
+  type StackListContextValue,
+  type StackStatusContextValue,
+} from '@/components/stacks/stacks-context';
 
-// Provide mocks for the split contexts
-const mockStacks = [
+const mockStacks: StackListContextValue['stacks'] = [
   { name: 'app-web', host: 'server-1', syncStatus: 'in_sync', deployMode: 'auto', lastDeployAt: null, lastDeployStatus: null, containerCount: 2, icon: 'nginx' },
   { name: 'app-db', host: 'server-1', syncStatus: 'pending', deployMode: 'manual', lastDeployAt: null, lastDeployStatus: null, containerCount: 1, icon: null },
   { name: 'monitoring', host: 'server-2', syncStatus: 'in_sync', deployMode: 'auto', lastDeployAt: null, lastDeployStatus: null, containerCount: 3, icon: 'grafana' },
 ];
 
-const mockListContextValue = {
+const listValue: StackListContextValue = {
   stacks: mockStacks,
   hosts: ['server-1', 'server-2'],
   isLoading: false,
 };
 
-const mockStatusContextValue = {
+const statusValue: StackStatusContextValue = {
   statusMap: new Map(),
   deployVersion: 0,
 };
@@ -29,83 +35,96 @@ mock.module('@/lib/utils/icon-resolver', () => ({
   getIconUrl: (slug: string) => slug ? `https://icons.test/${slug}.png` : null,
 }));
 
-const realContextModule = await import('@/components/stacks/stacks-context');
-
-mock.module('@/components/stacks/stacks-context', () => ({
-  ...realContextModule,
-  useStackListContext: () => mockListContextValue,
-  useStackStatusContext: () => mockStatusContextValue,
-}));
-
 mock.module('@tanstack/react-router', () => ({
-  Link: ({ children, to, params, className, activeProps, ...rest }: any) => (
+  Link: ({ children, to, params, className, activeProps: _activeProps, ...rest }: { children?: ReactNode; to: string; params?: Record<string, unknown>; className?: string; activeProps?: unknown; [k: string]: unknown }) => (
     <a href={to} data-params={JSON.stringify(params)} className={className} {...rest}>
       {children}
     </a>
   ),
-  // Additional exports that leak into concurrent test files via the shared module
-  // registry. `@tanstack/react-start`'s createServerFn imports both at runtime, so
-  // unrelated tests that transitively load a server function crash with a cryptic
-  // "Export not found" error unless we provide no-op stubs here.
+  // `@tanstack/react-start`'s createServerFn imports these at runtime in
+  // concurrent test files. Provide no-op stubs so unrelated tests don't
+  // crash with a cryptic "Export not found" error.
   isRedirect: () => false,
   useRouter: () => ({ navigate: () => {}, invalidate: () => {} }),
 }));
 
-let StackNav: ComponentType<{ onCreateClick: () => void }>;
+let StackNav: ComponentType<{ onCreateClick: () => void; driftByKey?: Map<string, StackDriftItem> }>;
+
+const driftByKey = new Map<string, StackDriftItem>([
+  ['server-1/app-db', {
+    host: 'server-1',
+    stack: 'app-db',
+    kind: 'ghost',
+    repoComposeHash: 'repo-hash',
+    latestDeployStatus: 'succeeded',
+  }],
+]);
 
 beforeAll(async () => {
   const mod = await import('../StackNav');
   StackNav = mod.default;
 });
 
+// Wrap in real context providers so we don't have to mock.module the context
+// module. Mocking the context module globally pollutes other tests that import
+// the same hooks (e.g. stacks-context.test.ts) because bun's mock.module is
+// process-scoped, not test-file-scoped.
+function renderWithContexts(ui: ReactNode) {
+  return render(
+    <StackListContext value={listValue}>
+      <StackStatusContext value={statusValue}>
+        {ui}
+      </StackStatusContext>
+    </StackListContext>,
+  );
+}
+
 describe('StackNav', () => {
   it('renders the Stacks header', () => {
-    render(<StackNav onCreateClick={() => {}} />);
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     expect(screen.getByText('Stacks')).toBeDefined();
   });
 
   it('renders the create button', () => {
-    render(<StackNav onCreateClick={() => {}} />);
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     expect(screen.getByLabelText('Create stack')).toBeDefined();
   });
 
   it('calls onCreateClick when create button is clicked', () => {
     const onCreateClick = mock(() => {});
-    render(<StackNav onCreateClick={onCreateClick} />);
+    renderWithContexts(<StackNav onCreateClick={onCreateClick} driftByKey={driftByKey} />);
     fireEvent.click(screen.getByLabelText('Create stack'));
     expect(onCreateClick).toHaveBeenCalledTimes(1);
   });
 
   it('renders host headers sorted alphabetically', () => {
-    render(<StackNav onCreateClick={() => {}} />);
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     const hosts = screen.getAllByText(/server-/);
     expect(hosts[0].textContent).toBe('server-1');
     expect(hosts[1].textContent).toBe('server-2');
   });
 
   it('renders stack names under their hosts', () => {
-    render(<StackNav onCreateClick={() => {}} />);
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     expect(screen.getByText('app-db')).toBeDefined();
     expect(screen.getByText('app-web')).toBeDefined();
     expect(screen.getByText('monitoring')).toBeDefined();
   });
 
   it('renders stacks sorted alphabetically within each host', () => {
-    render(<StackNav onCreateClick={() => {}} />);
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     const allLinks = screen.getAllByRole('link');
     const stackLinks = allLinks.filter((l) => {
       const params = l.getAttribute('data-params');
       return params && params.includes('stackName');
     });
-    // server-1 stacks: app-db before app-web
     expect(stackLinks[0].textContent).toContain('app-db');
     expect(stackLinks[1].textContent).toContain('app-web');
-    // server-2 stacks: monitoring
     expect(stackLinks[2].textContent).toContain('monitoring');
   });
 
   it('renders host links pointing to host settings route with correct params', () => {
-    render(<StackNav onCreateClick={() => {}} />);
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     const hostLinks = screen.getAllByRole('link').filter((l) =>
       l.getAttribute('href')?.includes('/stacks/host/'),
     );
@@ -116,7 +135,7 @@ describe('StackNav', () => {
   });
 
   it('renders stack links pointing to stack editor route with correct params', () => {
-    render(<StackNav onCreateClick={() => {}} />);
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     const stackLinks = screen.getAllByRole('link').filter((l) =>
       l.getAttribute('href')?.includes('/stacks/$stackName'),
     );
@@ -128,23 +147,25 @@ describe('StackNav', () => {
   });
 
   it('renders icon images for stacks with icons', () => {
-    const { container } = render(<StackNav onCreateClick={() => {}} />);
+    const { container } = renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     const images = container.querySelectorAll('img');
-    // app-web has nginx icon, monitoring has grafana icon
     expect(images).toHaveLength(2);
   });
 
   it('renders letter fallback for stacks without icons', () => {
-    render(<StackNav onCreateClick={() => {}} />);
-    // app-db has no icon, should show 'A' fallback
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     expect(screen.getByText('A')).toBeDefined();
   });
 
   it('shows container count when > 0', () => {
-    // app-web has 2 containers, app-db has 1, monitoring has 3
-    render(<StackNav onCreateClick={() => {}} />);
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
     expect(screen.getByText('2')).toBeDefined();
     expect(screen.getByText('1')).toBeDefined();
     expect(screen.getByText('3')).toBeDefined();
+  });
+
+  it('renders a drift marker for stacks with drift', () => {
+    renderWithContexts(<StackNav onCreateClick={() => {}} driftByKey={driftByKey} />);
+    expect(screen.getByLabelText('Drift detected for app-db')).toBeDefined();
   });
 });

--- a/src/data/stacks/__tests__/functions.test.ts
+++ b/src/data/stacks/__tests__/functions.test.ts
@@ -24,6 +24,12 @@ const mockResolveDeleteStack = mock(() =>
 );
 const mockResumePendingDeploy = mock(() => Promise.resolve({ deployId: 7 }));
 const mockRejectPendingDeploy = mock(() => Promise.resolve({ deployId: 7 }));
+const mockScanStackDrift = mock(() => Promise.resolve({
+  items: [],
+  summary: { total: 0, ghost: 0, untracked: 0, content: 0 },
+  scanErrors: [],
+}));
+const mockResolveStackDrift = mock(() => Promise.resolve({ outcome: 'repo-synced' as const, commitSha: 'abc123' }));
 
 mock.module('@/lib/stacks/stack-service', () => ({
   getStackSummaries: mockGetStackSummaries,
@@ -38,6 +44,8 @@ mock.module('@/lib/stacks/stack-service', () => ({
   resolveDeleteStack: mockResolveDeleteStack,
   resumePendingDeploy: mockResumePendingDeploy,
   rejectPendingDeploy: mockRejectPendingDeploy,
+  scanStackDrift: mockScanStackDrift,
+  resolveStackDrift: mockResolveStackDrift,
 }));
 
 /**
@@ -65,6 +73,8 @@ describe('stacks.functions module', () => {
     mockResolveDeleteStack.mockClear();
     mockResumePendingDeploy.mockClear();
     mockRejectPendingDeploy.mockClear();
+    mockScanStackDrift.mockClear();
+    mockResolveStackDrift.mockClear();
   });
 
   describe('exports', () => {
@@ -102,6 +112,18 @@ describe('stacks.functions module', () => {
       const mod = await import('../functions');
       expect(mod.updateStackIcon).toBeDefined();
       expect(typeof mod.updateStackIcon).toBe('function');
+    });
+
+    it('exports scanDrift server function', async () => {
+      const mod = await import('../functions');
+      expect(mod.scanDrift).toBeDefined();
+      expect(typeof mod.scanDrift).toBe('function');
+    });
+
+    it('exports resolveDrift server function', async () => {
+      const mod = await import('../functions');
+      expect(mod.resolveDrift).toBeDefined();
+      expect(typeof mod.resolveDrift).toBe('function');
     });
   });
 
@@ -269,6 +291,27 @@ describe('stacks.functions module', () => {
       await expect(rejectDeploy({ data: { deployId: 999 } })).rejects.toThrow(
         'Deploy 999 not found'
       );
+    });
+  });
+
+  describe('scanDrift', () => {
+    it('delegates to scanStackDrift', async () => {
+      const { scanDrift } = await import('../functions');
+      await scanDrift({});
+      expect(mockScanStackDrift).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('resolveDrift', () => {
+    it('delegates to resolveStackDrift with host, stack, and resolution', async () => {
+      const { resolveDrift } = await import('../functions');
+      await resolveDrift({ data: { host: 'server1', stack: 'grafana', resolution: 'trust_agent' } });
+      expect(mockResolveStackDrift).toHaveBeenCalledTimes(1);
+      expect(mockResolveStackDrift).toHaveBeenCalledWith({
+        host: 'server1',
+        stack: 'grafana',
+        resolution: 'trust_agent',
+      });
     });
   });
 

--- a/src/data/stacks/functions.tsx
+++ b/src/data/stacks/functions.tsx
@@ -10,7 +10,9 @@ import {
   updateStackIconSchema,
   resumeDeploySchema,
   rejectDeploySchema,
+  resolveDriftSchema,
 } from '@/data/stacks/schemas';
+import type { StackDriftReport, StackDriftResolutionResult } from '@/types/stacks';
 
 /**
  * Lazy wrapper around the shared OpenBao client factory. The factory owns
@@ -60,7 +62,7 @@ export const triggerDeploy = createServerFn()
   });
 
 /**
- * Approve a pending deploy — runs it through the pipeline's resumePending path.
+ * Approve a pending deploy: runs it through the pipeline's resumePending path.
  */
 export const resumeDeploy = createServerFn({ method: 'POST' })
   .inputValidator(resumeDeploySchema)
@@ -70,13 +72,34 @@ export const resumeDeploy = createServerFn({ method: 'POST' })
   });
 
 /**
- * Reject a pending deploy — marks it failed with a "Manually rejected" log.
+ * Reject a pending deploy: marks it failed with a "Manually rejected" log.
  */
 export const rejectDeploy = createServerFn({ method: 'POST' })
   .inputValidator(rejectDeploySchema)
   .handler(async ({ data }): Promise<{ deployId: number }> => {
     const { rejectPendingDeploy } = await import('@/lib/stacks/stack-service');
     return rejectPendingDeploy(data.deployId);
+  });
+
+/**
+ * Scan for drift between the repo manifest and each Docker host's agent filesystem.
+ * Fans out one agent call per host and returns items classified as ghost/untracked/content.
+ */
+export const scanDrift = createServerFn({ method: 'GET' })
+  .handler(async (): Promise<StackDriftReport> => {
+    const { scanStackDrift } = await import('@/lib/stacks/stack-service');
+    return scanStackDrift();
+  });
+
+/**
+ * Apply a chosen resolution to a single drift item.
+ * Re-scans before acting to catch stale UI clicks.
+ */
+export const resolveDrift = createServerFn({ method: 'POST' })
+  .inputValidator(resolveDriftSchema)
+  .handler(async ({ data }): Promise<StackDriftResolutionResult> => {
+    const { resolveStackDrift } = await import('@/lib/stacks/stack-service');
+    return resolveStackDrift(data);
   });
 
 /**

--- a/src/data/stacks/schemas.ts
+++ b/src/data/stacks/schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { SAFE_PATH_SEGMENT_PATTERN } from '@/lib/constants/openbao';
+import type { StackDriftResolution } from '@/types/stacks';
 
 /** Allowed stack name pattern: must match SAFE_PATH_SEGMENT_PATTERN used by OpenBao client. No dots, slashes, or path traversal. */
 const stackNameField = z.string().min(1).regex(SAFE_PATH_SEGMENT_PATTERN, 'Stack name must contain only letters, numbers, hyphens, and underscores');
@@ -38,4 +39,12 @@ export const resumeDeploySchema = z.object({
 
 export const rejectDeploySchema = z.object({
   deployId: z.number().int().positive(),
+});
+
+const RESOLUTIONS = ['trust_repo', 'trust_agent', 'remove'] as const satisfies readonly StackDriftResolution[];
+
+export const resolveDriftSchema = z.object({
+  host: z.string().min(1),
+  stack: stackNameField,
+  resolution: z.enum(RESOLUTIONS),
 });

--- a/src/lib/clients/__tests__/agent-client.test.ts
+++ b/src/lib/clients/__tests__/agent-client.test.ts
@@ -121,6 +121,56 @@ describe('AgentClient', () => {
     });
   });
 
+  describe('getStackInventory', () => {
+    it('returns parsed stack inventory from the agent', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          stacks: [
+            { name: 'grafana', hasComposeFile: true, composeHash: 'hash-1' },
+            { name: 'plex', hasComposeFile: true, composeHash: 'hash-2' },
+          ],
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      const result = await client.getStackInventory();
+
+      expect(result).toEqual([
+        { name: 'grafana', hasComposeFile: true, composeHash: 'hash-1' },
+        { name: 'plex', hasComposeFile: true, composeHash: 'hash-2' },
+      ]);
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe('http://agent:9090/stacks/inventory');
+    });
+  });
+
+  describe('getStackCompose', () => {
+    it('requests compose content for a specific stack', async () => {
+      fetchMock.mockResolvedValueOnce(
+        new Response(JSON.stringify({
+          stack: 'plex',
+          composeContent: 'services: {}',
+          composeHash: 'hash-1',
+        }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+
+      const result = await client.getStackCompose('plex');
+
+      expect(result).toEqual({
+        stack: 'plex',
+        composeContent: 'services: {}',
+        composeHash: 'hash-1',
+      });
+      const [url] = fetchMock.mock.calls[0];
+      expect(url).toBe('http://agent:9090/stacks/compose?stack=plex');
+    });
+  });
+
   describe('health', () => {
     it('returns health info from GET /health', async () => {
       fetchMock.mockResolvedValueOnce(

--- a/src/lib/clients/agent-client.ts
+++ b/src/lib/clients/agent-client.ts
@@ -1,4 +1,10 @@
-import type { AgentStackResponse, AgentHealthCheckResponse } from '@homelab-manager/agent/types';
+import type {
+  AgentStackResponse,
+  AgentHealthCheckResponse,
+  AgentStackInventoryResponse,
+  AgentStackInventoryEntry,
+  AgentStackComposeResponse,
+} from '@homelab-manager/agent/types';
 import type { AgentDeployPayload, AgentDeployResponse } from '@/lib/deploy/types';
 import { retry } from '@/lib/utils/backoff';
 
@@ -88,6 +94,15 @@ export class AgentClient {
   async restart(stack: string): Promise<AgentDeployResponse> {
     const raw = await this.postJson<AgentStackResponse>('/stacks/restart', { stack });
     return adaptDeployResponse(raw);
+  }
+
+  async getStackInventory(): Promise<AgentStackInventoryEntry[]> {
+    const raw = await this.getJson<AgentStackInventoryResponse>('/stacks/inventory');
+    return raw.stacks;
+  }
+
+  async getStackCompose(stack: string): Promise<AgentStackComposeResponse> {
+    return this.getJson<AgentStackComposeResponse>(`/stacks/compose?stack=${encodeURIComponent(stack)}`);
   }
 
   async health(): Promise<AgentHealthResponse> {

--- a/src/lib/constants/stacks-keys.ts
+++ b/src/lib/constants/stacks-keys.ts
@@ -9,3 +9,6 @@ export const STACK_VARIABLES_QUERY_KEY = ['stack-variables'] as const;
 
 /** Query key prefix for deploy history. Usage: [...DEPLOY_HISTORY_QUERY_KEY, stackName]. */
 export const DEPLOY_HISTORY_QUERY_KEY = ['deploy-history'] as const;
+
+/** Query key for stack drift scans. */
+export const STACK_DRIFT_QUERY_KEY = ['stack-drift'] as const;

--- a/src/lib/stacks/__tests__/stack-drift-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-drift-service.test.ts
@@ -1,0 +1,510 @@
+import { describe, expect, it, mock } from 'bun:test';
+import type { DeployRecord } from '@/lib/deploy/types';
+import {
+  buildStackDriftReport,
+  getAllowedStackDriftResolutions,
+  resolveStackDriftItem,
+  type RepoStackSnapshot,
+} from '@/lib/stacks/stack-drift-service';
+
+const baseDeploy = (overrides?: Partial<DeployRecord>): DeployRecord => ({
+  id: 1,
+  stack: 'plex',
+  host: 'alpha',
+  commitSha: 'sha-1',
+  composeHash: 'repo-hash',
+  envHash: 'env-hash',
+  status: 'succeeded',
+  trigger: 'ui',
+  action: 'deploy',
+  forceRecreate: false,
+  logs: null,
+  createdAt: new Date('2026-04-21T00:00:00Z'),
+  postSuccess: null,
+  ...overrides,
+});
+
+describe('buildStackDriftReport', () => {
+  it('classifies ghost drift when repo stack is missing on the agent', () => {
+    const report = buildStackDriftReport({
+      repoStacks: [
+        {
+          stack: 'plex',
+          host: 'alpha',
+          autoDeploy: true,
+          composeContent: 'services: {}',
+          composeHash: 'repo-hash',
+        },
+      ],
+      hosts: [{ name: 'alpha', dockerEnabled: true }],
+      latestDeploys: [baseDeploy()],
+      agentStacksByHost: new Map([['alpha', []]]),
+      scanErrors: [],
+    });
+
+    expect(report.items).toEqual([
+      expect.objectContaining({
+        host: 'alpha',
+        stack: 'plex',
+        kind: 'ghost',
+        repoComposeHash: 'repo-hash',
+        latestDeployStatus: 'succeeded',
+      }),
+    ]);
+    expect(report.summary).toEqual({
+      total: 1,
+      ghost: 1,
+      untracked: 0,
+      content: 0,
+    });
+  });
+
+  it('classifies untracked drift when the agent has a stack missing from the repo', () => {
+    const report = buildStackDriftReport({
+      repoStacks: [],
+      hosts: [{ name: 'alpha', dockerEnabled: true }],
+      latestDeploys: [],
+      agentStacksByHost: new Map([[
+        'alpha',
+        [{ name: 'grafana', hasComposeFile: true, composeHash: 'agent-hash' }],
+      ]]),
+      scanErrors: [],
+    });
+
+    expect(report.items).toEqual([
+      expect.objectContaining({
+        host: 'alpha',
+        stack: 'grafana',
+        kind: 'untracked',
+        agentComposeHash: 'agent-hash',
+        latestDeployStatus: null,
+      }),
+    ]);
+  });
+
+  it('classifies content drift when repo and agent hashes differ', () => {
+    const report = buildStackDriftReport({
+      repoStacks: [
+        {
+          stack: 'plex',
+          host: 'alpha',
+          autoDeploy: false,
+          composeContent: 'services: {}',
+          composeHash: 'repo-hash',
+        },
+      ],
+      hosts: [{ name: 'alpha', dockerEnabled: true }],
+      latestDeploys: [baseDeploy({ status: 'failed' })],
+      agentStacksByHost: new Map([[
+        'alpha',
+        [{ name: 'plex', hasComposeFile: true, composeHash: 'agent-hash' }],
+      ]]),
+      scanErrors: [],
+    });
+
+    expect(report.items).toEqual([
+      expect.objectContaining({
+        host: 'alpha',
+        stack: 'plex',
+        kind: 'content',
+        repoComposeHash: 'repo-hash',
+        agentComposeHash: 'agent-hash',
+        latestDeployStatus: 'failed',
+      }),
+    ]);
+  });
+
+  it('sorts items deterministically by host, stack, then kind', () => {
+    const report = buildStackDriftReport({
+      repoStacks: [
+        { stack: 'plex', host: 'bravo', autoDeploy: false, composeContent: '', composeHash: 'b-plex' },
+        { stack: 'grafana', host: 'alpha', autoDeploy: false, composeContent: '', composeHash: 'a-gr' },
+      ],
+      hosts: [
+        { name: 'bravo', dockerEnabled: true },
+        { name: 'alpha', dockerEnabled: true },
+      ],
+      latestDeploys: [],
+      agentStacksByHost: new Map([
+        ['bravo', [{ name: 'sonarr', hasComposeFile: true, composeHash: 'b-sonarr' }]],
+        ['alpha', [{ name: 'radarr', hasComposeFile: true, composeHash: 'a-radarr' }]],
+      ]),
+      scanErrors: [],
+    });
+
+    expect(report.items.map((i) => `${i.host}/${i.stack}/${i.kind}`)).toEqual([
+      'alpha/grafana/ghost',
+      'alpha/radarr/untracked',
+      'bravo/plex/ghost',
+      'bravo/sonarr/untracked',
+    ]);
+  });
+
+  it('skips hosts that do not have docker capability', () => {
+    const report = buildStackDriftReport({
+      repoStacks: [
+        { stack: 'plex', host: 'noDocker', autoDeploy: false, composeContent: '', composeHash: 'repo-hash' },
+      ],
+      hosts: [{ name: 'noDocker', dockerEnabled: false }],
+      latestDeploys: [],
+      agentStacksByHost: new Map(),
+      scanErrors: [],
+    });
+
+    expect(report.items).toEqual([]);
+    expect(report.summary.total).toBe(0);
+  });
+
+  it('skips drift classification for hosts with scan errors and reports the error', () => {
+    const report = buildStackDriftReport({
+      repoStacks: [
+        {
+          stack: 'plex',
+          host: 'alpha',
+          autoDeploy: false,
+          composeContent: 'services: {}',
+          composeHash: 'repo-hash',
+        },
+      ],
+      hosts: [{ name: 'alpha', dockerEnabled: true }],
+      latestDeploys: [baseDeploy()],
+      agentStacksByHost: new Map(),
+      scanErrors: [{ host: 'alpha', message: 'agent unreachable' }],
+    });
+
+    expect(report.items).toEqual([]);
+    expect(report.scanErrors).toEqual([{ host: 'alpha', message: 'agent unreachable' }]);
+  });
+});
+
+describe('getAllowedStackDriftResolutions', () => {
+  it('does not allow trusting the repo for untracked stacks', () => {
+    expect(getAllowedStackDriftResolutions('untracked')).toEqual(['trust_agent', 'remove']);
+  });
+
+  it('allows all actions for ghost and content drift', () => {
+    expect(getAllowedStackDriftResolutions('ghost')).toEqual(['trust_repo', 'trust_agent', 'remove']);
+    expect(getAllowedStackDriftResolutions('content')).toEqual(['trust_repo', 'trust_agent', 'remove']);
+  });
+});
+
+describe('resolveStackDriftItem', () => {
+  const repoStack: RepoStackSnapshot = {
+    stack: 'plex',
+    host: 'alpha',
+    autoDeploy: true,
+    composeContent: 'services:\n  plex:\n    image: plexinc/pms-docker',
+    composeHash: 'repo-hash',
+  };
+
+  it('trust_repo redeploys ghost drift from the repo copy', async () => {
+    const triggerDeploy = mock().mockResolvedValue({ deployId: 41 });
+
+    const result = await resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'plex',
+      resolution: 'trust_repo',
+      loadCurrentReport: async () => ({
+        items: [{
+          host: 'alpha',
+          stack: 'plex',
+          kind: 'ghost',
+          repoComposeHash: 'repo-hash',
+          latestDeployStatus: 'succeeded',
+        }],
+        summary: { total: 1, ghost: 1, untracked: 0, content: 0 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => repoStack,
+      readAgentCompose: async () => null,
+      triggerDeploy,
+      deleteTrackedStack: mock(),
+      syncRepoToAgent: mock(),
+    });
+
+    expect(triggerDeploy).toHaveBeenCalledWith({
+      stack: 'plex',
+      host: 'alpha',
+      action: 'deploy',
+    });
+    expect(result).toEqual({
+      outcome: 'deploy-queued',
+      deployId: 41,
+    });
+  });
+
+  it('trust_agent removes ghost drift from the repo', async () => {
+    const deleteTrackedStack = mock().mockResolvedValue({ status: 'removed', commitSha: 'abc123' });
+
+    const result = await resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'plex',
+      resolution: 'trust_agent',
+      loadCurrentReport: async () => ({
+        items: [{
+          host: 'alpha',
+          stack: 'plex',
+          kind: 'ghost',
+          repoComposeHash: 'repo-hash',
+          latestDeployStatus: 'succeeded',
+        }],
+        summary: { total: 1, ghost: 1, untracked: 0, content: 0 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => repoStack,
+      readAgentCompose: async () => null,
+      triggerDeploy: mock(),
+      deleteTrackedStack,
+      syncRepoToAgent: mock(),
+    });
+
+    expect(deleteTrackedStack).toHaveBeenCalledWith('plex', false);
+    expect(result).toEqual({
+      outcome: 'repo-removed',
+      commitSha: 'abc123',
+    });
+  });
+
+  it('trust_agent syncs untracked drift into the repo using agent compose content', async () => {
+    const syncRepoToAgent = mock().mockResolvedValue({ commitSha: 'abc123' });
+
+    const result = await resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'grafana',
+      resolution: 'trust_agent',
+      loadCurrentReport: async () => ({
+        items: [{
+          host: 'alpha',
+          stack: 'grafana',
+          kind: 'untracked',
+          agentComposeHash: 'agent-hash',
+          latestDeployStatus: null,
+        }],
+        summary: { total: 1, ghost: 0, untracked: 1, content: 0 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => null,
+      readAgentCompose: async () => ({
+        stack: 'grafana',
+        composeContent: 'services:\n  grafana:\n    image: grafana/grafana',
+        composeHash: 'agent-hash',
+      }),
+      triggerDeploy: mock(),
+      deleteTrackedStack: mock(),
+      syncRepoToAgent,
+    });
+
+    expect(syncRepoToAgent).toHaveBeenCalledWith({
+      stack: 'grafana',
+      host: 'alpha',
+      composeContent: 'services:\n  grafana:\n    image: grafana/grafana',
+    });
+    expect(result).toEqual({
+      outcome: 'repo-synced',
+      commitSha: 'abc123',
+    });
+  });
+
+  it('remove queues teardown for untracked agent-only drift', async () => {
+    const triggerDeploy = mock().mockResolvedValue({ deployId: 99 });
+
+    const result = await resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'grafana',
+      resolution: 'remove',
+      loadCurrentReport: async () => ({
+        items: [{
+          host: 'alpha',
+          stack: 'grafana',
+          kind: 'untracked',
+          agentComposeHash: 'agent-hash',
+          latestDeployStatus: null,
+        }],
+        summary: { total: 1, ghost: 0, untracked: 1, content: 0 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => null,
+      readAgentCompose: async () => null,
+      triggerDeploy,
+      deleteTrackedStack: mock(),
+      syncRepoToAgent: mock(),
+    });
+
+    expect(triggerDeploy).toHaveBeenCalledWith({
+      stack: 'grafana',
+      host: 'alpha',
+      action: 'teardown',
+    });
+    expect(result).toEqual({
+      outcome: 'teardown-queued',
+      deployId: 99,
+    });
+  });
+
+  it('remove queues teardown for content drift when deleteTrackedStack is pending', async () => {
+    const deleteTrackedStack = mock().mockResolvedValue({ status: 'teardown-pending', deployId: 77 });
+
+    const result = await resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'plex',
+      resolution: 'remove',
+      loadCurrentReport: async () => ({
+        items: [{
+          host: 'alpha',
+          stack: 'plex',
+          kind: 'content',
+          repoComposeHash: 'repo-hash',
+          agentComposeHash: 'agent-hash',
+          latestDeployStatus: 'succeeded',
+        }],
+        summary: { total: 1, ghost: 0, untracked: 0, content: 1 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => repoStack,
+      readAgentCompose: async () => null,
+      triggerDeploy: mock(),
+      deleteTrackedStack,
+      syncRepoToAgent: mock(),
+    });
+
+    expect(deleteTrackedStack).toHaveBeenCalledWith('plex', true);
+    expect(result).toEqual({ outcome: 'teardown-queued', deployId: 77 });
+  });
+
+  it('remove returns repo-removed when deleteTrackedStack finishes synchronously', async () => {
+    const deleteTrackedStack = mock().mockResolvedValue({ status: 'removed', commitSha: 'sha-remove' });
+
+    const result = await resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'plex',
+      resolution: 'remove',
+      loadCurrentReport: async () => ({
+        items: [{
+          host: 'alpha',
+          stack: 'plex',
+          kind: 'ghost',
+          repoComposeHash: 'repo-hash',
+          latestDeployStatus: 'succeeded',
+        }],
+        summary: { total: 1, ghost: 1, untracked: 0, content: 0 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => repoStack,
+      readAgentCompose: async () => null,
+      triggerDeploy: mock(),
+      deleteTrackedStack,
+      syncRepoToAgent: mock(),
+    });
+
+    expect(result).toEqual({ outcome: 'repo-removed', commitSha: 'sha-remove' });
+  });
+
+  it('surfaces the underlying scan error when the target host failed during re-scan', async () => {
+    await expect(resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'plex',
+      resolution: 'trust_repo',
+      loadCurrentReport: async () => ({
+        items: [],
+        summary: { total: 0, ghost: 0, untracked: 0, content: 0 },
+        scanErrors: [{ host: 'alpha', message: 'agent unreachable' }],
+      }),
+      readRepoStack: async () => repoStack,
+      readAgentCompose: async () => null,
+      triggerDeploy: mock(),
+      deleteTrackedStack: mock(),
+      syncRepoToAgent: mock(),
+    })).rejects.toThrow('Cannot resolve drift on "alpha": agent unreachable');
+  });
+
+  it('throws when the drift item no longer exists after re-scan (TOCTOU)', async () => {
+    await expect(resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'plex',
+      resolution: 'trust_repo',
+      loadCurrentReport: async () => ({
+        items: [],
+        summary: { total: 0, ghost: 0, untracked: 0, content: 0 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => repoStack,
+      readAgentCompose: async () => null,
+      triggerDeploy: mock(),
+      deleteTrackedStack: mock(),
+      syncRepoToAgent: mock(),
+    })).rejects.toThrow('No drift item found for "alpha/plex"');
+  });
+
+  it('throws when repo copy has disappeared between scan and trust_repo resolve', async () => {
+    await expect(resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'plex',
+      resolution: 'trust_repo',
+      loadCurrentReport: async () => ({
+        items: [{
+          host: 'alpha',
+          stack: 'plex',
+          kind: 'ghost',
+          repoComposeHash: 'repo-hash',
+          latestDeployStatus: 'succeeded',
+        }],
+        summary: { total: 1, ghost: 1, untracked: 0, content: 0 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => null,
+      readAgentCompose: async () => null,
+      triggerDeploy: mock(),
+      deleteTrackedStack: mock(),
+      syncRepoToAgent: mock(),
+    })).rejects.toThrow('Stack "plex" is not tracked in the repo');
+  });
+
+  it('throws when agent compose has disappeared between scan and trust_agent resolve of content drift', async () => {
+    await expect(resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'plex',
+      resolution: 'trust_agent',
+      loadCurrentReport: async () => ({
+        items: [{
+          host: 'alpha',
+          stack: 'plex',
+          kind: 'content',
+          repoComposeHash: 'repo-hash',
+          agentComposeHash: 'agent-hash',
+          latestDeployStatus: 'succeeded',
+        }],
+        summary: { total: 1, ghost: 0, untracked: 0, content: 1 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => repoStack,
+      readAgentCompose: async () => null,
+      triggerDeploy: mock(),
+      deleteTrackedStack: mock(),
+      syncRepoToAgent: mock(),
+    })).rejects.toThrow('Stack "plex" was not found on agent host "alpha"');
+  });
+
+  it('rejects trust_repo for untracked drift', async () => {
+    await expect(resolveStackDriftItem({
+      host: 'alpha',
+      stack: 'grafana',
+      resolution: 'trust_repo',
+      loadCurrentReport: async () => ({
+        items: [{
+          host: 'alpha',
+          stack: 'grafana',
+          kind: 'untracked',
+          agentComposeHash: 'agent-hash',
+          latestDeployStatus: null,
+        }],
+        summary: { total: 1, ghost: 0, untracked: 1, content: 0 },
+        scanErrors: [],
+      }),
+      readRepoStack: async () => null,
+      readAgentCompose: async () => null,
+      triggerDeploy: mock(),
+      deleteTrackedStack: mock(),
+      syncRepoToAgent: mock(),
+    })).rejects.toThrow('Resolution "trust_repo" is not valid for drift kind "untracked"');
+  });
+});

--- a/src/lib/stacks/stack-drift-service.ts
+++ b/src/lib/stacks/stack-drift-service.ts
@@ -1,0 +1,226 @@
+import type {
+  AgentStackComposeResponse,
+  AgentStackInventoryEntry,
+} from '@homelab-manager/agent/types';
+import type { DeployRecord } from '@/lib/deploy/types';
+import type {
+  StackDriftItem,
+  StackDriftKind,
+  StackDriftReport,
+  StackDriftResolution,
+  StackDriftResolutionResult,
+  StackDriftScanError,
+} from '@/types/stacks';
+
+export interface RepoStackSnapshot {
+  stack: string;
+  host: string;
+  autoDeploy: boolean;
+  composeContent: string;
+  composeHash: string;
+}
+
+interface ScanHost {
+  name: string;
+  dockerEnabled: boolean;
+}
+
+interface BuildStackDriftReportInput {
+  repoStacks: RepoStackSnapshot[];
+  hosts: ScanHost[];
+  latestDeploys: DeployRecord[];
+  agentStacksByHost: Map<string, AgentStackInventoryEntry[]>;
+  scanErrors: StackDriftScanError[];
+}
+
+interface ResolveStackDriftInput {
+  host: string;
+  stack: string;
+  resolution: StackDriftResolution;
+  loadCurrentReport: () => Promise<StackDriftReport>;
+  readRepoStack: (stack: string) => Promise<RepoStackSnapshot | null>;
+  readAgentCompose: (host: string, stack: string) => Promise<AgentStackComposeResponse | null>;
+  triggerDeploy: (input: {
+    stack: string;
+    host: string;
+    action: 'deploy' | 'teardown';
+  }) => Promise<{ deployId: number }>;
+  deleteTrackedStack: (
+    stack: string,
+    teardown: boolean,
+  ) => Promise<{ status: 'removed'; commitSha: string } | { status: 'teardown-pending'; deployId: number }>;
+  syncRepoToAgent: (input: { stack: string; host: string; composeContent: string }) => Promise<{ commitSha: string }>;
+}
+
+const KIND_LABELS: Record<StackDriftKind, string> = {
+  ghost: 'Ghost',
+  untracked: 'Untracked',
+  content: 'Content Drift',
+};
+
+const RESOLUTION_LABELS: Record<StackDriftResolution, string> = {
+  trust_repo: 'Trust Repo',
+  trust_agent: 'Trust Agent',
+  remove: 'Remove',
+};
+
+export function getStackDriftKindLabel(kind: StackDriftKind): string {
+  return KIND_LABELS[kind];
+}
+
+export function getStackDriftResolutionLabel(resolution: StackDriftResolution): string {
+  return RESOLUTION_LABELS[resolution];
+}
+
+/**
+ * `untracked` excludes `trust_repo` because there is no repo copy to redeploy;
+ * the user must either adopt the agent's copy or tear it down.
+ */
+export function getAllowedStackDriftResolutions(kind: StackDriftKind): StackDriftResolution[] {
+  if (kind === 'untracked') return ['trust_agent', 'remove'];
+  return ['trust_repo', 'trust_agent', 'remove'];
+}
+
+export function buildStackDriftReport(input: BuildStackDriftReportInput): StackDriftReport {
+  const latestDeployMap = new Map(input.latestDeploys.map((deploy) => [`${deploy.host}/${deploy.stack}`, deploy]));
+  const scanErrorHosts = new Set(input.scanErrors.map((error) => error.host));
+  const items: StackDriftItem[] = [];
+
+  for (const host of input.hosts) {
+    if (!host.dockerEnabled || scanErrorHosts.has(host.name)) continue;
+
+    const repoStacks = input.repoStacks.filter((stack) => stack.host === host.name);
+    const repoByName = new Map(repoStacks.map((stack) => [stack.stack, stack]));
+    const agentStacks = input.agentStacksByHost.get(host.name) ?? [];
+    const agentByName = new Map(agentStacks.map((stack) => [stack.name, stack]));
+
+    for (const repoStack of repoStacks) {
+      const agentStack = agentByName.get(repoStack.stack);
+      const latestDeploy = latestDeployMap.get(`${repoStack.host}/${repoStack.stack}`) ?? null;
+
+      if (!agentStack) {
+        items.push({
+          host: repoStack.host,
+          stack: repoStack.stack,
+          kind: 'ghost',
+          repoComposeHash: repoStack.composeHash,
+          latestDeployStatus: latestDeploy?.status ?? null,
+        });
+        continue;
+      }
+
+      if (agentStack.composeHash !== repoStack.composeHash) {
+        items.push({
+          host: repoStack.host,
+          stack: repoStack.stack,
+          kind: 'content',
+          repoComposeHash: repoStack.composeHash,
+          agentComposeHash: agentStack.composeHash,
+          latestDeployStatus: latestDeploy?.status ?? null,
+        });
+      }
+    }
+
+    for (const agentStack of agentStacks) {
+      if (repoByName.has(agentStack.name)) continue;
+      items.push({
+        host: host.name,
+        stack: agentStack.name,
+        kind: 'untracked',
+        agentComposeHash: agentStack.composeHash,
+        latestDeployStatus: null,
+      });
+    }
+  }
+
+  items.sort((a, b) =>
+    a.host.localeCompare(b.host) ||
+    a.stack.localeCompare(b.stack) ||
+    a.kind.localeCompare(b.kind),
+  );
+
+  return {
+    items,
+    summary: {
+      total: items.length,
+      ghost: items.filter((item) => item.kind === 'ghost').length,
+      untracked: items.filter((item) => item.kind === 'untracked').length,
+      content: items.filter((item) => item.kind === 'content').length,
+    },
+    scanErrors: input.scanErrors,
+  };
+}
+
+/**
+ * Re-scan before acting so a stale UI can't drive a destructive resolution
+ * against a stack whose drift state has changed since the user clicked.
+ * When a re-scan records a scanError for the target host, surface that error
+ * directly instead of the misleading "no drift item found" path (the host
+ * gets skipped in `buildStackDriftReport` when it's in scanErrors).
+ */
+export async function resolveStackDriftItem(input: ResolveStackDriftInput): Promise<StackDriftResolutionResult> {
+  const report = await input.loadCurrentReport();
+
+  const hostScanError = report.scanErrors.find((error) => error.host === input.host);
+  if (hostScanError) {
+    throw new Error(`Cannot resolve drift on "${input.host}": ${hostScanError.message}`);
+  }
+
+  const item = report.items.find((candidate) => candidate.host === input.host && candidate.stack === input.stack);
+  if (!item) {
+    throw new Error(`No drift item found for "${input.host}/${input.stack}"`);
+  }
+
+  const allowed = getAllowedStackDriftResolutions(item.kind);
+  if (!allowed.includes(input.resolution)) {
+    throw new Error(`Resolution "${input.resolution}" is not valid for drift kind "${item.kind}"`);
+  }
+
+  if (input.resolution === 'trust_repo') {
+    const repoStack = await input.readRepoStack(input.stack);
+    if (!repoStack) {
+      throw new Error(`Stack "${input.stack}" is not tracked in the repo`);
+    }
+    const result = await input.triggerDeploy({
+      stack: input.stack,
+      host: input.host,
+      action: 'deploy',
+    });
+    return { outcome: 'deploy-queued', deployId: result.deployId };
+  }
+
+  if (input.resolution === 'trust_agent') {
+    if (item.kind === 'ghost') {
+      const result = await input.deleteTrackedStack(input.stack, false);
+      if (result.status !== 'removed') {
+        throw new Error(`Unexpected delete result while trusting agent for "${input.stack}"`);
+      }
+      return { outcome: 'repo-removed', commitSha: result.commitSha };
+    }
+
+    const compose = await input.readAgentCompose(input.host, input.stack);
+    if (!compose) {
+      throw new Error(`Stack "${input.stack}" was not found on agent host "${input.host}"`);
+    }
+    const result = await input.syncRepoToAgent({
+      stack: input.stack,
+      host: input.host,
+      composeContent: compose.composeContent,
+    });
+    return { outcome: 'repo-synced', commitSha: result.commitSha };
+  }
+
+  if (item.kind !== 'untracked') {
+    const result = await input.deleteTrackedStack(input.stack, true);
+    return result.status === 'teardown-pending'
+      ? { outcome: 'teardown-queued', deployId: result.deployId }
+      : { outcome: 'repo-removed', commitSha: result.commitSha };
+  }
+
+  const result = await input.triggerDeploy({
+    stack: input.stack,
+    host: input.host,
+    action: 'teardown',
+  });
+  return { outcome: 'teardown-queued', deployId: result.deployId };
+}

--- a/src/lib/stacks/stack-service.ts
+++ b/src/lib/stacks/stack-service.ts
@@ -3,12 +3,22 @@
  * Called by server functions in src/data/stacks/functions.tsx.
  */
 
-import type { StackSummary, StackDetail, StackDeployRecord } from '@/types/stacks';
+import type {
+  StackSummary,
+  StackDetail,
+  StackDeployRecord,
+  StackDriftReport,
+  StackDriftResolution,
+  StackDriftResolutionResult,
+} from '@/types/stacks';
 import type { DeployRecord, DeployRequest } from '@/lib/deploy/types';
 import { loadGitConfig } from '@/lib/config/git-config';
 import { readFileFromRepo, commitFiles, FileNotFoundError } from '@/lib/git/repo';
 import { parseManifest } from '@/lib/git/manifest';
 import { saveAndCommitFile } from '@/lib/git/editor-operations';
+import { computeHash } from '@/lib/deploy/change-detection';
+import { AgentClientError } from '@/lib/clients/agent-client';
+import type { AgentStackInventoryEntry } from '@homelab-manager/agent/types';
 import yaml from 'js-yaml';
 import { SAFE_PATH_SEGMENT_PATTERN } from '@/lib/constants/openbao';
 import {
@@ -19,6 +29,11 @@ import {
   computeSyncStatus,
 } from '@/lib/stacks/stack-mappers';
 import { resolveDeleteStack, type DeleteStackResult } from '@/lib/stacks/delete-stack-resolver';
+import {
+  buildStackDriftReport,
+  resolveStackDriftItem,
+  type RepoStackSnapshot,
+} from '@/lib/stacks/stack-drift-service';
 
 /** Re-exported alongside service layer for consistent mock.module() targeting in tests. */
 export { resolveDeleteStack } from '@/lib/stacks/delete-stack-resolver';
@@ -221,7 +236,7 @@ export async function rejectPendingDeploy(deployId: number): Promise<{ deployId:
   // by another client between the getById above and this UPDATE.
   const claimed = await deployRepo.rejectPending(deployId, 'Manually rejected');
   if (!claimed) {
-    throw new Error(`Deploy ${deployId} is no longer pending — it was approved or rejected by another client`);
+    throw new Error(`Deploy ${deployId} is no longer pending: it was approved or rejected by another client`);
   }
   try {
     await deployRepo.notifyStackChange(deploy.stack, deploy.host);
@@ -438,6 +453,191 @@ export async function getManagedHostNames(): Promise<string[]> {
   const hostsRepo = new ManagedHostsRepository(dbClient.getPool());
   const hosts = await hostsRepo.getAll();
   return hosts.map((h) => h.name);
+}
+
+async function getManagedHosts() {
+  const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+  const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+  const { ManagedHostsRepository } = await import('@/lib/database/repositories/managed-hosts-repository');
+
+  const dbConfig = loadDatabaseConfig();
+  const dbClient = await databaseConnectionManager.getClient(dbConfig);
+  const hostsRepo = new ManagedHostsRepository(dbClient.getPool());
+  return hostsRepo.getAll();
+}
+
+async function getLatestDeploys() {
+  const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+  const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+  const { DeployRepository } = await import('@/lib/database/repositories/deploy-repository');
+
+  const dbConfig = loadDatabaseConfig();
+  const dbClient = await databaseConnectionManager.getClient(dbConfig);
+  const repo = new DeployRepository(dbClient.getPool());
+  return repo.getLatestDeployPerStack();
+}
+
+async function getAgentClientForHost(hostName: string) {
+  const [hosts, { getOpenBaoClient }, { AgentClient }] = await Promise.all([
+    getManagedHosts(),
+    import('@/lib/clients/openbao-client-factory'),
+    import('@/lib/clients/agent-client'),
+  ]);
+  const host = hosts.find((candidate) => candidate.name === hostName);
+  if (!host) throw new Error(`Host "${hostName}" not found in managed_hosts`);
+  const baoClient = await getOpenBaoClient();
+  const token = await baoClient.getHostSecret(host.name, 'agent_token');
+  if (!token) throw new Error(`No agent token found in OpenBao for host "${host.name}"`);
+  return new AgentClient({ agentUrl: host.agentUrl, agentToken: token });
+}
+
+async function loadRepoStacks(): Promise<RepoStackSnapshot[]> {
+  const repoPath = getRepoPath();
+  let manifestContent: string;
+  try {
+    manifestContent = await readFileFromRepo(repoPath, MANIFEST_FILENAME);
+  } catch (err) {
+    // A missing manifest means no stacks yet, empty drift state is correct.
+    // Rethrow anything else so a corrupt git ODB does not masquerade as
+    // "every agent stack is untracked" and invite destructive cleanup.
+    if (err instanceof FileNotFoundError) return [];
+    console.error('[StackService] loadRepoStacks: failed to read manifest:', err);
+    throw err;
+  }
+
+  const manifest = parseManifest(manifestContent);
+  const entries = await Promise.all(
+    Object.entries(manifest.stacks).map(async ([stack, entry]) => {
+      let composeContent = '';
+      try {
+        composeContent = await readFileFromRepo(repoPath, `${stack}/${COMPOSE_FILENAME}`);
+      } catch (err) {
+        if (!(err instanceof FileNotFoundError)) throw err;
+      }
+
+      return {
+        stack,
+        host: entry.host,
+        autoDeploy: entry.autoDeploy,
+        composeContent,
+        composeHash: computeHash(composeContent),
+      } satisfies RepoStackSnapshot;
+    }),
+  );
+
+  return entries;
+}
+
+async function syncRepoStackToAgentCompose(params: {
+  stack: string;
+  host: string;
+  composeContent: string;
+}): Promise<{ commitSha: string }> {
+  const repoPath = getRepoPath();
+  const commitSha = await commitFiles(repoPath, (existingFiles) => {
+    const manifestContent = existingFiles.get(MANIFEST_FILENAME);
+    const manifest = manifestContent ? parseManifest(manifestContent) : { stacks: {} };
+    const existingEntry = manifest.stacks[params.stack];
+
+    // If the stack was created in the repo on a different host since the
+    // scan, bail out so we don't silently rewrite the host assignment.
+    // The user must re-scan and explicitly pick an action.
+    if (existingEntry && existingEntry.host !== params.host) {
+      throw new Error(
+        `Stack "${params.stack}" already exists in manifest on host "${existingEntry.host}"; refusing to sync from "${params.host}"`,
+      );
+    }
+
+    manifest.stacks[params.stack] = {
+      host: params.host,
+      autoDeploy: existingEntry?.autoDeploy ?? false,
+    };
+
+    const newManifestContent = yaml.dump(manifest, {
+      indent: 2,
+      lineWidth: -1,
+      noRefs: true,
+      sortKeys: true,
+    });
+
+    return {
+      files: [
+        { path: MANIFEST_FILENAME, content: newManifestContent },
+        { path: `${params.stack}/${COMPOSE_FILENAME}`, content: params.composeContent },
+      ],
+      message: `Sync stack from agent: ${params.stack} on ${params.host}`,
+      author: SYSTEM_AUTHOR,
+    };
+  });
+
+  if (commitSha === null) {
+    throw new Error(`Sync produced no commit for stack "${params.stack}"`);
+  }
+  return { commitSha };
+}
+
+export async function scanStackDrift(): Promise<StackDriftReport> {
+  const [repoStacks, hosts, latestDeploys] = await Promise.all([
+    loadRepoStacks(),
+    getManagedHosts(),
+    getLatestDeploys(),
+  ]);
+
+  const dockerHosts = hosts
+    .filter((host) => host.capabilities.docker === true)
+    .map((host) => ({ name: host.name, dockerEnabled: true }));
+
+  const agentStacksByHost = new Map<string, AgentStackInventoryEntry[]>();
+  const scanErrors: Array<{ host: string; message: string }> = [];
+
+  // Every async path inside MUST report via scanErrors. An uncaught throw
+  // here would abort all parallel host scans and we'd lose visibility on
+  // hosts that are reachable just because one is not.
+  await Promise.all(dockerHosts.map(async (host) => {
+    try {
+      const agent = await getAgentClientForHost(host.name);
+      agentStacksByHost.set(host.name, await agent.getStackInventory());
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[StackService] drift scan failed for host "${host.name}":`, err);
+      scanErrors.push({ host: host.name, message });
+    }
+  }));
+
+  return buildStackDriftReport({
+    repoStacks,
+    hosts: dockerHosts,
+    latestDeploys,
+    agentStacksByHost,
+    scanErrors,
+  });
+}
+
+export async function resolveStackDrift(input: {
+  host: string;
+  stack: string;
+  resolution: StackDriftResolution;
+}): Promise<StackDriftResolutionResult> {
+  return resolveStackDriftItem({
+    ...input,
+    loadCurrentReport: () => scanStackDrift(),
+    readRepoStack: async (stack) => {
+      const repoStacks = await loadRepoStacks();
+      return repoStacks.find((candidate) => candidate.stack === stack) ?? null;
+    },
+    readAgentCompose: async (host, stack) => {
+      try {
+        const agent = await getAgentClientForHost(host);
+        return await agent.getStackCompose(stack);
+      } catch (err) {
+        if (err instanceof AgentClientError && err.statusCode === 404) return null;
+        throw err;
+      }
+    },
+    triggerDeploy: ({ stack, host, action }) => triggerStackDeploy({ stack, host, action }),
+    deleteTrackedStack: (stack, teardown) => deleteStackFromRepo(stack, teardown),
+    syncRepoToAgent: syncRepoStackToAgentCompose,
+  });
 }
 
 export async function updateStackIconSlug(

--- a/src/routes/stacks.tsx
+++ b/src/routes/stacks.tsx
@@ -2,12 +2,14 @@ import { useState, useEffect } from 'react'
 import { createFileRoute, Outlet, useNavigate } from '@tanstack/react-router'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { CircularProgress, Typography } from '@mui/material'
-import { listStacks, createStack, listManagedHostNames } from '@/data/stacks/functions'
+import { listStacks, createStack, listManagedHostNames, scanDrift, resolveDrift } from '@/data/stacks/functions'
 import { useStackStatus } from '@/hooks/useStackStatus'
+import { useToast } from '@/hooks/toastAtom'
 import CreateStackDialog from '@/components/stacks/CreateStackDialog'
 import StackNav from '@/components/stacks/StackNav'
+import StackDriftSummary from '@/components/stacks/StackDriftSummary'
 import { StackListContext, StackStatusContext } from '@/components/stacks/stacks-context'
-import { STACKS_QUERY_KEY } from '@/lib/constants/stacks-keys'
+import { STACKS_QUERY_KEY, STACK_DRIFT_QUERY_KEY } from '@/lib/constants/stacks-keys'
 
 export const Route = createFileRoute('/stacks')({
   ssr: false,
@@ -19,6 +21,7 @@ const HOST_NAMES_QUERY_KEY = ['managed-host-names']
 function StacksLayout() {
   const queryClient = useQueryClient()
   const navigate = useNavigate()
+  const { showToast } = useToast()
   const [dialogOpen, setDialogOpen] = useState(false)
   const [createError, setCreateError] = useState<string | null>(null)
 
@@ -30,6 +33,15 @@ function StacksLayout() {
   const { data: hosts, isLoading: hostsLoading, error: hostsError } = useQuery({
     queryKey: HOST_NAMES_QUERY_KEY,
     queryFn: () => listManagedHostNames(),
+  })
+
+  const { data: driftReport, isLoading: driftLoading, refetch: refetchDrift } = useQuery({
+    queryKey: STACK_DRIFT_QUERY_KEY,
+    queryFn: () => scanDrift(),
+    // Each scan fans out an HTTP call per docker host. Keep the result warm
+    // across route swaps; users can hit Refresh to force a fresh scan.
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
   })
 
   const isLoading = stacksLoading || hostsLoading
@@ -57,6 +69,21 @@ function StacksLayout() {
     },
   })
 
+  const resolveDriftMutation = useMutation({
+    mutationFn: (input: { host: string; stack: string; resolution: 'trust_repo' | 'trust_agent' | 'remove' }) =>
+      resolveDrift({ data: input }),
+    onSuccess: (result, variables) => {
+      queryClient.invalidateQueries({ queryKey: STACK_DRIFT_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY })
+      showToast(`${variables.stack}: ${result.outcome}`, 'success')
+    },
+    onError: (err) => {
+      showToast(err instanceof Error ? err.message : String(err), 'error')
+    },
+  })
+
+  const driftByKey = new Map((driftReport?.items ?? []).map((item) => [`${item.host}/${item.stack}`, item] as const))
+
   if (error) {
     return (
       <div className="flex items-center justify-center h-64">
@@ -80,8 +107,22 @@ function StacksLayout() {
     <StackListContext value={{ stacks: stacks ?? [], hosts: hosts ?? [], isLoading }}>
       <StackStatusContext value={{ statusMap, deployVersion }}>
         <div className="flex w-full flex-1 min-h-0">
-          <StackNav onCreateClick={() => { setCreateError(null); setDialogOpen(true) }} />
+          <StackNav
+            onCreateClick={() => { setCreateError(null); setDialogOpen(true) }}
+            driftByKey={driftByKey}
+          />
           <div className="flex-1 min-h-0 flex flex-col p-6">
+            <StackDriftSummary
+              report={driftReport}
+              isLoading={driftLoading}
+              isResolving={resolveDriftMutation.isPending}
+              onRefresh={() => { void refetchDrift() }}
+              onResolve={(item, resolution) => resolveDriftMutation.mutate({
+                host: item.host,
+                stack: item.stack,
+                resolution,
+              })}
+            />
             <Outlet />
           </div>
         </div>

--- a/src/routes/stacks/$stackName.tsx
+++ b/src/routes/stacks/$stackName.tsx
@@ -23,6 +23,8 @@ import {
   listManagedHostNames,
   resumeDeploy,
   rejectDeploy,
+  scanDrift,
+  resolveDrift,
 } from '@/data/stacks/functions'
 import ComposeEditorLoader from '@/components/stacks/ComposeEditorLoader'
 import VariablesPanel from '@/components/stacks/VariablesPanel'
@@ -31,7 +33,8 @@ import ContainerList from '@/components/stacks/ContainerList'
 import StackActionBar from '@/components/stacks/StackActionBar'
 import DeleteStackDialog from '@/components/stacks/DeleteStackDialog'
 import StackSettingsDialog from '@/components/stacks/StackSettingsDialog'
-import { STACKS_QUERY_KEY, DEPLOY_HISTORY_QUERY_KEY } from '@/lib/constants/stacks-keys'
+import StackDriftWarning from '@/components/stacks/StackDriftWarning'
+import { STACKS_QUERY_KEY, DEPLOY_HISTORY_QUERY_KEY, STACK_DRIFT_QUERY_KEY } from '@/lib/constants/stacks-keys'
 import { parseVariables } from '@/lib/stacks/parse-variables'
 
 export const Route = createFileRoute('/stacks/$stackName')({
@@ -68,6 +71,13 @@ function StackEditorView() {
     enabled: settingsDialogOpen,
   })
 
+  const { data: driftReport } = useQuery({
+    queryKey: STACK_DRIFT_QUERY_KEY,
+    queryFn: () => scanDrift(),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  })
+
   // Invalidate deploy history when a deploy completes
   useEffect(() => {
     if (deployVersion === 0) return;
@@ -78,6 +88,9 @@ function StackEditorView() {
 
   const statusKey = detail ? `${detail.host}/${detail.name}` : ''
   const containers = statusMap.get(statusKey)?.containers ?? []
+  const driftItem = detail
+    ? (driftReport?.items ?? []).find((item) => item.host === detail.host && item.stack === detail.name) ?? null
+    : null
 
   const deployMutation = useMutation({
     mutationFn: (action: 'deploy' | 'restart' | 'teardown') =>
@@ -156,6 +169,20 @@ function StackEditorView() {
     },
   })
 
+  const resolveDriftMutation = useMutation({
+    mutationFn: (input: { host: string; stack: string; resolution: 'trust_repo' | 'trust_agent' | 'remove' }) =>
+      resolveDrift({ data: input }),
+    onSuccess: (result) => {
+      setDeployMessage({ type: 'success', text: result.outcome })
+      queryClient.invalidateQueries({ queryKey: STACK_DRIFT_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: [...DEPLOY_HISTORY_QUERY_KEY, stackName] })
+    },
+    onError: (err) => {
+      setDeployMessage({ type: 'error', text: err instanceof Error ? err.message : String(err) })
+    },
+  })
+
   if (isLoading) {
     return (
       <div className="flex items-center gap-2 text-sm opacity-70 py-8">
@@ -198,6 +225,16 @@ function StackEditorView() {
               </IconButton>
             </Tooltip>
           </div>
+
+          <StackDriftWarning
+            item={driftItem}
+            isResolving={resolveDriftMutation.isPending}
+            onResolve={(item, resolution) => resolveDriftMutation.mutate({
+              host: item.host,
+              stack: item.stack,
+              resolution,
+            })}
+          />
 
           {/* Compose Editor */}
           <ComposeEditorLoader

--- a/src/types/stacks.ts
+++ b/src/types/stacks.ts
@@ -6,6 +6,49 @@ import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/typ
 export type SyncStatus = 'in_sync' | 'pending' | 'in_progress' | 'failed' | 'unknown';
 
 export type DeployMode = 'auto' | 'manual';
+export type StackDriftKind = 'ghost' | 'untracked' | 'content';
+export type StackDriftResolution = 'trust_repo' | 'trust_agent' | 'remove';
+
+interface StackDriftItemBase {
+  host: string;
+  stack: string;
+  latestDeployStatus: DeployStatus | null;
+}
+
+/**
+ * Drift between the repo's view of a stack and the agent's filesystem.
+ * Discriminated on `kind` so consumers cannot read a hash that isn't present.
+ */
+export type StackDriftItem =
+  | (StackDriftItemBase & { kind: 'ghost'; repoComposeHash: string })
+  | (StackDriftItemBase & { kind: 'untracked'; agentComposeHash: string })
+  | (StackDriftItemBase & { kind: 'content'; repoComposeHash: string; agentComposeHash: string });
+
+export interface StackDriftSummary {
+  total: number;
+  ghost: number;
+  untracked: number;
+  content: number;
+}
+
+export interface StackDriftScanError {
+  host: string;
+  message: string;
+}
+
+export interface StackDriftReport {
+  items: StackDriftItem[];
+  summary: StackDriftSummary;
+  scanErrors: StackDriftScanError[];
+}
+
+/**
+ * Discriminated on `outcome` so the UI doesn't need to non-null-assert
+ * `deployId`/`commitSha` on branches where the other field is the payload.
+ */
+export type StackDriftResolutionResult =
+  | { outcome: 'deploy-queued' | 'teardown-queued'; deployId: number }
+  | { outcome: 'repo-synced' | 'repo-removed'; commitSha: string };
 
 /** Summary of a stack as shown in the list view */
 export interface StackSummary {


### PR DESCRIPTION
## Summary

Adds drift detection between the repo manifest and each Docker host's agent filesystem, plus a resolution flow to trust the repo, trust the agent, or remove on both sides. Closes #95.

- Agent `GET /stacks/inventory` returns per-stack sha256 compose hashes; `GET /stacks/compose?stack=name` returns a single compose file so the server can adopt agent state.
- Classifies items as `ghost` (in repo, not on agent), `untracked` (on agent, not in repo), or `content` (both, hashes differ).
- Re-scans before acting so a stale UI click cannot drive a destructive resolution.
- If the target host errored during the re-scan, surfaces the real message instead of "no drift item found".

## Type safety

- `StackDriftItem` is discriminated on `kind` so consumers cannot read a hash that is not present for that variant.
- `StackDriftResolutionResult` is discriminated on `outcome` so the UI does not non-null-assert `deployId` / `commitSha`.
- `resolveDriftSchema` resolution enum is locked against `StackDriftResolution` via `satisfies`.

## Robustness

- `loadRepoStacks` narrows its catch to `FileNotFoundError`, logs and rethrows everything else. A corrupt git ODB no longer masquerades as "every agent stack is untracked".
- `readAgentCompose` detects 404 via `AgentClientError.statusCode === 404` instead of substring-matching error messages.
- `syncRepoStackToAgentCompose` throws if the target stack already exists in the manifest on a different host (instead of silently rewriting the host assignment). Also drops a spurious `commitSha!` non-null assertion.
- Agent `handleStackInventory` skips individual unreadable compose files (EACCES / EIO / TOCTOU delete / EISDIR) rather than aborting the whole inventory. One bad directory no longer makes the scanner think the host has zero stacks.
- Agent `handleGetStackCompose` catches `readFileSync` failures and returns 500 with a message instead of throwing out of the request handler.
- `scanStackDrift` logs per-host failures server-side in addition to pushing to `scanErrors` for the UI.

## UI

- Drift summary alert on `/stacks` with per-item resolve buttons.
- Drift warning on `/stacks/$stackName` for the stack being viewed.
- Drift marker icon in the side nav for any stack with drift.
- Resolve buttons disabled while a scan or resolve is in flight.
- Drift query kept warm (`staleTime: 60s`, no refetch on focus) so navigating between list and detail does not re-fan-out to every agent.

## Tests

- `stack-drift-service.test.ts`: classification (ghost, untracked, content), scan-error propagation, sort stability, non-docker hosts skipped, all four resolution paths including `teardown-pending` and synchronous `remove`, TOCTOU (item disappears after scan), scan-error during resolve, repo copy disappears before `trust_repo`, agent compose disappears before `trust_agent`.
- `StackDriftSummary.test.tsx`: empty / loading / scan-error / disabled-while-resolving / disabled-while-loading.
- Agent inventory: empty dir, unreadable compose entries skipped, 500 when the stacks dir is not a dir. Compose handler: 400 for invalid stack name, 400 for missing stack query param.
- Existing `agent-client.test.ts`, `functions.test.ts`, `StackNav.test.tsx` extended for the new endpoints, server functions, and drift marker.

## Test pollution fix

`StackNav.test.tsx` used `mock.module('@/components/stacks/stacks-context', ...)` which is process-scoped under bun and leaks into `stacks-context.test.ts`. That was latent on main and got exposed when the new drift tests reordered the suite. The fix renders real `StackListContext` / `StackStatusContext` providers instead.

## Test plan
- [x] `bun run typecheck`
- [x] `cd agent && bun run typecheck`
- [x] `bun test` (2361 pass, 0 fail)
- [x] `cd agent && bun test` (215 pass, 0 fail)
- [ ] Manual: scan with one agent offline, confirm partial report + scanError
- [ ] Manual: trigger each resolution path (trust_repo / trust_agent / remove) on each drift kind

🤖 Generated with [Claude Code](https://claude.com/claude-code)