### PR TITLE
fix(local-dev): resolve agent JWT mismatch on fresh start, allow stack deploys

### DIFF
--- a/agent/src/__tests__/middleware.test.ts
+++ b/agent/src/__tests__/middleware.test.ts
@@ -86,4 +86,17 @@ describe('authenticateRequest (JWT)', () => {
     );
     expect(result?.status).toBe(401);
   });
+
+  it('requires auth on /auth/verify (not bypassed like /health)', async () => {
+    const { trusted, sign } = await makeAuth();
+    const noAuth = await authenticateRequest(new Headers(), trusted, '/auth/verify');
+    expect(noAuth?.status).toBe(401);
+    const jwt = await sign();
+    const withAuth = await authenticateRequest(
+      new Headers({ Authorization: `Bearer ${jwt}` }),
+      trusted,
+      '/auth/verify',
+    );
+    expect(withAuth).toBeNull();
+  });
 });

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -36,10 +36,18 @@ if (AGENT_TRUSTED_PUBKEY_FILE) {
       console.error(`AGENT_TRUSTED_PUBKEY_FILE not found after ${POLL_TIMEOUT_MS / 1000}s: ${AGENT_TRUSTED_PUBKEY_FILE}`);
       process.exit(1);
     }
+    if (waited > 0 && waited % 10_000 === 0) {
+      console.info(`Still waiting for AGENT_TRUSTED_PUBKEY_FILE (${waited / 1000}s elapsed)...`);
+    }
     await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
     waited += POLL_INTERVAL_MS;
   }
-  trustedPubkeyJson = (await file.text()).trim();
+  try {
+    trustedPubkeyJson = (await file.text()).trim();
+  } catch (err) {
+    console.error(`Failed to read AGENT_TRUSTED_PUBKEY_FILE '${AGENT_TRUSTED_PUBKEY_FILE}': ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
 } else if (AGENT_TRUSTED_PUBKEY_ENV) {
   trustedPubkeyJson = AGENT_TRUSTED_PUBKEY_ENV.trim();
 } else {

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -27,9 +27,17 @@ const DOCKER_HOST = process.env.DOCKER_HOST;
 let trustedPubkeyJson: string;
 if (AGENT_TRUSTED_PUBKEY_FILE) {
   const file = Bun.file(AGENT_TRUSTED_PUBKEY_FILE);
-  if (!(await file.exists())) {
-    console.error(`AGENT_TRUSTED_PUBKEY_FILE not found: ${AGENT_TRUSTED_PUBKEY_FILE}`);
-    process.exit(1);
+  const POLL_INTERVAL_MS = 1000;
+  const POLL_TIMEOUT_MS = 60_000;
+  let waited = 0;
+  while (!(await file.exists())) {
+    if (waited === 0) console.info(`Waiting for AGENT_TRUSTED_PUBKEY_FILE: ${AGENT_TRUSTED_PUBKEY_FILE}`);
+    if (waited >= POLL_TIMEOUT_MS) {
+      console.error(`AGENT_TRUSTED_PUBKEY_FILE not found after ${POLL_TIMEOUT_MS / 1000}s: ${AGENT_TRUSTED_PUBKEY_FILE}`);
+      process.exit(1);
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    waited += POLL_INTERVAL_MS;
   }
   trustedPubkeyJson = (await file.text()).trim();
 } else if (AGENT_TRUSTED_PUBKEY_ENV) {

--- a/agent/src/routes/stacks.ts
+++ b/agent/src/routes/stacks.ts
@@ -212,10 +212,12 @@ export async function handleStackDeploy(
       if (configResult.exitCode === 0 && configResult.stdout.trim()) {
         resolvedContent = configResult.stdout;
       }
-    } catch {
-      // Non-fatal: fall back to raw content
+    } catch (err) {
+      console.error(`[forceRecreate] Failed to resolve compose variables for ${parsed.stack}, falling back to raw content:`, err instanceof Error ? err.message : String(err));
     } finally {
-      try { unlinkSync(tmpFile); } catch { /* ignore */ }
+      try { unlinkSync(tmpFile); } catch (unlinkErr) {
+        console.info(`[forceRecreate] Failed to remove tmp file ${tmpFile}:`, unlinkErr instanceof Error ? unlinkErr.message : String(unlinkErr));
+      }
     }
     const namedContainers = parseContainerNames(resolvedContent);
     for (const name of namedContainers) {
@@ -227,8 +229,10 @@ export async function handleStackDeploy(
           stderr: 'pipe',
           env: composeEnv,
         }, 10_000);
-      } catch {
-        // Non-fatal: container may not exist
+      } catch (err) {
+        // spawnWithTimeout only throws on spawn failure (binary missing, fork error),
+        // not on non-zero docker exit codes — those are in SpawnResult.exitCode.
+        console.error(`[forceRecreate] Failed to spawn docker rm for '${name}':`, err instanceof Error ? err.message : String(err));
       }
     }
   }

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -130,6 +130,8 @@ services:
       ALLOW_STOP: 1
       ALLOW_RESTARTS: 1
       EXEC: 1
+      POST: 1
+      DELETE: 1
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:2375/version"]
       interval: 10s

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev:local:down": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml down",
     "dev:local:restart": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml up -d --force-recreate",
     "dev:local:rebuild": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml down && docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml build --no-cache && docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml up -d",
-    "dev:local:wipe": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml down -v",
+    "dev:local:wipe": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml down -v && rm -f data/dev-agent-pubkey.json",
     "dev:local:logs": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml logs -f",
     "dev:local:logs:worker": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml logs -f worker",
     "dev:local:logs:db": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml logs -f postgres",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev:local:down": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml down",
     "dev:local:restart": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml up -d --force-recreate",
     "dev:local:rebuild": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml down && docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml build --no-cache && docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml up -d",
-    "dev:local:wipe": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml down -v && rm -f data/dev-agent-pubkey.json",
+    "dev:local:wipe": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml down -v; rm -f data/dev-agent-pubkey.json",
     "dev:local:logs": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml logs -f",
     "dev:local:logs:worker": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml logs -f worker",
     "dev:local:logs:db": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml logs -f postgres",

--- a/src/components/stacks/ComposeEditor.tsx
+++ b/src/components/stacks/ComposeEditor.tsx
@@ -1,38 +1,29 @@
-import { useCallback, useEffect, useRef, useState, type PointerEvent as ReactPointerEvent } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Button, Paper, Typography, CircularProgress } from '@mui/material';
 import { Save } from 'lucide-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import Editor from '@monaco-editor/react';
 import type { editor } from 'monaco-editor';
 import { saveComposeFile } from '@/data/stacks/functions';
-import { parseVariables } from '@/lib/stacks/parse-variables';
-import VariablesPanel from '@/components/stacks/VariablesPanel';
-
-const MAX_PANEL_WIDTH = 600;
-const MIN_PANEL_WIDTH = 80;
-const MIN_EDITOR_WIDTH = 200;
 
 interface ComposeEditorProps {
   stackName: string;
   content: string;
-  variables: string[];
   _monacoLoader?: () => Promise<unknown>;
   _saveCompose?: typeof saveComposeFile;
 }
 
-export default function ComposeEditor({ stackName, content, variables: initialVariables, _monacoLoader, _saveCompose }: Readonly<ComposeEditorProps>) {
+export default function ComposeEditor({ stackName, content, _monacoLoader, _saveCompose }: Readonly<ComposeEditorProps>) {
   const [monacoReady, setMonacoReady] = useState(false);
   const [monacoLoadFailed, setMonacoLoadFailed] = useState(false);
   const [editorContent, setEditorContent] = useState(content);
-  const [detectedVars, setDetectedVars] = useState<string[]>(initialVariables);
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const queryClient = useQueryClient();
 
   /** Sync editor state when the parent provides new content (e.g., switching stacks) */
   useEffect(() => {
     setEditorContent(content);
-    setDetectedVars(initialVariables);
-  }, [stackName, content, initialVariables]);
+  }, [stackName, content]);
 
   // Monaco setup (local workers + YAML support) is in a separate file that uses
   // Vite's ?worker imports. Must complete before Editor mounts to avoid
@@ -63,34 +54,6 @@ export default function ComposeEditor({ stackName, content, variables: initialVa
 
   const handleChange = useCallback((newContent = '') => {
     setEditorContent(newContent);
-    setDetectedVars(parseVariables(newContent));
-  }, []);
-
-  const [panelWidth, setPanelWidth] = useState(280);
-  const panelWidthRef = useRef(panelWidth);
-  panelWidthRef.current = panelWidth;
-
-  const handleDragStart = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const startX = e.clientX;
-    const startWidth = panelWidthRef.current;
-    const target = e.currentTarget;
-    target.setPointerCapture(e.pointerId);
-
-    const onMove = (ev: globalThis.PointerEvent) => {
-      const delta = startX - ev.clientX;
-      const containerWidth = target.parentElement?.clientWidth ?? (MAX_PANEL_WIDTH + MIN_EDITOR_WIDTH);
-      const effectiveMinEditorWidth = Math.min(MIN_EDITOR_WIDTH, Math.max(0, containerWidth - MIN_PANEL_WIDTH));
-      setPanelWidth(Math.min(containerWidth - effectiveMinEditorWidth, Math.max(MIN_PANEL_WIDTH, startWidth + delta)));
-    };
-    const onUp = () => {
-      target.removeEventListener('pointermove', onMove);
-      target.removeEventListener('pointerup', onUp);
-      target.removeEventListener('pointercancel', onUp);
-    };
-    target.addEventListener('pointermove', onMove);
-    target.addEventListener('pointerup', onUp);
-    target.addEventListener('pointercancel', onUp);
   }, []);
 
   // Reads the current theme on each render. Theme toggles trigger re-renders
@@ -122,81 +85,45 @@ export default function ComposeEditor({ stackName, content, variables: initialVa
         </Button>
       </div>
 
-      {/* Editor + resizable variables panel: use calc() so Monaco gets an explicit width */}
-      <div className="relative min-h-[400px]">
-        <div
-          className="absolute inset-y-0 left-0 overflow-hidden"
-          style={{ right: panelWidth + 4 }}
-        >
-          {monacoLoadFailed ? (
-            <div className="flex items-center justify-center h-[400px]">
-              <Typography variant="body2" className="opacity-50">
-                Failed to load editor. Please refresh the page.
-              </Typography>
-            </div>
-          ) : monacoReady ? (
-            <Editor
-              height="400px"
-              language="yaml"
-              theme={isDark ? 'vs-dark' : 'light'}
-              value={editorContent}
-              onChange={handleChange}
-              onMount={handleEditorMount}
-              options={{
-                minimap: { enabled: false },
-                fontSize: 13,
-                lineNumbers: 'on',
-                scrollBeyondLastLine: false,
-                wordWrap: 'on',
-                tabSize: 2,
-                automaticLayout: true,
-                padding: { top: 8, bottom: 8 },
-                renderLineHighlight: 'line',
-                fixedOverflowWidgets: true,
-              }}
-              loading={
-                <div className="flex items-center justify-center h-full">
-                  <CircularProgress size={24} />
-                </div>
-              }
-            />
-          ) : (
-            <div className="flex items-center justify-center h-[400px]">
-              <CircularProgress size={24} />
-            </div>
-          )}
-        </div>
-
-        {/* Drag handle */}
-        <div
-          className="absolute inset-y-0 w-1 cursor-col-resize hover:bg-[var(--mui-palette-primary-main)]/30 active:bg-[var(--mui-palette-primary-main)]/50 transition-colors z-10 touch-none"
-          style={{ right: panelWidth }}
-          tabIndex={0}
-          role="separator"
-          aria-orientation="vertical"
-          aria-valuemin={MIN_PANEL_WIDTH}
-          aria-valuemax={MAX_PANEL_WIDTH}
-          aria-valuenow={panelWidth}
-          onPointerDown={handleDragStart}
-          onKeyDown={(e) => {
-            const step = 20;
-            if (e.key === 'ArrowLeft') {
-              e.preventDefault();
-              setPanelWidth(w => Math.min(MAX_PANEL_WIDTH, w + step));
-            } else if (e.key === 'ArrowRight') {
-              e.preventDefault();
-              setPanelWidth(w => Math.max(MIN_PANEL_WIDTH, w - step));
+      {/* Editor */}
+      <div className="min-h-[400px]">
+        {monacoLoadFailed ? (
+          <div className="flex items-center justify-center h-[400px]">
+            <Typography variant="body2" className="opacity-50">
+              Failed to load editor. Please refresh the page.
+            </Typography>
+          </div>
+        ) : monacoReady ? (
+          <Editor
+            height="400px"
+            language="yaml"
+            theme={isDark ? 'vs-dark' : 'light'}
+            value={editorContent}
+            onChange={handleChange}
+            onMount={handleEditorMount}
+            options={{
+              minimap: { enabled: false },
+              fontSize: 13,
+              lineNumbers: 'on',
+              scrollBeyondLastLine: false,
+              wordWrap: 'on',
+              tabSize: 2,
+              automaticLayout: true,
+              padding: { top: 8, bottom: 8 },
+              renderLineHighlight: 'line',
+              fixedOverflowWidgets: true,
+            }}
+            loading={
+              <div className="flex items-center justify-center h-full">
+                <CircularProgress size={24} />
+              </div>
             }
-          }}
-        />
-
-        {/* Variables side panel */}
-        <div
-          className="absolute inset-y-0 right-0 border-l border-[var(--mui-palette-divider)] p-3 overflow-y-auto"
-          style={{ width: panelWidth }}
-        >
-          <VariablesPanel stackName={stackName} composeVariables={detectedVars} />
-        </div>
+          />
+        ) : (
+          <div className="flex items-center justify-center h-[400px]">
+            <CircularProgress size={24} />
+          </div>
+        )}
       </div>
     </Paper>
   );

--- a/src/components/stacks/ComposeEditorLoader.tsx
+++ b/src/components/stacks/ComposeEditorLoader.tsx
@@ -6,7 +6,6 @@ const ComposeEditor = lazy(() => import('@/components/stacks/ComposeEditor'));
 interface ComposeEditorLoaderProps {
   stackName: string;
   content: string;
-  variables: string[];
 }
 
 export default function ComposeEditorLoader(props: Readonly<ComposeEditorLoaderProps>) {

--- a/src/components/stacks/__tests__/ComposeEditor-fallback.test.tsx
+++ b/src/components/stacks/__tests__/ComposeEditor-fallback.test.tsx
@@ -21,7 +21,6 @@ describe('ComposeEditor monaco load failure', () => {
           <ComposeEditor
             stackName="test-stack"
             content="image: nginx"
-            variables={[]}
             _monacoLoader={() => Promise.reject(new Error('Monaco load failed'))}
           />
         </QueryClientProvider>,

--- a/src/components/stacks/__tests__/ComposeEditor.test.tsx
+++ b/src/components/stacks/__tests__/ComposeEditor.test.tsx
@@ -59,12 +59,11 @@ function createWrapper() {
   };
 }
 
-async function renderComposeEditor(props?: Partial<{ stackName: string; content: string; variables: string[] }>) {
+async function renderComposeEditor(props?: Partial<{ stackName: string; content: string }>) {
   const { default: ComposeEditor } = await import('../ComposeEditor');
   const defaultProps = {
     stackName: 'test-stack',
     content: 'image: nginx:latest',
-    variables: [],
     ...props,
   };
   const result = render(<ComposeEditor {...defaultProps} _saveCompose={saveComposeStub} />, { wrapper: createWrapper() });
@@ -199,7 +198,7 @@ describe('ComposeEditor component', () => {
     const { default: ComposeEditor } = await import('../ComposeEditor');
     render(
       <QueryClientProvider client={queryClient}>
-        <ComposeEditor stackName="test-stack" content="image: nginx" variables={[]} _saveCompose={saveComposeStub} />
+        <ComposeEditor stackName="test-stack" content="image: nginx" _saveCompose={saveComposeStub} />
       </QueryClientProvider>,
     );
     await waitFor(() => expect(screen.getByTestId('mock-editor')).toBeDefined());

--- a/src/components/stacks/__tests__/ComposeEditor.test.tsx
+++ b/src/components/stacks/__tests__/ComposeEditor.test.tsx
@@ -16,7 +16,7 @@ const saveComposeStub = mockSaveCompose as unknown as typeof saveComposeFile;
  * Monaco Editor cannot render in Happy-DOM (CDN script loading is blocked).
  * We mock only @monaco-editor/react (a narrow, component-specific dependency)
  * to provide a simple textarea stand-in. This lets us test the toolbar,
- * save button, VariablesPanel integration, and dirty-state logic.
+ * save button and dirty-state logic.
  *
  * monaco-setup uses Vite ?worker imports that Bun can't resolve, so it must be
  * mocked before ComposeEditor is imported.

--- a/src/routes/stacks/$stackName.tsx
+++ b/src/routes/stacks/$stackName.tsx
@@ -203,7 +203,6 @@ function StackEditorView() {
           <ComposeEditorLoader
             stackName={stackName}
             content={detail.composeContent}
-            variables={composeVars}
           />
 
           {/* Panel Toggle */}


### PR DESCRIPTION
## Summary

- **Agent startup polling**: on a fresh start (after `dev:local:wipe`), the agent now waits up to 60s for `AGENT_TRUSTED_PUBKEY_FILE` to appear instead of failing immediately or loading a stale key left over from the wiped DB
- **Wipe cleanup**: `dev:local:wipe` now also deletes `data/dev-agent-pubkey.json` so the next startup generates a fresh keypair that matches the agent
- **Socket proxy permissions**: added `POST: 1` and `DELETE: 1` to the local socket proxy so `docker compose` can pull images and remove containers during stack deploys and teardowns
- **Stacks UI**: removed the redundant variables side panel from `ComposeEditor` (the Secrets tab below covers this); editor now fills the full width

## Test plan

- [ ] Run `bun run dev:local:wipe` then `bun run dev:local:up --profile management` and confirm agent connects and containers appear without 401 errors
- [ ] Deploy a stack with an image pull and confirm no 403 from the socket proxy
- [ ] Confirm the Secrets tab is the single place to manage stack variables

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent startup now polls for trusted public key file availability with timeout handling and improved error reporting.

* **Refactor**
  * Simplified compose editor interface.

* **Chores**
  * Updated local development configuration and cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->