### PR TITLE
docs: fix inaccuracies found in doc audit

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,15 +26,6 @@ WORKER_COLLECTION_INTERVAL_MS="1000"
 # Docker monitoring: configure hosts via Settings → Managed Hosts in the web UI
 # (deploy the agent container on each host, then register the agent URL + token).
 
-# ZFS Host (supports multiple: _1, _2, _3)
-# ZFS_HOST_1=""
-# ZFS_HOST_PORT_1="22"
-# ZFS_HOST_NAME_1=""
-# ZFS_HOST_USER_1=""
-# ZFS_HOST_PASSWORD_1=""
-# ZFS_HOST_KEY_PATH_1=""
-# ZFS_HOST_KEY_PASSPHRASE_1=""
-
 # Proxmox VE API
 # Token format: USER@REALM!TOKENID (e.g., root@pam!monitoring)
 # PROXMOX_HOST=""

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ bun run dev:local:wipe        # Stop Docker services and delete volumes
 bun run dev:local:logs        # Tail all Docker service logs
 bun run dev:local:logs:worker # Worker logs only
 bun run dev:local:logs:agent  # Agent logs only
+bun run dev:local:logs:db     # Postgres logs only
 
 # Setup
 bun run setup                 # Install homelab-manager and agent
@@ -39,7 +40,7 @@ bun run setup                 # Install homelab-manager and agent
 # Testing & Build (homelab-manager only)
 bun run typecheck             # TypeScript type checking
 bun test --isolate            # Run all tests (--isolate required: module mocks leak across files without it)
-bun run test                  # Same as above + coverage enforcement (95%/99%)
+bun run test                  # Same as above + coverage enforcement (95%/98%)
 bun test --isolate --watch    # Run tests in watch mode
 bun build                     # Production build (runs typecheck first)
 bun run build:demo            # Demo build (no server required, mock data)
@@ -49,7 +50,7 @@ bun icons:download            # Download dashboard icons from homarr-labs/dashbo
 # Agent-only
 bun run typecheck:agent       # Agent type checking
 bun run test:agent            # Agent tests (no coverage)
-bun run test:coverage:agent   # Agent tests + coverage enforcement (95%/99%)
+bun run test:coverage:agent   # Agent tests + coverage enforcement (95%/98%)
 
 # Combined (homelab-manager + agent)
 bun run typecheck:all         # Typecheck both
@@ -60,12 +61,12 @@ bun run test:coverage:all     # Run tests in both with coverage enforcement
 ## Critical Rules
 
 1. **Styling**: TailwindCSS ONLY. Never use MUI `sx` props or create `.css` files (exceptions: `App.css`, `theme.ts`). Inline `style` only when Tailwind cannot express the value (virtualizer positioning, dynamic indent, computed transforms). Never use hardcoded hex colors - use theme CSS variables. To override MUI defaults, use Tailwind's `!` prefix: `!bg-[var(--mui-palette-background-chartBg)]`. Prefer MUI's built-in component behavior (hover effects, transitions) over custom overrides unless there's a specific design requirement.
-2. **Imports**: Always use `@/` for src files. Relative paths only within `__tests__/`. Never mix both in one file (except tests).
+2. **Imports**: Always use `@/` for src files. In test files: use `@/` for imports from outside `__tests__/`, relative paths for imports within the same `__tests__/` directory. Never mix `@/` and relative paths in non-test files.
 3. **Server Functions**: All server logic via `createServerFn()` + middleware injection. Never create clients directly in server functions.
 4. **Dynamic Imports**: ALWAYS use `await import()` for server-only modules (pg, subscription-service, database-client) inside SSE handlers and server functions. Static imports leak into the client bundle and break the app with `node:async_hooks` errors.
 5. **SSE Pattern**: TanStack Router server routes (`src/routes/api/`) → `useTimeSeriesStream` hook → shared `DataTable` (CSS Grid + conditional `useVirtualizer`). Use div-based rows (not `<table>/<tr>/<td>`). Server handles client disconnect via `request.signal`. Never use TanStack Start streaming server functions for real-time data.
 6. **File Creation**: PREFER editing existing files over creating new ones.
-7. **Testing**: Tests in `__tests__/` folders co-located with source. Test utilities in `src/lib/test/` (NOT in `__tests__/`). Use `bun:test` imports. 95% functions / 99% lines coverage enforced. Test scripts run with `bun test --isolate`, so each file gets a fresh global object and `mock.module()` calls do not leak across files. Within a single file, mocks still affect every sibling test, so prefer `renderHook`, dependency injection, or narrow-scope `spyOn` when only some tests need the override. For server functions that use dynamic `await import()` inside `createServerFn` handlers, prefer mocking the underlying service module (e.g. `@/lib/stacks/stack-service`) over the barrel (`@/data/stacks/functions`) - fewer mocked exports to keep in sync as the barrel grows. When tests need `setTimeout` to fire immediately (retry loops, health checks), spy on `globalThis.setTimeout` in `beforeEach`/`afterEach` at the appropriate `describe` scope.
+7. **Testing**: Tests in `__tests__/` folders co-located with source. Test utilities in `src/lib/test/` (NOT in `__tests__/`). Use `bun:test` imports. 95% functions / 98% lines coverage enforced. Test scripts run with `bun test --isolate`, so each file gets a fresh global object and `mock.module()` calls do not leak across files. Within a single file, mocks still affect every sibling test, so prefer `renderHook`, dependency injection, or narrow-scope `spyOn` when only some tests need the override. For server functions that use dynamic `await import()` inside `createServerFn` handlers, prefer mocking the underlying service module (e.g. `@/lib/stacks/stack-service`) over the barrel (`@/data/stacks/functions`) - fewer mocked exports to keep in sync as the barrel grows. When tests need `setTimeout` to fire immediately (retry loops, health checks), spy on `globalThis.setTimeout` in `beforeEach`/`afterEach` at the appropriate `describe` scope.
 8. **Logging**: Be purposeful with console methods. Use `console.error` for actual errors, `console.info` for operational messages (startup, shutdown), and `console.log` sparingly for temporary debugging only (do not commit). No drive-by `console.log` statements in committed code.
 9. **Routing**: Never edit `routeTree.gen.ts` (auto-generated). `AppShell` renders in root layout (`__root.tsx`) - never wrap individual routes with it. All routes use `ssr: false`. QueryClient is a singleton in `AppShell.tsx` - never create per-route.
 10. **Entity IDs**: Always use entity IDs with host prefix (e.g., `server1/tank`, `192.168.1.10/abc123`) for state keys and uniqueness checks. Never use display names - they collide across hosts.
@@ -108,7 +109,7 @@ Browser → Server (SSE) ← StatsPollService (1s poll) → Query DB → Broadca
 
 Two factories in `src/lib/sse/` own the shared boilerplate (`ReadableStream`, heartbeat, `closed` flag, abort/teardown):
 
-- **`createStatsSseHandler(source)`**: for `docker-stats`, `zfs-stats`, `proxmox-stats`. Wraps the three-arg `statsPollService.subscribe(source, sendData, sendError)` and emits an `event: stats_error` frame when the subscribe path fails.
+- **`createStatsSseHandler(source)`**: source values are `'docker'`, `'zfs'`, `'proxmox'` (type `StatsSource`; the corresponding route files are `/api/docker-stats`, `/api/zfs-stats`, `/api/proxmox-stats`). Wraps the three-arg `statsPollService.subscribe(source, sendData, sendError)` and emits an `event: stats_error` frame when the subscribe path fails.
 - **`createBroadcastSseHandler({ loadSubscribe, serialize })`**: for single-arg subscribe-based services (`docker-inventory`, `stack-status`, `settings`). Caller owns the full SSE frame via `serialize`, so named events (`event: foo`) are possible when needed.
 
 Server-only imports must happen inside the factory callbacks:
@@ -134,7 +135,7 @@ Unified table using TanStack Table v8 (headless) + CSS Grid rows. Key files: `Da
 
 **Mobile**: `ResizeObserver` on DataTable container detects <1024px (not media queries). Sticky toolbar shows metric group toggles (CPU/RAM, Disk I/O, Net I/O), one group at a time.
 
-**Scroll**: Table fills remaining viewport height (`flex-1 min-h-0`). `scrollbar-gutter: stable` on the DataTable scroll container (not `html`). Sticky header inside scroll container tracks horizontal scroll.
+**Scroll**: Table fills remaining viewport height (`flex-1 min-h-0`). `scrollbar-gutter: stable` on the DataTable scroll container when virtualized or `maxHeight` is set (not applied unconditionally; `html` has `scrollbar-gutter: auto`). Sticky header inside scroll container tracks horizontal scroll.
 
 ### Key Patterns
 
@@ -153,7 +154,7 @@ The agent is intentionally NOT a workspace member of the homelab-manager `packag
 
 ### Deploy Pipeline (`src/lib/deploy/`)
 
-Trigger-agnostic orchestration: `DeployRequest` → validate → resolve secrets → dispatch to agent → record result. Uses `GitTriggerBuilder` (post-receive) or `UITriggerBuilder` (UI actions). Concurrency enforced via PostgreSQL partial unique index. Stuck deploys recovered on startup and via `DeployWatchdog` (default 10-min threshold) so a crashed process can't leave `in_flight` rows stranded.
+Trigger-agnostic orchestration: `DeployRequest` → validate → resolve secrets → dispatch to agent → record result. Uses `GitTriggerBuilder` (post-receive) or `UITriggerBuilder` (UI actions). Concurrency enforced via PostgreSQL partial unique index. Stuck deploys recovered on startup and via `DeployWatchdog` (default 10-min threshold) so a crashed process can't leave `in_progress` rows stranded.
 
 ### Git Management (`src/lib/git/`)
 
@@ -173,7 +174,7 @@ Non-obvious pitfalls from past sessions (not restated from rules above):
 4. **PostgreSQL extended query protocol**: Parameterized queries use extended protocol which doesn't support multi-statement. INSERT and NOTIFY must be separate `client.query()` calls.
 5. **React.memo with streaming data**: Incorrect memoization freezes streaming updates. Be cautious with `React.memo` on components receiving `latestByEntity` or `rows`.
 6. **Conditional rendering belongs in the parent**: When a component only renders for a subset of rows/items (e.g., container rows but not host rows), guard at the call site (`if (!row.container) return null` in the column `cell` function) rather than adding an early return inside the component. This makes it immediately clear from reading the parent what is always rendered vs. conditionally rendered, and avoids calling hooks conditionally inside the child.
-7. **Layout shift in metric columns**: Dynamic number formatting (KB→MB, varying decimals) causes width instability. Use minimum widths with `ch` units in MetricValue.
+7. **Layout shift in metric columns**: Dynamic number formatting (KB→MB, varying decimals) causes width instability. Use minimum widths with `ch` units in `MetricCell`.
 8. **Fix root causes, not symptoms**: Investigate actual bugs rather than adding caching/memoization workarounds. Past band-aid fixes were frequently reverted.
 9. **Icon attribution**: Dashboard icons from `homarr-labs/dashboard-icons` (NOT the old `walkxcode` name).
 10. **Parallel agent worktree isolation**: When dispatching multiple agents into git worktrees, each agent must `cd "$WORKTREE_PATH"` before any file writes and use relative paths only. Never run `git stash` inside a worktree while other worktrees are active: `.git/refs/stash` is shared across all worktrees, so a stash created in one worktree can be popped (and destroyed) by an agent in another.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -150,7 +150,7 @@ Hosts are registered via the Settings UI and stored in the `managed_hosts` datab
 - `resolveAgentUrl()`: rewrites localhost agent URLs to Docker-internal hostnames via `WORKER_LOCALHOST_AGENT` env var
 
 **Managed-host collector lifecycle** (`src/worker/host-collector-manager.ts`):
-- `HostCollectorManager`: owns one `AsyncDisposableStack` per registered host, each containing `AgentStatsCollector`, `ContainerInventoryCollector`, and/or `ZFSCollector` depending on the host's capabilities. `reconcile()` is the sole mutator -- it adds collectors for new hosts, disposes them for removed hosts, and recreates them when a host's `agentUrl` or capabilities change. Reconcile calls are serialised through an internal promise chain so back-to-back notifications don't race.
+- `HostCollectorManager`: owns one `AsyncDisposableStack` per registered host, each containing `AgentStatsCollector`, `ContainerInventoryCollector`, and/or `ZFSCollector` depending on the host's capabilities. `reconcile()` is the sole mutator: it adds collectors for new hosts, disposes them for removed hosts, and recreates them when a host's `agentUrl` or capabilities change. Reconcile calls are serialised through an internal promise chain so back-to-back notifications don't race.
 
 **JWT signing**: Per-agent Ed25519 keypairs are stored encrypted in `agent_keypairs`. The deploy pipeline signs a short-lived JWT for each request; the agent verifies it against its trusted public JWK. Hosts with no keypair are skipped with a logged warning.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,9 @@ graph TD
         ContainerEvents["docker_container_events hypertable"]
         DeployHistory["deploy_history"]
         ManagedHosts["managed_hosts"]
+        EntityMetadata["entity_metadata"]
+        StackSecrets["stack_secrets"]
+        AgentKeypairs["agent_keypairs"]
     end
 
     subgraph Worker["Background Worker"]
@@ -144,8 +147,10 @@ Hosts are registered via the Settings UI and stored in the `managed_hosts` datab
 
 **Collector creation** (`src/worker/collector-factory.ts`):
 - `createCollectors()`: env-configured collectors (Proxmox only; Docker and ZFS always go through managed hosts)
-- `createCollectorsForManagedHosts()`: agent-based collectors for registered hosts (Docker stats + ZFS)
-- `createContainerInventoryCollectors()`: container inventory from agent `/containers/events` SSE, writing to `docker_container_events`
+- `resolveAgentUrl()`: rewrites localhost agent URLs to Docker-internal hostnames via `WORKER_LOCALHOST_AGENT` env var
+
+**Managed-host collector lifecycle** (`src/worker/host-collector-manager.ts`):
+- `HostCollectorManager`: owns one `AsyncDisposableStack` per registered host, each containing `AgentStatsCollector`, `ContainerInventoryCollector`, and/or `ZFSCollector` depending on the host's capabilities. `reconcile()` is the sole mutator -- it adds collectors for new hosts, disposes them for removed hosts, and recreates them when a host's `agentUrl` or capabilities change. Reconcile calls are serialised through an internal promise chain so back-to-back notifications don't race.
 
 **JWT signing**: Per-agent Ed25519 keypairs are stored encrypted in `agent_keypairs`. The deploy pipeline signs a short-lived JWT for each request; the agent verifies it against its trusted public JWK. Hosts with no keypair are skipped with a logged warning.
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -206,8 +206,8 @@ Tests use [Bun's built-in test runner](https://bun.sh/docs/cli/test), organized 
 
 ```bash
 # homelab-manager only
-bun test                    # Run homelab-manager tests (enforces coverage thresholds)
-bun test --watch            # Watch mode (no coverage enforcement)
+bun test --isolate          # Run homelab-manager tests (enforces coverage thresholds)
+bun test --isolate --watch  # Watch mode (no coverage enforcement)
 bun run test:coverage       # Coverage report only
 
 # Agent only
@@ -222,7 +222,7 @@ bun run test:coverage:all   # Run tests in both with coverage thresholds
 ### Coverage Requirements
 
 - Minimum **95% function coverage**
-- Minimum **99% line coverage**
+- Minimum **98% line coverage**
 - Automatically enforced by `bun test` and CI
 
 Test files use `*.test.ts` naming in `__tests__/` directories co-located with source (e.g., `src/lib/__tests__/stream-utils.test.ts`).

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -11,14 +11,14 @@ src/
 │   ├── ThemeProvider.tsx            # MUI Material theme wrapper
 │   ├── Toasts.tsx                   # Toast notification display
 │   ├── docker/
-│   │   ├── ContainerTable.tsx       # Docker table (wraps shared DataTable, includes HostRow)
-│   │   ├── ContainerRow.tsx         # Container row with icon, metrics, and sparklines
-│   │   ├── ContainerStateChip.tsx   # Container state indicator chip (running/stopped/etc.)
-│   │   ├── ContainerChartsCard.tsx  # Expanded container detail (dual-series charts + log viewer)
+│   │   ├── ContainerDetailPanel.tsx # Expanded container detail (dual-series charts + log viewer)
 │   │   ├── ContainerHistoryPage.tsx # Historical data page for a container
 │   │   ├── ContainerHistoryPanel.tsx # History panel drawer wrapper
 │   │   ├── ContainerLogViewer.tsx   # Live xterm.js log viewer with SSE streaming
 │   │   ├── ContainerMetricChart.tsx # Individual metric chart component
+│   │   ├── ContainerStateChip.tsx   # Container state indicator chip (running/stopped/etc.)
+│   │   ├── ContainerTable.tsx       # Docker table (wraps shared DataTable, includes HostRow)
+│   │   ├── DockerStatusSummary.tsx  # Docker status summary display
 │   │   ├── DualSeriesChart.tsx      # Dual-series ECharts component (CPU/Mem, Network I/O)
 │   │   ├── DualSeriesChartRenderer.tsx # Renders dual-series chart from shared data/config
 │   │   ├── HistoricalChartsGrid.tsx # Grid layout for historical charts
@@ -26,9 +26,7 @@ src/
 │   │   ├── HistoricalTimeline.tsx   # Timeline navigation for history
 │   │   ├── IconGrid.tsx             # Grid of selectable container icons
 │   │   ├── IconPickerDialog.tsx     # Container icon picker with search
-│   │   ├── MetricCheckboxes.tsx     # Metric toggle controls
-│   │   ├── MetricSparkline.tsx      # Inline sparkline for metric values
-│   │   └── SparklineChart.tsx       # Inline SVG sparkline for real-time metrics
+│   │   └── MetricCheckboxes.tsx     # Metric toggle controls
 │   ├── stacks/
 │   │   ├── ComposeEditor.tsx        # Monaco YAML editor for docker-compose files
 │   │   ├── ComposeEditorLoader.tsx  # Dynamic loader for compose editor
@@ -61,24 +59,43 @@ src/
 │   │   ├── GuestSection.tsx         # VM/LXC guest list within a node
 │   │   └── StorageSection.tsx       # Storage list within a node
 │   ├── shared-table/
-│   │   ├── index.tsx                # Barrel exports
-│   │   ├── MetricValue.tsx          # Formatted metric display (value + unit + optional sparkline)
-│   │   ├── MetricHeader.tsx         # Sortable column header for metric tables
-│   │   └── StaleDataAlert.tsx       # Stale data warning indicator
+│   │   ├── DataTable.tsx            # Unified table (TanStack Table + CSS Grid rows, virtualizer at 150+ rows)
+│   │   ├── DataTableToolbar.tsx     # Table toolbar with search, filters, and metric group toggles
+│   │   ├── MetricCell.tsx           # Metric value cell with formatted display
+│   │   ├── MetricHeaderCell.tsx     # Sortable column header for metric tables
+│   │   ├── SparklineCanvas.tsx      # Canvas-based sparkline renderer
+│   │   ├── SparklineCell.tsx        # Sparkline cell wrapper for DataTable
+│   │   ├── StaleDataAlert.tsx       # Stale data warning indicator
+│   │   ├── columns.tsx              # Column factories (metricColumn, nameColumn, statusColumn, progressColumn)
+│   │   └── index.tsx                # Barrel exports
 │   └── shared/
 │       └── BottomDrawer.tsx         # Reusable bottom drawer component
 ├── hooks/
 │   ├── settingsAtom.ts              # Jotai atoms (rawSettings → derived settings), types, parsing
+│   ├── timeSeriesStream/            # Modular time-series stream internals
+│   │   ├── timeWindowTrim.ts        # Trims data to configured time window
+│   │   ├── types.ts                 # Shared types for stream hooks
+│   │   ├── useLatestByEntity.ts     # Latest snapshot per entity ID
+│   │   ├── useSSEBuffer.ts          # SSE event buffering and deduplication
+│   │   └── useVisibilityRefresh.ts  # Refresh on tab visibility change
+│   ├── toastAtom.ts                 # Toast notification atom + useToast hook
+│   ├── useContainerChartData.ts     # Derived chart data from container time-series
+│   ├── useContainerLogs.ts          # SSE-based container log stream → xterm.js with reconnection
+│   ├── useDockerInventory.ts        # Docker container inventory SSE subscription
+│   ├── useDockerSettings.ts         # Docker settings slice with optimistic setters
+│   ├── useEChartTimeScroll.ts       # ECharts time-axis scroll interaction
+│   ├── useEventSource.ts            # EventSource-based SSE consumer with exponential backoff
+│   ├── useGeneralSettings.ts        # General settings slice with optimistic setters
+│   ├── useLightPaletteEffect.ts     # Light mode palette adjustment
+│   ├── useOptimisticSetting.ts      # Generic optimistic setting updater with rollback
+│   ├── useProxmoxSettings.ts        # Proxmox settings slice with optimistic setters
+│   ├── usePulseIndicator.ts         # Pulse animation indicator for live data
 │   ├── useSettings.tsx              # Consumer hook - settings + optimistic setters with rollback
 │   ├── useSettingsSync.ts           # SSE-to-atom bridge (syncs /api/settings → rawSettingsAtom)
-│   ├── useEventSource.ts            # EventSource-based SSE consumer with exponential backoff
-│   ├── useContainerLogs.ts          # SSE-based container log stream → xterm.js with reconnection
-│   ├── useTimeSeriesStream.ts       # Preload + SSE merge + time-windowed buffer + stale detection
 │   ├── useStackStatus.ts            # Stack status SSE subscription with shallow equality
-│   ├── useDockerInventory.ts        # Docker container inventory SSE subscription
-│   ├── useEChartTimeScroll.ts       # ECharts time-axis scroll interaction
-│   ├── useLightPaletteEffect.ts     # Light mode palette adjustment
-│   └── toastAtom.ts                 # Toast notification atom + useToast hook
+│   ├── useTimeSeriesStream.ts       # Preload + SSE merge + time-windowed buffer + stale detection
+│   ├── useVisibleRAF.ts             # requestAnimationFrame gated on tab visibility
+│   └── useZfsSettings.ts            # ZFS settings slice with optimistic setters
 ├── data/
 │   ├── docker/
 │   │   ├── functions.tsx            # Docker server functions (active containers, icon updates)
@@ -131,9 +148,9 @@ src/
 │   │   │   ├── deploy-repository.ts # Deploy history data access
 │   │   │   ├── host-repository.ts   # managed_hosts data access (UI + deploy)
 │   │   │   ├── docker-container-event-repository.ts # Docker container inventory events data access
+│   │   │   ├── entity-metadata-repository.ts    # Entity metadata (icons/labels) data access
 │   │   │   ├── stack-secrets-repository.ts  # JWE-encrypted stack secrets data access
-│   │   │   ├── agent-keypairs-repository.ts # Encrypted per-agent Ed25519 keypairs data access
-│   │   │   └── stack-status-repository.ts  # Stack status data access
+│   │   │   └── agent-keypairs-repository.ts # Encrypted per-agent Ed25519 keypairs data access
 │   │   ├── subscription-service.ts  # StatsPollService - shared 1s poll, broadcasts to SSE clients
 │   │   └── migrate.ts               # Database migration runner
 │   ├── deploy/
@@ -141,9 +158,13 @@ src/
 │   │   │   ├── git-trigger-builder.ts  # Builds DeployRequest from git post-receive
 │   │   │   ├── ui-trigger-builder.ts   # Builds DeployRequest from UI actions
 │   │   │   └── index.ts               # Barrel exports
-│   │   ├── pipeline.ts              # Deploy pipeline orchestrator (validate → resolve secrets → dispatch)
 │   │   ├── change-detection.ts      # Content hashing to skip no-op deploys
+│   │   ├── deploy-watchdog.ts       # Recovers stuck in_flight deploys (default 10-min threshold)
+│   │   ├── pipeline.ts              # Deploy pipeline orchestrator (validate → resolve secrets → dispatch)
+│   │   ├── pipeline-factory.ts      # Factory for building configured pipeline instances
 │   │   ├── secret-resolver.ts       # Pluggable secret resolution interface
+│   │   ├── stack-repo-writer.ts     # Writes compose files to the git-backed stack repository
+│   │   ├── startup-recovery.ts      # Recovers stuck deploys on process startup
 │   │   ├── types.ts                 # Deploy domain types
 │   │   └── index.ts                 # Barrel exports
 │   ├── git/
@@ -157,10 +178,10 @@ src/
 │   │   ├── init-repo.ts             # Startup initialization with seed manifest
 │   │   └── editor-operations.ts     # In-app file save/commit and manifest updates
 │   ├── stacks/
-│   │   ├── stack-service.ts         # Stack CRUD and orchestration
-│   │   ├── stack-mappers.ts         # Map domain to/from storage models
+│   │   ├── delete-stack-resolver.ts # Resolve and execute stack deletion
 │   │   ├── parse-variables.ts       # Parse compose variable references
-│   │   ├── teardown-poller.ts       # Poll agent for teardown completion
+│   │   ├── stack-mappers.ts         # Map domain to/from storage models
+│   │   ├── stack-service.ts         # Stack CRUD and orchestration
 │   │   └── stack-status-broadcast-service.ts # PostgreSQL LISTEN + SSE broadcast for stack status
 │   ├── services/
 │   │   ├── agent-health-service.ts  # Agent health check with timeout

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -2,10 +2,10 @@
 
 | Layer | Technology | Role |
 |-------|-----------|------|
-| **Framework** | [TanStack Start](https://tanstack.com/start) | Full-stack React framework - server functions, SSR, and file-based routing |
+| **Framework** | [TanStack Start](https://tanstack.com/start) | Full-stack React framework - server functions, file-based routing (SPA mode, SSR disabled) |
 | **Routing** | [TanStack Router](https://tanstack.com/router) | Type-safe, file-based routing with built-in devtools |
 | **Async State** | [TanStack Query](https://tanstack.com/query) | Server state management - caching, refetching, and stale data detection |
-| **Virtualization** | [TanStack Virtual](https://tanstack.com/virtual) | Virtualized rendering for large lists (page-scroll mode) |
+| **Virtualization** | [TanStack Virtual](https://tanstack.com/virtual) | Virtualized rendering for large lists (container-scroll mode) |
 | **Runtime** | [Bun](https://bun.sh) | Package manager, test runner, and JavaScript runtime |
 | **Build** | [Vite](https://vite.dev) | Dev server and production bundler |
 | **UI** | [MUI Material UI](https://mui.com/material-ui/getting-started/) + [TailwindCSS](https://tailwindcss.com) | Component library and utility-first styling |

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test": "cross-env-shell \"bun test --isolate --coverage 2>&1 | node scripts/check-coverage.js\"",
     "test:agent": "cd agent && bun test --isolate",
     "test:all": "bun test --isolate && bun run test:agent",
-    "test:watch": "bun test --watch",
+    "test:watch": "bun test --isolate --watch",
     "test:coverage": "bun test --isolate --coverage --coverage-reporter=text --coverage-reporter=lcov",
     "test:coverage:agent": "cd agent && bun run test:coverage",
     "test:coverage:all": "bun run test && bun run test:coverage:agent",

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -137,6 +137,14 @@ Stack management lets you deploy and manage Docker Compose stacks on your hosts 
 >
 > **Adding a host:** Use **Settings → Managed Hosts → Add Host** in the dashboard. The wizard generates a compose snippet for the agent and handles key exchange during the Verify step. Once connectivity is confirmed, the keypair is stored and the host is ready.
 
+### PostgreSQL Connection
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `POSTGRES_SSL` | `false` | Enable TLS for the PostgreSQL connection |
+| `POSTGRES_SSL_REJECT_UNAUTHORIZED` | `true` | Verify the server's TLS certificate. Set to `false` only for self-signed certificates -- this disables chain validation and exposes the connection to MITM attacks. |
+| `POSTGRES_POOL_SIZE` | `10` | Database connection pool size |
+
 ### Worker Behavior
 
 | Variable | Default | Description |
@@ -146,7 +154,7 @@ Stack management lets you deploy and manage Docker Compose stacks on your hosts 
 | `WORKER_ZFS_ENABLED` | `false` | Enable ZFS stats collection |
 | `WORKER_PROXMOX_ENABLED` | `false` | Enable Proxmox stats collection |
 | `WORKER_COLLECTION_INTERVAL_MS` | `1000` | Collection interval in milliseconds |
-| `POSTGRES_POOL_SIZE` | `10` | Database connection pool size |
+| `WORKER_LOCALHOST_AGENT` | - | Docker-internal hostname to substitute for `localhost` agent URLs (e.g. `hlm-agent`). Set this when the worker and an agent container run on the same Docker host; without it, `localhost` agent URLs resolve to the worker container itself rather than the agent container. |
 
 ---
 

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -142,7 +142,7 @@ Stack management lets you deploy and manage Docker Compose stacks on your hosts 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `POSTGRES_SSL` | `false` | Enable TLS for the PostgreSQL connection |
-| `POSTGRES_SSL_REJECT_UNAUTHORIZED` | `true` | Verify the server's TLS certificate. Set to `false` only for self-signed certificates -- this disables chain validation and exposes the connection to MITM attacks. |
+| `POSTGRES_SSL_REJECT_UNAUTHORIZED` | `true` | Verify the server's TLS certificate. Set to `false` only for self-signed certificates. This disables chain validation and exposes the connection to MITM attacks. |
 | `POSTGRES_POOL_SIZE` | `10` | Database connection pool size |
 
 ### Worker Behavior


### PR DESCRIPTION
## Summary

- Corrects 24 validated inaccuracies across CLAUDE.md, docs/, self-hosting/README.md, .env.example, and package.json
- All findings were confirmed by an independent validation agent before fixing

## Changes by file

**CLAUDE.md**
- Coverage line threshold: 98% (was 99%, actual enforced value in scripts/check-coverage.js)
- Deploy status string: `in_progress` (was `in_flight`, wrong enum value)
- Gotcha #7 component name: `MetricCell` (was `MetricValue`, file doesn't exist)
- scrollbar-gutter: described as conditional on virtualization/maxHeight (was implied always-on)
- `createStatsSseHandler` source values: `'docker'/'zfs'/'proxmox'` (was route filenames `docker-stats` etc.)
- Import rule (Critical Rule 2): clarified test file pattern to remove self-contradiction
- Added missing `dev:local:logs:db` command

**docs/development.md**
- `bun test` commands now include `--isolate` (critical: without it, module mocks leak)
- Coverage line threshold: 98% (was 99%)

**docs/project-structure.md**
- Removed 4 non-existent docker components (ContainerRow, ContainerChartsCard, MetricSparkline, SparklineChart)
- Fixed MetricHeader.tsx -> MetricHeaderCell.tsx
- Removed non-existent stack-status-repository.ts and teardown-poller.ts
- Added missing deploy/ files (deploy-watchdog, pipeline-factory, stack-repo-writer, startup-recovery)
- Added 9 missing hooks including timeSeriesStream/ subdirectory and domain-scoped settings hooks
- Added entity-metadata-repository.ts to repositories section

**docs/architecture.md**
- Replaced non-existent `createCollectorsForManagedHosts`/`createContainerInventoryCollectors` with accurate `HostCollectorManager` description
- Added `entity_metadata`, `stack_secrets`, `agent_keypairs` to system diagram

**docs/tech-stack.md**
- TanStack Start: SPA mode, SSR disabled (was incorrectly listed as SSR-enabled)
- TanStack Virtual: container-scroll mode (was page-scroll mode)

**package.json**
- `test:watch` script: added `--isolate` to match documented requirement

**self-hosting/README.md**
- Added `POSTGRES_SSL` and `POSTGRES_SSL_REJECT_UNAUTHORIZED` to PostgreSQL Connection section
- Added `WORKER_LOCALHOST_AGENT` to Worker Behavior section
- Moved `POSTGRES_POOL_SIZE` to the new PostgreSQL Connection section

**.env.example**
- Removed 7 stale `ZFS_HOST_*` SSH variables from the old SSH-based ZFS architecture (no code reads them; ZFS now uses agent SSE)

## Related

- Issue #162: `scrollbar-gutter: stable` conditional behavior investigation (doc updated to reflect current behavior; issue open for whether it should be unconditional)

## Test plan

- [ ] Verify `bun test --isolate` passes locally
- [ ] Verify `bun run typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated architecture documentation with expanded database schema and collector management design
  * Clarified project structure and technical implementation details

* **Configuration**
  * Added PostgreSQL TLS configuration options (`POSTGRES_SSL`, `POSTGRES_SSL_REJECT_UNAUTHORIZED`)
  * Added worker localhost agent configuration variable for Docker environments
  * Removed ZFS Host configuration template

* **Chores**
  * Adjusted test coverage thresholds (line coverage lowered to 98%)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/163)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->