### PR TITLE
fix: unblock OpenBao init and agent port reachability

### DIFF
--- a/self-hosting/docker-compose.yml
+++ b/self-hosting/docker-compose.yml
@@ -45,6 +45,7 @@ services:
     container_name: homelab-openbao
     environment:
       OPENBAO_TOKEN: ${OPENBAO_TOKEN}
+      BAO_ADDR: "http://127.0.0.1:8200"
     volumes:
       - openbao-data:/openbao/data
       - ./openbao-entrypoint.sh:/openbao/entrypoint.sh:ro

--- a/self-hosting/openbao-entrypoint.sh
+++ b/self-hosting/openbao-entrypoint.sh
@@ -7,7 +7,10 @@ set -e
 
 INIT_FILE="/openbao/data/.init-keys.json"
 ROOT_TOKEN="${OPENBAO_TOKEN:?OPENBAO_TOKEN must be set}"
-BAO_ADDR="http://127.0.0.1:8200"
+# Exported so the `bao` CLI invoked below picks it up; without this it defaults
+# to https://127.0.0.1:8200 and fails the TLS handshake against our HTTP listener,
+# causing `set -e` to kill the script silently mid-init.
+export BAO_ADDR="http://127.0.0.1:8200"
 
 # Start server in background
 bao server -config=/openbao/config/prod.hcl &
@@ -77,7 +80,11 @@ path "secret/metadata/hosts/*" { capabilities = ["read","delete"] }
 path "sys/mounts" { capabilities = ["read"] }
 path "sys/mounts/secret" { capabilities = ["create","update"] }
 POLICY
-  BAO_TOKEN="$BOOTSTRAP_TOKEN" bao policy write "$APP_POLICY_NAME" "$POLICY_FILE" >/dev/null
+  if ! POLICY_OUTPUT=$(BAO_TOKEN="$BOOTSTRAP_TOKEN" bao policy write "$APP_POLICY_NAME" "$POLICY_FILE" 2>&1); then
+    echo "[openbao-init] ERROR: bao policy write failed: $POLICY_OUTPUT"
+    rm -f "$POLICY_FILE"
+    exit 1
+  fi
   rm -f "$POLICY_FILE"
 
   echo "[openbao-init] Creating application token..."

--- a/src/lib/templates/__tests__/__snapshots__/agent-stack-compose.test.ts.snap
+++ b/src/lib/templates/__tests__/__snapshots__/agent-stack-compose.test.ts.snap
@@ -40,6 +40,7 @@ services:
       - ./agent-token:/run/secrets/agent_token:ro
     networks:
       - agent-internal
+      - agent-public
     depends_on:
       - socket-proxy
     labels:
@@ -62,6 +63,8 @@ networks:
   agent-internal:
     driver: bridge
     internal: true
+  agent-public:
+    driver: bridge
 "
 `;
 
@@ -148,6 +151,7 @@ services:
       - \${DOCKER_GID}
     networks:
       - agent-internal
+      - agent-public
     depends_on:
       - socket-proxy
     labels:
@@ -170,6 +174,8 @@ networks:
   agent-internal:
     driver: bridge
     internal: true
+  agent-public:
+    driver: bridge
 "
 `;
 

--- a/src/lib/templates/__tests__/agent-stack-compose.test.ts
+++ b/src/lib/templates/__tests__/agent-stack-compose.test.ts
@@ -52,12 +52,17 @@ describe('generateAgentStackCompose', () => {
     expect(result).toMatchSnapshot();
   });
 
-  it('agent-internal network declared only when docker capability is enabled', () => {
+  it('agent networks declared only when docker capability is enabled', () => {
     const dockerResult = generateAgentStackCompose(dockerOnlyConfig);
     const dockerParsed = parseYaml(dockerResult);
     expect(dockerParsed.networks['agent-internal']).toEqual({
       driver: 'bridge',
       internal: true,
+    });
+    // agent-public must be a non-internal bridge: an internal-only network
+    // breaks the published port (host->container DNAT has no path).
+    expect(dockerParsed.networks['agent-public']).toEqual({
+      driver: 'bridge',
     });
 
     const zfsResult = generateAgentStackCompose(zfsOnlyConfig);
@@ -158,7 +163,7 @@ describe('generateAgentStackCompose', () => {
     }
   });
 
-  it('agent-internal network only present when docker capability', () => {
+  it('agent attached to both internal and public networks when docker capability', () => {
     const zfsResult = generateAgentStackCompose(zfsOnlyConfig);
     const zfsParsed = parseYaml(zfsResult);
     expect(zfsParsed.services.agent.networks).toBeUndefined();
@@ -166,6 +171,7 @@ describe('generateAgentStackCompose', () => {
     const dockerResult = generateAgentStackCompose(dockerOnlyConfig);
     const dockerParsed = parseYaml(dockerResult);
     expect(dockerParsed.services.agent.networks).toContain('agent-internal');
+    expect(dockerParsed.services.agent.networks).toContain('agent-public');
   });
 
   it('ZFS-only: top-level networks key is absent', () => {

--- a/src/lib/templates/agent-stack-compose.ts
+++ b/src/lib/templates/agent-stack-compose.ts
@@ -28,11 +28,6 @@ export function generateAgentStackCompose(config: AgentStackConfig): string {
   const doc: Record<string, unknown> = { services };
 
   if (docker) {
-    // agent-internal isolates socket-proxy so the Docker socket is only reachable
-    // from agent containers. agent-public is the bridge that lets the host's
-    // published port actually deliver inbound traffic to the agent: an
-    // internal-only network has no external routing, so port publishing on a
-    // service attached only to it silently fails.
     doc['networks'] = {
       'agent-internal': {
         driver: 'bridge',

--- a/src/lib/templates/agent-stack-compose.ts
+++ b/src/lib/templates/agent-stack-compose.ts
@@ -28,10 +28,18 @@ export function generateAgentStackCompose(config: AgentStackConfig): string {
   const doc: Record<string, unknown> = { services };
 
   if (docker) {
+    // agent-internal isolates socket-proxy so the Docker socket is only reachable
+    // from agent containers. agent-public is the bridge that lets the host's
+    // published port actually deliver inbound traffic to the agent: an
+    // internal-only network has no external routing, so port publishing on a
+    // service attached only to it silently fails.
     doc['networks'] = {
       'agent-internal': {
         driver: 'bridge',
         internal: true,
+      },
+      'agent-public': {
+        driver: 'bridge',
       },
     };
   }
@@ -140,7 +148,7 @@ function buildAgent(config: AgentStackConfig): Record<string, unknown> {
   }
 
   if (docker) {
-    agent['networks'] = ['agent-internal'];
+    agent['networks'] = ['agent-internal', 'agent-public'];
     agent['depends_on'] = ['socket-proxy'];
   }
 


### PR DESCRIPTION
## Summary

Three independent bugs that blocked the self-hosted setup path. Found while walking through Add Host on a fresh install.

### 1. OpenBao init fails silently (`self-hosting/docker-compose.yml`, `self-hosting/openbao-entrypoint.sh`)

The openbao service was missing \`BAO_ADDR\` in its environment. The entrypoint script invokes \`bao policy write\` to install the \`hlm-app\` policy; the \`bao\` CLI without \`BAO_ADDR\` defaults to \`https://127.0.0.1:8200\` and fails the TLS handshake against our HTTP listener. With \`set -e\`, the script dies silently after \`Unsealing...\` and never reaches \`Creating application token...\`.

The volume is left in an unsealed-but-no-app-token state. On every subsequent boot the entrypoint takes the \`Existing data: unsealing...\` branch, which doesn't recreate the token. The dashboard then gets HTTP 403 / permission denied on every OpenBao call (e.g. \`OpenBao GET_MOUNTS failed for sys/mounts\`).

Fix:
- Add \`BAO_ADDR: \"http://127.0.0.1:8200\"\` to the openbao service env (defense in depth, also helps anyone running \`bao\` manually inside the container).
- \`export BAO_ADDR\` in the entrypoint so subprocesses inherit it.
- Capture stderr from \`bao policy write\` and log it under \`[openbao-init] ERROR:\` instead of letting the script die quietly.

### 2. Generated agent compose has unreachable port (`src/lib/templates/agent-stack-compose.ts`)

The wizard-generated compose put the agent on \`agent-internal\` only. That network has \`internal: true\`, which removes external routing on the bridge. Even though \`ports: [9090:9090]\` is declared, the host->container DNAT path doesn't work and the dashboard's health check fails with \"Unable to connect.\"

Fix: define a non-internal \`agent-public\` bridge and attach the agent to both networks. \`socket-proxy\` stays on \`agent-internal\` alone, preserving Docker socket isolation.

### 3. Tests + snapshots updated for the new network

\`agent-stack-compose.test.ts\` now asserts both \`agent-internal\` and \`agent-public\` are declared and that the agent is on both. Snapshots regenerated.

## Test plan

- [x] \`bun run typecheck\`
- [x] \`bun test src/lib/templates/__tests__/agent-stack-compose.test.ts\` (24 pass)
- [x] \`bun test\` full suite (one pre-existing flake in \`stacks-context.test.ts\` from test pollution; unrelated and passes in isolation)
- [ ] Manual: deploy from scratch on a clean host, confirm openbao logs show all four \`[openbao-init]\` lines and the wizard's Add Host check passes against \`http://host.docker.internal:9090\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and output visibility in the self-hosting initialization process with explicit failure detection and reporting.

* **Improvements**
  * Updated Docker configuration to ensure proper OpenBao service address resolution in self-hosted environments.
  * Enhanced agent service network configuration with dual network support for improved traffic management and inbound connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->