### PR TITLE
refactor(docker): extract ContainerHistoryPage data logic into custom hook

### DIFF
--- a/src/components/docker/ContainerHistoryPage.tsx
+++ b/src/components/docker/ContainerHistoryPage.tsx
@@ -1,13 +1,10 @@
-import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { Typography, CircularProgress, IconButton, Skeleton } from '@mui/material';
 import { X } from 'lucide-react';
-import { getContainerHistory, getContainerInfo } from '@/data/docker/functions';
-import { getIconUrl, FALLBACK_ICON_URL } from '@/lib/utils/icon-resolver';
-import { CHART_DEBOUNCE_MS } from '@/lib/constants/ui-timing';
-import MetricCheckboxes, { type MetricType } from '@/components/docker/MetricCheckboxes';
+import { FALLBACK_ICON_URL } from '@/lib/utils/icon-resolver';
+import MetricCheckboxes from '@/components/docker/MetricCheckboxes';
 import HistoricalChartsGrid from '@/components/docker/HistoricalChartsGrid';
 import HistoricalTimeline from '@/components/docker/HistoricalTimeline';
+import { useContainerHistoryData } from '@/components/docker/useContainerHistoryData';
 
 interface ContainerHistoryPageProps {
   containerId: string;
@@ -17,20 +14,6 @@ interface ContainerHistoryPageProps {
   initialTo?: number;
   onClose?: () => void;
 }
-
-/**
- * Parse a comma-separated metrics string into a set of recognized metric keys.
- *
- * @param metricsStr - Comma-separated metric identifiers (e.g. "cpu,memory,networkRx")
- * @returns A set containing the parsed `MetricType` values; if the input contains no valid metrics, returns a set with `cpu` and `memory`
- */
-function parseMetrics(metricsStr: string): Set<MetricType> {
-  const valid: MetricType[] = ['cpu', 'memory', 'blockRead', 'blockWrite', 'networkRx', 'networkTx'];
-  const parsed = metricsStr.split(',').filter((m): m is MetricType => valid.includes(m as MetricType));
-  return new Set(parsed.length > 0 ? parsed : ['cpu', 'memory']);
-}
-
-const DEFAULT_RANGE_MS = 3_600_000; // 1 hour
 
 /**
  * Render a container's historical metrics UI including a timeline, selectable metrics, and detailed charts.
@@ -52,135 +35,30 @@ export default function ContainerHistoryPage({
   initialTo,
   onClose,
 }: Readonly<ContainerHistoryPageProps>) {
-
-  const now = useRef(Date.now()).current;
-  const initialRange = useRef({
-    from: initialFrom ?? now - DEFAULT_RANGE_MS,
-    to: initialTo ?? now,
-  }).current;
-
-  // Absolute timeline range - determines what data the timeline fetches.
-  // Presets compute { from: now - ms, to: now }; custom dates set arbitrary values.
-  const [timelineRange, setTimelineRange] = useState(initialRange);
-
-  // Track which preset is active (null = custom range)
-  const [activePresetMs, setActivePresetMs] = useState<number | null>(() => {
-    const span = initialRange.to - initialRange.from;
-    const PRESETS = [3_600_000, 21_600_000, 43_200_000, 86_400_000, 259_200_000, 604_800_000, 2_592_000_000];
-    return PRESETS.find((p) => Math.abs(span - p) / p < 0.05) ?? null;
-  });
-
-  // Debounced range drives chart query - updated after 800ms of slider idle
-  const [debouncedRange, setDebouncedRange] = useState(initialRange);
-  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
-
-  // Metric selection state
-  const [selectedMetrics, setSelectedMetrics] = useState<Set<MetricType>>(
-    () => parseMetrics(initialMetrics),
-  );
-
-  // ─── Stream 1: Timeline data for the current range ───
-  // Query key includes absolute from/to so presets and custom ranges trigger refetch.
-  // Auto-refresh only when the range actually overlaps the current moment.
-  const currentTime = Date.now();
-  const timelineIncludesNow = timelineRange.from <= currentTime && timelineRange.to >= currentTime - 30_000;
-  const timelineQuery = useQuery({
-    queryKey: ['container-timeline', host, containerId, timelineRange.from, timelineRange.to],
-    queryFn: () => getContainerHistory({
-      data: {
-        containerId,
-        host,
-        fromMs: timelineRange.from,
-        toMs: timelineRange.to,
-        targetPoints: 2000,
-      },
-    }),
-    staleTime: 30_000,
-    refetchInterval: timelineIncludesNow ? 60_000 : false,
-  });
-
-  // Fetch container info (name, image, icon)
-  const infoQuery = useQuery({
-    queryKey: ['container-info', host, containerId],
-    queryFn: () => getContainerInfo({ data: { containerId, host } }),
-    staleTime: 60_000,
-  });
-
-  // Auto-refresh charts when the range actually overlaps "now" (within 30s)
-  const includesNow = debouncedRange.from <= currentTime && debouncedRange.to >= currentTime - 30_000;
-
-  // ─── Stream 2: Chart detail (debounced, fine-grained) ───
-  const chartQuery = useQuery({
-    queryKey: ['container-charts', host, containerId, debouncedRange.from, debouncedRange.to],
-    queryFn: () => getContainerHistory({
-      data: {
-        containerId,
-        host,
-        fromMs: debouncedRange.from,
-        toMs: debouncedRange.to,
-        targetPoints: 600,
-      },
-    }),
-    refetchInterval: includesNow ? 10_000 : false,
-  });
-
-  // Slider drag → debounced chart update only
-  const handleRangeChange = useCallback((from: number, to: number) => {
-    clearTimeout(debounceRef.current);
-    debounceRef.current = setTimeout(() => {
-      setDebouncedRange({ from, to });
-    }, CHART_DEBOUNCE_MS);
-  }, []);
-
-  // Preset click → immediate timeline refetch + chart range reset
-  const handlePresetChange = useCallback((ms: number) => {
-    const presetNow = Date.now();
-    const from = presetNow - ms;
-    setTimelineRange({ from, to: presetNow });
-    setActivePresetMs(ms);
-    clearTimeout(debounceRef.current);
-    setDebouncedRange({ from, to: presetNow });
-  }, []);
-
-  // Custom date range → timeline + chart range update, deselect preset
-  const handleCustomRangeChange = useCallback((from: number, to: number) => {
-    setTimelineRange({ from, to });
-    setActivePresetMs(null);
-    clearTimeout(debounceRef.current);
-    setDebouncedRange({ from, to });
-  }, []);
-
-  // Cleanup debounce timer
-  useEffect(() => () => clearTimeout(debounceRef.current), []);
-
-  const handleMetricsChange = useCallback((metrics: Set<MetricType>) => {
-    setSelectedMetrics(metrics);
-  }, []);
-
-  // Container display info
-  const containerName = infoQuery.data?.containerName ?? containerId.substring(0, 12);
-  const containerImage = infoQuery.data?.image ?? '';
-  const containerIcon = infoQuery.data?.icon ?? null;
-  const serviceKey = infoQuery.data?.serviceKey ?? null;
-  // Only show service key label when it's compose-based (contains '/'), i.e. "media-stack/plex".
-  // When it's just the container name fallback, the label would be redundant.
-  const showServiceKey = serviceKey?.includes('/') ?? false;
-  const iconUrl = containerImage ? getIconUrl(containerIcon, containerImage) : FALLBACK_ICON_URL;
-  const [iconError, setIconError] = useState(false);
-
-  // Reset icon error when the resolved URL changes (e.g. new valid icon assigned)
-  useEffect(() => {
-    setIconError(false);
-  }, [iconUrl]);
-
-  const timelineData = useMemo(() => timelineQuery.data ?? [], [timelineQuery.data]);
-  const chartData = useMemo(() => chartQuery.data ?? [], [chartQuery.data]);
-
-  // Always use the requested range for chart axes - this keeps the full time range
-  // visible even when data only covers a portion, preventing the appearance of
-  // low-resolution data when the range exceeds available history.
-  const chartFrom = debouncedRange.from;
-  const chartTo = debouncedRange.to;
+  const {
+    isInfoLoading,
+    isChartFetching,
+    isChartDataEmpty,
+    timelineData,
+    chartData,
+    containerName,
+    containerImage,
+    iconUrl,
+    iconError,
+    showServiceKey,
+    serviceKey,
+    setIconError,
+    initialRange,
+    timelineRange,
+    activePresetMs,
+    chartFrom,
+    chartTo,
+    selectedMetrics,
+    handleMetricsChange,
+    handleRangeChange,
+    handlePresetChange,
+    handleCustomRangeChange,
+  } = useContainerHistoryData({ containerId, host, initialMetrics, initialFrom, initialTo });
 
   return (
     <div className="flex flex-col min-h-0">
@@ -188,7 +66,7 @@ export default function ContainerHistoryPage({
       <div className="sticky top-0 z-10 bg-(--mui-palette-background-level1)! border-b border-(--mui-palette-divider) px-6 pt-4 pb-3 select-none">
         <div className="relative">
           {/* Real content: always in flow, determines height */}
-          <div className={`flex items-center gap-3 transition-opacity duration-300 ${infoQuery.isLoading ? 'opacity-0' : 'opacity-100'}`}>
+          <div className={`flex items-center gap-3 transition-opacity duration-300 ${isInfoLoading ? 'opacity-0' : 'opacity-100'}`}>
             <img
               src={iconError ? FALLBACK_ICON_URL : iconUrl}
               alt=""
@@ -198,14 +76,14 @@ export default function ContainerHistoryPage({
             <div className="min-w-0 flex-1">
               <div className="flex items-center gap-2">
                 <Typography variant="h5" noWrap>{containerName}</Typography>
-                {chartQuery.isFetching && (
+                {isChartFetching && (
                   <CircularProgress size={18} />
                 )}
               </div>
               {showServiceKey && (
                 <Typography variant="caption" className="text-(--mui-palette-text-secondary) block" noWrap>Service: {serviceKey}</Typography>
               )}
-              <Typography variant="caption" className="text-neutral-500 block" noWrap>{containerImage || '\u00A0'}</Typography>
+              <Typography variant="caption" className="text-neutral-500 block" noWrap>{containerImage || ' '}</Typography>
             </div>
             {onClose && (
               <IconButton onClick={onClose} aria-label="Close history panel" className="shrink-0!">
@@ -214,7 +92,7 @@ export default function ContainerHistoryPage({
             )}
           </div>
           {/* Skeleton overlay: always absolute, fades out */}
-          <div className={`absolute inset-0 flex items-center gap-3 transition-opacity duration-300 ${infoQuery.isLoading ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
+          <div className={`absolute inset-0 flex items-center gap-3 transition-opacity duration-300 ${isInfoLoading ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}>
             <Skeleton variant="rounded" width={32} height={32} className="shrink-0" />
             <div className="min-w-0 flex-1">
               <Typography variant="h5"><Skeleton width={180} /></Typography>
@@ -231,7 +109,7 @@ export default function ContainerHistoryPage({
       <div className="overflow-y-auto flex-1 min-h-0 themed-scrollbar">
         {/* Charts area */}
         <div className="px-6 py-4">
-          {chartData.length === 0 && !chartQuery.isFetching ? (
+          {isChartDataEmpty ? (
             <div className="flex items-center justify-center h-64 text-neutral-500">
               <Typography variant="body1">No data available for this time range.</Typography>
             </div>

--- a/src/components/docker/ContainerHistoryPage.tsx
+++ b/src/components/docker/ContainerHistoryPage.tsx
@@ -83,7 +83,7 @@ export default function ContainerHistoryPage({
               {showServiceKey && (
                 <Typography variant="caption" className="text-(--mui-palette-text-secondary) block" noWrap>Service: {serviceKey}</Typography>
               )}
-              <Typography variant="caption" className="text-neutral-500 block" noWrap>{containerImage || ' '}</Typography>
+              <Typography variant="caption" className="text-(--mui-palette-text-secondary) block" noWrap>{containerImage || ' '}</Typography>
             </div>
             {onClose && (
               <IconButton onClick={onClose} aria-label="Close history panel" className="shrink-0!">
@@ -110,7 +110,7 @@ export default function ContainerHistoryPage({
         {/* Charts area */}
         <div className="px-6 py-4">
           {isChartDataEmpty ? (
-            <div className="flex items-center justify-center h-64 text-neutral-500">
+            <div className="flex items-center justify-center h-64 text-(--mui-palette-text-secondary)">
               <Typography variant="body1">No data available for this time range.</Typography>
             </div>
           ) : (

--- a/src/components/docker/useContainerHistoryData.ts
+++ b/src/components/docker/useContainerHistoryData.ts
@@ -1,0 +1,229 @@
+import { useState, useCallback, useRef, useMemo, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getContainerHistory, getContainerInfo } from '@/data/docker/functions';
+import { getIconUrl, FALLBACK_ICON_URL } from '@/lib/utils/icon-resolver';
+import { CHART_DEBOUNCE_MS } from '@/lib/constants/ui-timing';
+import { type MetricType } from '@/components/docker/MetricCheckboxes';
+import type { DockerStatsRow } from '@/types/docker';
+
+export type { MetricType };
+
+/**
+ * Parse a comma-separated metrics string into a set of recognized metric keys.
+ *
+ * @param metricsStr - Comma-separated metric identifiers (e.g. "cpu,memory,networkRx")
+ * @returns A set containing the parsed `MetricType` values; if the input contains no valid metrics, returns a set with `cpu` and `memory`
+ */
+export function parseMetrics(metricsStr: string): Set<MetricType> {
+  const valid: MetricType[] = ['cpu', 'memory', 'blockRead', 'blockWrite', 'networkRx', 'networkTx'];
+  const parsed = metricsStr.split(',').filter((m): m is MetricType => valid.includes(m as MetricType));
+  return new Set(parsed.length > 0 ? parsed : ['cpu', 'memory']);
+}
+
+export const DEFAULT_RANGE_MS = 3_600_000; // 1 hour
+
+const PRESETS = [3_600_000, 21_600_000, 43_200_000, 86_400_000, 259_200_000, 604_800_000, 2_592_000_000];
+
+export interface UseContainerHistoryDataParams {
+  containerId: string;
+  host?: string;
+  initialMetrics: string;
+  initialFrom?: number;
+  initialTo?: number;
+}
+
+export interface ContainerHistoryData {
+  // Query loading/fetching states
+  isInfoLoading: boolean;
+  isChartFetching: boolean;
+  isChartDataEmpty: boolean;
+
+  // Derived data
+  timelineData: DockerStatsRow[];
+  chartData: DockerStatsRow[];
+
+  // Container display info
+  containerName: string;
+  containerImage: string;
+  iconUrl: string;
+  iconError: boolean;
+  showServiceKey: boolean;
+  serviceKey: string | null;
+  setIconError: (value: boolean) => void;
+
+  // Range state
+  initialRange: { from: number; to: number };
+  timelineRange: { from: number; to: number };
+  activePresetMs: number | null;
+  chartFrom: number;
+  chartTo: number;
+
+  // Metric selection
+  selectedMetrics: Set<MetricType>;
+  handleMetricsChange: (metrics: Set<MetricType>) => void;
+
+  // Range handlers
+  handleRangeChange: (from: number, to: number) => void;
+  handlePresetChange: (ms: number) => void;
+  handleCustomRangeChange: (from: number, to: number) => void;
+}
+
+export function useContainerHistoryData({
+  containerId,
+  host,
+  initialMetrics,
+  initialFrom,
+  initialTo,
+}: UseContainerHistoryDataParams): ContainerHistoryData {
+  const now = useRef(Date.now()).current;
+  const initialRange = useRef({
+    from: initialFrom ?? now - DEFAULT_RANGE_MS,
+    to: initialTo ?? now,
+  }).current;
+
+  // Absolute timeline range - determines what data the timeline fetches.
+  // Presets compute { from: now - ms, to: now }; custom dates set arbitrary values.
+  const [timelineRange, setTimelineRange] = useState(initialRange);
+
+  // Track which preset is active (null = custom range)
+  const [activePresetMs, setActivePresetMs] = useState<number | null>(() => {
+    const span = initialRange.to - initialRange.from;
+    return PRESETS.find((p) => Math.abs(span - p) / p < 0.05) ?? null;
+  });
+
+  // Debounced range drives chart query - updated after 800ms of slider idle
+  const [debouncedRange, setDebouncedRange] = useState(initialRange);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  const [selectedMetrics, setSelectedMetrics] = useState<Set<MetricType>>(
+    () => parseMetrics(initialMetrics),
+  );
+
+  // ─── Stream 1: Timeline data for the current range ───
+  // Query key includes absolute from/to so presets and custom ranges trigger refetch.
+  // Auto-refresh only when the range actually overlaps the current moment.
+  const currentTime = Date.now();
+  const timelineIncludesNow = timelineRange.from <= currentTime && timelineRange.to >= currentTime - 30_000;
+  const timelineQuery = useQuery({
+    queryKey: ['container-timeline', host, containerId, timelineRange.from, timelineRange.to],
+    queryFn: () => getContainerHistory({
+      data: {
+        containerId,
+        host,
+        fromMs: timelineRange.from,
+        toMs: timelineRange.to,
+        targetPoints: 2000,
+      },
+    }),
+    staleTime: 30_000,
+    refetchInterval: timelineIncludesNow ? 60_000 : false,
+  });
+
+  // Fetch container info (name, image, icon)
+  const infoQuery = useQuery({
+    queryKey: ['container-info', host, containerId],
+    queryFn: () => getContainerInfo({ data: { containerId, host } }),
+    staleTime: 60_000,
+  });
+
+  // Auto-refresh charts when the range actually overlaps "now" (within 30s)
+  const includesNow = debouncedRange.from <= currentTime && debouncedRange.to >= currentTime - 30_000;
+
+  // ─── Stream 2: Chart detail (debounced, fine-grained) ───
+  const chartQuery = useQuery({
+    queryKey: ['container-charts', host, containerId, debouncedRange.from, debouncedRange.to],
+    queryFn: () => getContainerHistory({
+      data: {
+        containerId,
+        host,
+        fromMs: debouncedRange.from,
+        toMs: debouncedRange.to,
+        targetPoints: 600,
+      },
+    }),
+    refetchInterval: includesNow ? 10_000 : false,
+  });
+
+  // Slider drag → debounced chart update only
+  const handleRangeChange = useCallback((from: number, to: number) => {
+    clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(() => {
+      setDebouncedRange({ from, to });
+    }, CHART_DEBOUNCE_MS);
+  }, []);
+
+  // Preset click → immediate timeline refetch + chart range reset
+  const handlePresetChange = useCallback((ms: number) => {
+    const presetNow = Date.now();
+    const from = presetNow - ms;
+    setTimelineRange({ from, to: presetNow });
+    setActivePresetMs(ms);
+    clearTimeout(debounceRef.current);
+    setDebouncedRange({ from, to: presetNow });
+  }, []);
+
+  // Custom date range → timeline + chart range update, deselect preset
+  const handleCustomRangeChange = useCallback((from: number, to: number) => {
+    setTimelineRange({ from, to });
+    setActivePresetMs(null);
+    clearTimeout(debounceRef.current);
+    setDebouncedRange({ from, to });
+  }, []);
+
+  // Cleanup debounce timer
+  useEffect(() => () => clearTimeout(debounceRef.current), []);
+
+  const handleMetricsChange = useCallback((metrics: Set<MetricType>) => {
+    setSelectedMetrics(metrics);
+  }, []);
+
+  // Container display info
+  const containerName = infoQuery.data?.containerName ?? containerId.substring(0, 12);
+  const containerImage = infoQuery.data?.image ?? '';
+  const containerIcon = infoQuery.data?.icon ?? null;
+  const serviceKey = infoQuery.data?.serviceKey ?? null;
+  // Only show service key label when it's compose-based (contains '/'), i.e. "media-stack/plex".
+  // When it's just the container name fallback, the label would be redundant.
+  const showServiceKey = serviceKey?.includes('/') ?? false;
+  const iconUrl = containerImage ? getIconUrl(containerIcon, containerImage) : FALLBACK_ICON_URL;
+  const [iconError, setIconError] = useState(false);
+
+  // Reset icon error when the resolved URL changes (e.g. new valid icon assigned)
+  useEffect(() => {
+    setIconError(false);
+  }, [iconUrl]);
+
+  const timelineData = useMemo(() => timelineQuery.data ?? [], [timelineQuery.data]);
+  const chartData = useMemo(() => chartQuery.data ?? [], [chartQuery.data]);
+
+  // Always use the requested range for chart axes - this keeps the full time range
+  // visible even when data only covers a portion, preventing the appearance of
+  // low-resolution data when the range exceeds available history.
+  const chartFrom = debouncedRange.from;
+  const chartTo = debouncedRange.to;
+
+  return {
+    isInfoLoading: infoQuery.isLoading,
+    isChartFetching: chartQuery.isFetching,
+    isChartDataEmpty: chartData.length === 0 && !chartQuery.isFetching,
+    timelineData,
+    chartData,
+    containerName,
+    containerImage,
+    iconUrl,
+    iconError,
+    showServiceKey,
+    serviceKey,
+    setIconError,
+    initialRange,
+    timelineRange,
+    activePresetMs,
+    chartFrom,
+    chartTo,
+    selectedMetrics,
+    handleMetricsChange,
+    handleRangeChange,
+    handlePresetChange,
+    handleCustomRangeChange,
+  };
+}

--- a/src/components/docker/useContainerHistoryData.ts
+++ b/src/components/docker/useContainerHistoryData.ts
@@ -85,10 +85,16 @@ export function useContainerHistoryData({
   // Presets compute { from: now - ms, to: now }; custom dates set arbitrary values.
   const [timelineRange, setTimelineRange] = useState(initialRange);
 
-  // Track which preset is active (null = custom range)
+  // Track which preset is active (null = custom range).
+  // Only match a preset when the range also ends near now - a historical custom range
+  // with the same duration as a preset (e.g. exactly 1h but anchored in the past)
+  // must not be treated as an active preset.
   const [activePresetMs, setActivePresetMs] = useState<number | null>(() => {
     const span = initialRange.to - initialRange.from;
-    return PRESETS.find((p) => Math.abs(span - p) / p < 0.05) ?? null;
+    const endsNearNow = Math.abs(initialRange.to - Date.now()) <= 30_000;
+    return endsNearNow
+      ? (PRESETS.find((p) => Math.abs(span - p) / p < 0.05) ?? null)
+      : null;
   });
 
   // Debounced range drives chart query - updated after 800ms of slider idle


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Extracts all data fetching and state logic from `ContainerHistoryPage.tsx` into a new `useContainerHistoryData` hook at `src/components/docker/useContainerHistoryData.ts`
- Moves TanStack Query calls (timeline, container info, chart data), debounced range state, metric selection state, and derived display values into the hook
- `ContainerHistoryPage.tsx` is now a thin rendering layer that calls the hook and maps its return value to JSX

## Test plan

- [ ] Verify the history panel opens and displays container metrics correctly
- [ ] Verify preset time range buttons update both the timeline and charts
- [ ] Verify the timeline slider debounces chart updates (no immediate refetch on drag)
- [ ] Verify custom date range selection deselects the active preset
- [ ] Verify metric checkboxes filter which charts are shown
- [ ] Verify the loading skeleton fades out once container info loads
- [ ] Run `bun run typecheck:all` with no new errors
- [ ] Run `bun run test:all` with no new failures

https://claude.ai/code/session_019pZueriYXEmx2yXp5GSa4z
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019pZueriYXEmx2yXp5GSa4z)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated container history data, fetching, and state into a single hook for cleaner architecture and more reliable UI updates.
* **Bug Fixes / UX**
  * Improved loading indicators, empty-state detection, and chart/timeline sync so ranges, presets, and metric selections update consistently and debounce correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/175)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->