### PR TITLE
feat(crypto): support master key versioning and add migration CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,6 +164,28 @@ Server-side bare git repo via isomorphic-git. Git HTTP smart protocol at `/api/g
 
 Hypertables: `docker_stats`, `zfs_stats`, `proxmox_stats`, `docker_container_events` (append-only state-change log; current snapshot via `DISTINCT ON (host, container_id) ORDER BY at DESC`, broadcast via `NOTIFY docker_container_change`). Plus `entity_metadata` (icons/labels), `settings` (KV with NOTIFY trigger), `managed_hosts` (Docker hosts with agent connection details), `deploy_history` (deploy records with status tracking), `stack_secrets` (per-stack environment-variable secrets, JWE-encrypted at rest), and `agent_keypairs` (per-host Ed25519 keypair: private JWK encrypted, public JWK as JSONB). Schema details in `migrations/`.
 
+### Key Rotation
+
+Encrypted columns (`stack_secrets.ciphertext_jwe`, `agent_keypairs.private_jwk_jwe`) use a versioned keyring so a new master key can be enrolled without breaking existing ciphertext.
+
+**Env var patterns:**
+- `MASTER_KEY` / `MASTER_KEY_FILE` — single-key legacy pattern, treated as KID `v1`.
+- `MASTER_KEY_<KID>` / `MASTER_KEY_FILE_<KID>` — additional keys, e.g. `MASTER_KEY_v2=<base64>`.
+
+The lexicographically last KID is used for new encryptions; all loaded keys are available for decryption.
+
+**Rotation procedure:**
+1. Generate a new key: `openssl rand -base64 32`
+2. Add it alongside the old key: set `MASTER_KEY_v2=<new-base64>` (keep `MASTER_KEY`/`MASTER_KEY_v1` in place).
+3. Restart the app — new secrets encrypt under `v2`, old secrets still decrypt via `v1`.
+4. Run the migration CLI to re-encrypt existing rows:
+   ```bash
+   bun run migrate-secrets --from v1 --to v2
+   ```
+5. Remove the old key env var (`MASTER_KEY` or `MASTER_KEY_v1`) and restart.
+
+The migration script exits non-zero on any failure. Partially migrated rows are safe because both keys remain in the keyring during the rotation window.
+
 ## Gotchas
 
 Non-obvious pitfalls from past sessions (not restated from rules above):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,9 +179,11 @@ The lexicographically last KID is used for new encryptions; all loaded keys are 
 2. Add it alongside the old key: set `MASTER_KEY_v2=<new-base64>` (keep `MASTER_KEY`/`MASTER_KEY_v1` in place).
 3. Restart the app — new secrets encrypt under `v2`, old secrets still decrypt via `v1`.
 4. Run the migration CLI to re-encrypt existing rows:
+
    ```bash
    bun run migrate-secrets --from v1 --to v2
    ```
+
 5. Remove the old key env var (`MASTER_KEY` or `MASTER_KEY_v1`) and restart.
 
 The migration script exits non-zero on any failure. Partially migrated rows are safe because both keys remain in the keyring during the rotation window.

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "dev:local:logs:db": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml logs -f postgres",
     "dev:local:logs:agent": "docker compose --env-file ~/.config/homelab-manager/.env -f docker-compose.local.yml logs -f agent",
     "icons:download": "bun scripts/download-icons.ts",
-    "schema:download": "bun scripts/download-compose-schema.ts"
+    "schema:download": "bun scripts/download-compose-schema.ts",
+    "migrate-secrets": "bun run scripts/migrate-master-key.ts"
   },
   "dependencies": {
     "@emotion/react": "11.14.0",

--- a/scripts/migrate-master-key.ts
+++ b/scripts/migrate-master-key.ts
@@ -1,0 +1,260 @@
+#!/usr/bin/env bun
+/**
+ * Master key migration CLI.
+ *
+ * Re-encrypts all JWE-encrypted values in stack_secrets and agent_keypairs
+ * from one key version (--from <kid>) to another (--to <kid>).
+ *
+ * Both keys must be present in the environment at runtime so that the old key
+ * can still decrypt existing ciphertext while the new key encrypts the result.
+ * Rows encrypted under a different KID are left untouched.
+ *
+ * Usage:
+ *   bun run scripts/migrate-master-key.ts --from v1 --to v2
+ *
+ * On failure the process exits non-zero. Partially migrated rows are safe:
+ * the old key is still in the keyring and can decrypt them on the next run.
+ */
+import { readFileSync } from 'node:fs';
+import { Pool } from 'pg';
+import { compactDecrypt, CompactEncrypt } from 'jose';
+
+// ---- CLI arg parsing -------------------------------------------------------
+
+function parseArgs(): { from: string; to: string } {
+  const args = process.argv.slice(2);
+  let from: string | undefined;
+  let to: string | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--from' && i + 1 < args.length) {
+      from = args[++i];
+    } else if (args[i] === '--to' && i + 1 < args.length) {
+      to = args[++i];
+    }
+  }
+
+  if (!from || !to) {
+    console.error('Usage: bun run scripts/migrate-master-key.ts --from <kid> --to <kid>');
+    process.exit(1);
+  }
+  if (from === to) {
+    console.error('--from and --to must be different KIDs');
+    process.exit(1);
+  }
+
+  return { from, to };
+}
+
+// ---- Key loading (inline, no imports from src/ so this runs standalone) ---
+
+const KEY_ALG = 'dir';
+const ENC_ALG = 'A256GCM';
+
+async function loadKey(kid: string): Promise<CryptoKey> {
+  const raw = readKeyBase64(kid);
+  const bytes = Uint8Array.from(Buffer.from(raw, 'base64'));
+  if (bytes.byteLength !== 32) {
+    throw new Error(
+      `Key "${kid}" must decode to 32 bytes; got ${bytes.byteLength}. ` +
+        `Generate with: openssl rand -base64 32`,
+    );
+  }
+  return crypto.subtle.importKey(
+    'raw',
+    bytes,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
+  );
+}
+
+function readKeyBase64(kid: string): string {
+  // MASTER_KEY_FILE_<KID> takes priority over MASTER_KEY_<KID>
+  const fileSuffix = `MASTER_KEY_FILE_${kid}`;
+  const keySuffix = `MASTER_KEY_${kid}`;
+
+  // Legacy KID "v1" also maps to MASTER_KEY_FILE / MASTER_KEY
+  if (kid === 'v1') {
+    const legacyFile = process.env.MASTER_KEY_FILE;
+    if (legacyFile && legacyFile.length > 0) {
+      return readFileSync(legacyFile, 'utf-8').trim();
+    }
+    const legacyKey = process.env.MASTER_KEY;
+    if (legacyKey && legacyKey.trim().length > 0) {
+      return legacyKey.trim();
+    }
+  }
+
+  const fileEnv = process.env[fileSuffix];
+  if (fileEnv && fileEnv.length > 0) {
+    return readFileSync(fileEnv, 'utf-8').trim();
+  }
+
+  const keyEnv = process.env[keySuffix];
+  if (keyEnv && keyEnv.trim().length > 0) {
+    return keyEnv.trim();
+  }
+
+  throw new Error(
+    `No key found for KID "${kid}". ` +
+      `Set MASTER_KEY_${kid} or MASTER_KEY_FILE_${kid} (or MASTER_KEY/MASTER_KEY_FILE for "v1").`,
+  );
+}
+
+async function decryptJwe(jwe: string, key: CryptoKey): Promise<string> {
+  const { plaintext } = await compactDecrypt(jwe, key);
+  return new TextDecoder().decode(plaintext);
+}
+
+async function encryptJwe(plaintext: string, kid: string, key: CryptoKey): Promise<string> {
+  return new CompactEncrypt(new TextEncoder().encode(plaintext))
+    .setProtectedHeader({ alg: KEY_ALG, enc: ENC_ALG, kid })
+    .encrypt(key);
+}
+
+/** Extract the KID from a JWE compact serialization without full decryption. */
+function extractKid(jwe: string): string | null {
+  const header = jwe.split('.')[0];
+  if (!header) return null;
+  try {
+    const decoded = JSON.parse(Buffer.from(header, 'base64url').toString('utf-8')) as Record<string, unknown>;
+    return typeof decoded.kid === 'string' ? decoded.kid : null;
+  } catch {
+    return null;
+  }
+}
+
+// ---- Database helpers -------------------------------------------------------
+
+function buildPool(): Pool {
+  return new Pool({
+    host: process.env.POSTGRES_HOST ?? 'localhost',
+    port: parseInt(process.env.POSTGRES_PORT ?? '5432', 10),
+    database: process.env.POSTGRES_DB ?? 'homelab',
+    user: process.env.POSTGRES_USER ?? 'homelab',
+    password: process.env.POSTGRES_PASSWORD ?? '',
+    max: 3,
+  });
+}
+
+// ---- Migration logic --------------------------------------------------------
+
+async function migrateStackSecrets(
+  pool: Pool,
+  fromKid: string,
+  toKid: string,
+  fromKey: CryptoKey,
+  toKey: CryptoKey,
+): Promise<number> {
+  const result = await pool.query<{ stack_name: string; variable_name: string; ciphertext_jwe: string }>(
+    'SELECT stack_name, variable_name, ciphertext_jwe FROM stack_secrets',
+  );
+
+  let count = 0;
+
+  for (const row of result.rows) {
+    if (extractKid(row.ciphertext_jwe) !== fromKid) continue;
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const plaintext = await decryptJwe(row.ciphertext_jwe, fromKey);
+      const newJwe = await encryptJwe(plaintext, toKid, toKey);
+
+      await client.query(
+        `UPDATE stack_secrets
+            SET ciphertext_jwe = $1, updated_at = now()
+          WHERE stack_name = $2 AND variable_name = $3`,
+        [newJwe, row.stack_name, row.variable_name],
+      );
+
+      await client.query('COMMIT');
+      count++;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw new Error(
+        `Failed to migrate stack_secrets(${row.stack_name}, ${row.variable_name}): ${String(err)}`,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  return count;
+}
+
+async function migrateAgentKeypairs(
+  pool: Pool,
+  fromKid: string,
+  toKid: string,
+  fromKey: CryptoKey,
+  toKey: CryptoKey,
+): Promise<number> {
+  const result = await pool.query<{ host_name: string; private_jwk_jwe: string }>(
+    'SELECT host_name, private_jwk_jwe FROM agent_keypairs',
+  );
+
+  let count = 0;
+
+  for (const row of result.rows) {
+    if (extractKid(row.private_jwk_jwe) !== fromKid) continue;
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      const plaintext = await decryptJwe(row.private_jwk_jwe, fromKey);
+      const newJwe = await encryptJwe(plaintext, toKid, toKey);
+
+      await client.query(
+        `UPDATE agent_keypairs
+            SET private_jwk_jwe = $1, rotated_at = now()
+          WHERE host_name = $2`,
+        [newJwe, row.host_name],
+      );
+
+      await client.query('COMMIT');
+      count++;
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw new Error(
+        `Failed to migrate agent_keypairs(${row.host_name}): ${String(err)}`,
+      );
+    } finally {
+      client.release();
+    }
+  }
+
+  return count;
+}
+
+// ---- Entry point ------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const { from: fromKid, to: toKid } = parseArgs();
+
+  console.info(`Loading keys: from="${fromKid}", to="${toKid}"`);
+  const [fromKey, toKey] = await Promise.all([loadKey(fromKid), loadKey(toKid)]);
+  console.info('Keys loaded successfully.');
+
+  const pool = buildPool();
+
+  try {
+    await pool.query('SELECT 1');
+    console.info('Database connected.');
+
+    const secretsMigrated = await migrateStackSecrets(pool, fromKid, toKid, fromKey, toKey);
+    const keypairsMigrated = await migrateAgentKeypairs(pool, fromKid, toKid, fromKey, toKey);
+
+    console.info(`Migration complete: ${secretsMigrated} secret(s), ${keypairsMigrated} keypair(s) migrated.`);
+  } catch (err) {
+    console.error('Migration failed:', err);
+    process.exit(1);
+  } finally {
+    await pool.end();
+  }
+}
+
+await main();

--- a/src/lib/crypto/master-key.test.ts
+++ b/src/lib/crypto/master-key.test.ts
@@ -162,6 +162,9 @@ describe('loadMasterKeyring', () => {
     await expect(loadMasterKeyring()).rejects.toThrow(/32 bytes/);
   });
 
+  // KIDs are sorted lexicographically: 'v9' > 'v10' because '9' > '1'.
+  // Operators needing more than 9 versions should use zero-padded names
+  // (v01, v02, ..., v10) to preserve natural ordering.
   it('lexicographic ordering picks v9 over v10 (natural vs lex sort awareness)', async () => {
     // Lex sort: "v10" < "v9" because "1" < "9" char comparison.
     // The active key should be "v9" (lexicographically last).

--- a/src/lib/crypto/master-key.test.ts
+++ b/src/lib/crypto/master-key.test.ts
@@ -5,12 +5,21 @@ import { join } from 'node:path';
 
 import { loadMasterKeyring } from './master-key';
 
+// Stable 32-byte key fixtures (different bytes so cross-key decryption fails predictably).
+const KEY_A = Buffer.alloc(32, 0xaa).toString('base64');
+const KEY_B = Buffer.alloc(32, 0xbb).toString('base64');
+const KEY_C = Buffer.alloc(32, 0xcc).toString('base64');
+
 describe('loadMasterKeyring', () => {
   const originalEnv = { ...process.env };
   let tmpDir: string;
 
   beforeEach(() => {
     tmpDir = mkdtempSync(join(tmpdir(), 'hlm-master-key-'));
+    // Wipe all MASTER_KEY* vars so tests start from a blank slate.
+    for (const k of Object.keys(process.env)) {
+      if (k.startsWith('MASTER_KEY')) delete process.env[k];
+    }
   });
 
   afterEach(() => {
@@ -18,28 +27,30 @@ describe('loadMasterKeyring', () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  // ---- Single-key (backward-compat) ----------------------------------------
+
   it('loads from MASTER_KEY_FILE when set', async () => {
     const file = join(tmpDir, 'master.key');
     writeFileSync(file, Buffer.alloc(32, 1).toString('base64'));
     process.env.MASTER_KEY_FILE = file;
-    delete process.env.MASTER_KEY;
     const keyring = await loadMasterKeyring();
     expect(keyring.activeKid).toBe('v1');
     expect(keyring.keys.has('v1')).toBe(true);
+    expect(keyring.keys.size).toBe(1);
   });
 
   it('falls back to MASTER_KEY env var when MASTER_KEY_FILE not set', async () => {
-    delete process.env.MASTER_KEY_FILE;
-    process.env.MASTER_KEY = Buffer.alloc(32, 2).toString('base64');
+    process.env.MASTER_KEY = KEY_A;
     const keyring = await loadMasterKeyring();
     expect(keyring.activeKid).toBe('v1');
+    expect(keyring.keys.size).toBe(1);
   });
 
   it('prefers MASTER_KEY_FILE over MASTER_KEY when both are set', async () => {
     const file = join(tmpDir, 'master.key');
-    writeFileSync(file, Buffer.alloc(32, 0xAA).toString('base64'));
+    writeFileSync(file, KEY_A);
     process.env.MASTER_KEY_FILE = file;
-    process.env.MASTER_KEY = Buffer.alloc(32, 0xBB).toString('base64');
+    process.env.MASTER_KEY = KEY_B;
 
     const fileKeyring = await loadMasterKeyring();
 
@@ -50,21 +61,113 @@ describe('loadMasterKeyring', () => {
     const { encryptValue, decryptValue } = await import('@/lib/crypto/encrypted-value');
 
     const ciphertext = await encryptValue('hello', fileKeyring);
-    // File keyring can round-trip the value.
     expect(await decryptValue(ciphertext, fileKeyring)).toBe('hello');
-    // Env keyring (different key bytes) cannot decrypt the ciphertext.
+    // Env keyring has different key bytes and cannot decrypt.
     await expect(decryptValue(ciphertext, envKeyring)).rejects.toThrow();
   });
 
   it('throws when neither env var is set', async () => {
-    delete process.env.MASTER_KEY_FILE;
-    delete process.env.MASTER_KEY;
     await expect(loadMasterKeyring()).rejects.toThrow(/MASTER_KEY/);
   });
 
   it('throws when key does not decode to 32 bytes', async () => {
-    delete process.env.MASTER_KEY_FILE;
     process.env.MASTER_KEY = Buffer.alloc(16).toString('base64');
     await expect(loadMasterKeyring()).rejects.toThrow(/32 bytes/);
+  });
+
+  // ---- Multi-key support ----------------------------------------------------
+
+  it('loads multiple keys and selects the lexicographically last KID as active', async () => {
+    process.env.MASTER_KEY = KEY_A;       // KID "v1"
+    process.env.MASTER_KEY_v2 = KEY_B;    // KID "v2"
+    const keyring = await loadMasterKeyring();
+    expect(keyring.activeKid).toBe('v2');
+    expect(keyring.keys.size).toBe(2);
+    expect(keyring.keys.has('v1')).toBe(true);
+    expect(keyring.keys.has('v2')).toBe(true);
+  });
+
+  it('can decrypt old ciphertext (v1) while new encryptions use v2', async () => {
+    const { encryptValue, decryptValue } = await import('@/lib/crypto/encrypted-value');
+
+    // Simulate existing setup: only v1 key present.
+    process.env.MASTER_KEY = KEY_A;
+    const oldKeyring = await loadMasterKeyring();
+    const oldCiphertext = await encryptValue('secret', oldKeyring);
+
+    // Add v2 key — both keys present during rotation window.
+    process.env.MASTER_KEY_v2 = KEY_B;
+    const twoKeyKeyring = await loadMasterKeyring();
+
+    // Active key switches to v2.
+    expect(twoKeyKeyring.activeKid).toBe('v2');
+
+    // Old ciphertext (encrypted under v1) still decrypts.
+    expect(await decryptValue(oldCiphertext, twoKeyKeyring)).toBe('secret');
+
+    // New ciphertext is encrypted under v2.
+    const newCiphertext = await encryptValue('secret', twoKeyKeyring);
+    const header = JSON.parse(
+      Buffer.from(newCiphertext.split('.')[0], 'base64url').toString(),
+    ) as Record<string, string>;
+    expect(header.kid).toBe('v2');
+  });
+
+  it('uses MASTER_KEY_FILE_<KID> over MASTER_KEY_<KID> for the same KID', async () => {
+    const file = join(tmpDir, 'v2.key');
+    writeFileSync(file, KEY_C);
+    process.env.MASTER_KEY = KEY_A;
+    process.env.MASTER_KEY_v2 = KEY_B;      // should be overridden by the file
+    process.env.MASTER_KEY_FILE_v2 = file;  // KEY_C wins
+
+    const keyring = await loadMasterKeyring();
+    expect(keyring.activeKid).toBe('v2');
+    expect(keyring.keys.size).toBe(2);
+
+    const { encryptValue, decryptValue } = await import('@/lib/crypto/encrypted-value');
+
+    // Encrypt with the keyring (uses v2 = KEY_C).
+    const ct = await encryptValue('x', keyring);
+
+    // A keyring with KEY_B for v2 cannot decrypt — confirms KEY_C won.
+    const keyBforV2 = await crypto.subtle.importKey(
+      'raw',
+      Buffer.from(KEY_B, 'base64'),
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['encrypt', 'decrypt'],
+    );
+    const wrongKeyring = {
+      activeKid: 'v2',
+      keys: new Map([['v2', keyBforV2]]),
+    };
+    await expect(decryptValue(ct, wrongKeyring)).rejects.toThrow();
+  });
+
+  it('throws a controlled error when KID is unknown at decryption time', async () => {
+    const { encryptValue, decryptValue } = await import('@/lib/crypto/encrypted-value');
+
+    process.env.MASTER_KEY = KEY_A;
+    const keyring = await loadMasterKeyring();
+    const ct = await encryptValue('x', keyring);
+
+    // Keyring with no keys at all — should throw "Unknown JWE kid".
+    const emptyKeyring = { activeKid: 'v1', keys: new Map<string, CryptoKey>() };
+    await expect(decryptValue(ct, emptyKeyring)).rejects.toThrow(/Unknown JWE kid/);
+  });
+
+  it('throws when a multi-key entry does not decode to 32 bytes', async () => {
+    process.env.MASTER_KEY = KEY_A;
+    process.env.MASTER_KEY_v2 = Buffer.alloc(10).toString('base64');
+    await expect(loadMasterKeyring()).rejects.toThrow(/32 bytes/);
+  });
+
+  it('lexicographic ordering picks v9 over v10 (natural vs lex sort awareness)', async () => {
+    // Lex sort: "v10" < "v9" because "1" < "9" char comparison.
+    // The active key should be "v9" (lexicographically last).
+    process.env.MASTER_KEY_v10 = KEY_A;
+    process.env.MASTER_KEY_v9 = KEY_B;
+    const keyring = await loadMasterKeyring();
+    expect(keyring.activeKid).toBe('v9');
   });
 });

--- a/src/lib/crypto/master-key.ts
+++ b/src/lib/crypto/master-key.ts
@@ -29,7 +29,7 @@ export async function loadMasterKeyring(): Promise<MasterKeyring> {
 
   if (entries.length === 0) {
     throw new Error(
-      'MASTER_KEY_FILE or MASTER_KEY environment variable must be set. ' +
+      'MASTER_KEY(_<KID>) or MASTER_KEY_FILE(_<KID>) environment variable must be set. ' +
         'Generate a key with: openssl rand -base64 32',
     );
   }

--- a/src/lib/crypto/master-key.ts
+++ b/src/lib/crypto/master-key.ts
@@ -7,28 +7,89 @@ export interface MasterKeyring {
   keys: Map<Kid, CryptoKey>;
 }
 
-const ACTIVE_KID: Kid = 'v1';
+const LEGACY_KID: Kid = 'v1';
 
+/**
+ * Load the master keyring from environment variables.
+ *
+ * Single-key (legacy) pattern — backward compatible:
+ *   MASTER_KEY / MASTER_KEY_FILE  →  KID "v1", active key
+ *
+ * Multi-key pattern (for key rotation):
+ *   MASTER_KEY_<KID> / MASTER_KEY_FILE_<KID>  →  additional keys by explicit KID
+ *   e.g. MASTER_KEY_v2=<base64>
+ *
+ * The active key is the lexicographically last KID across all loaded keys.
+ * During rotation both keys are present, so old ciphertext decrypts with the old
+ * key while new encryptions use the new key. After running the migration CLI and
+ * removing the old env var, only the new key remains.
+ */
 export async function loadMasterKeyring(): Promise<MasterKeyring> {
-  const raw = readMasterKeyBase64();
-  const bytes = Uint8Array.from(Buffer.from(raw, 'base64'));
-  if (bytes.byteLength !== 32) {
+  const entries = collectKeyEntries();
+
+  if (entries.length === 0) {
     throw new Error(
-      `Master key must decode to 32 bytes; got ${bytes.byteLength}. ` +
-        `Generate with: openssl rand -base64 32`,
+      'MASTER_KEY_FILE or MASTER_KEY environment variable must be set. ' +
+        'Generate a key with: openssl rand -base64 32',
     );
   }
-  const key = await crypto.subtle.importKey(
-    'raw',
-    bytes,
-    { name: 'AES-GCM', length: 256 },
-    false,
-    ['encrypt', 'decrypt'],
+
+  const loaded = await Promise.all(
+    entries.map(async ({ kid, raw }) => ({ kid, key: await importRawKey(raw, kid) })),
   );
-  return { activeKid: ACTIVE_KID, keys: new Map<Kid, CryptoKey>([[ACTIVE_KID, key]]) };
+
+  const keys = new Map<Kid, CryptoKey>(loaded.map(({ kid, key }) => [kid, key]));
+
+  // Lexicographically last KID is the active key for new encryptions.
+  const sortedKids = [...keys.keys()].sort();
+  const activeKid = sortedKids[sortedKids.length - 1];
+
+  return { activeKid, keys };
 }
 
-function readMasterKeyBase64(): string {
+/** Parse all key env vars and return { kid, raw } pairs. */
+function collectKeyEntries(): Array<{ kid: Kid; raw: string }> {
+  const entries: Array<{ kid: Kid; raw: string }> = [];
+
+  // Legacy single-key pattern: MASTER_KEY / MASTER_KEY_FILE → KID "v1"
+  const legacyRaw = readLegacyKey();
+  if (legacyRaw !== null) {
+    entries.push({ kid: LEGACY_KID, raw: legacyRaw });
+  }
+
+  // Multi-key pattern: MASTER_KEY_<KID> / MASTER_KEY_FILE_<KID>
+  for (const [name, value] of Object.entries(process.env)) {
+    if (!value) continue;
+    // Skip the legacy bare names handled above.
+    if (name === 'MASTER_KEY' || name === 'MASTER_KEY_FILE') continue;
+
+    // MASTER_KEY_FILE_<KID> takes priority over MASTER_KEY_<KID> for the same KID.
+    const fileMatch = /^MASTER_KEY_FILE_(.+)$/.exec(name);
+    if (fileMatch) {
+      const kid = fileMatch[1];
+      // Avoid re-registering "v1" if MASTER_KEY_FILE was already picked up above.
+      if (kid !== LEGACY_KID || legacyRaw === null) {
+        entries.push({ kid, raw: readFileSync(value.trim(), 'utf-8').trim() });
+      }
+      continue;
+    }
+
+    const keyMatch = /^MASTER_KEY_(.+)$/.exec(name);
+    if (keyMatch) {
+      const kid = keyMatch[1];
+      // Skip if MASTER_KEY_FILE_<KID> was already collected for this KID.
+      const alreadyHaveKid = entries.some((e) => e.kid === kid);
+      if (!alreadyHaveKid) {
+        entries.push({ kid, raw: value.trim() });
+      }
+    }
+  }
+
+  return entries;
+}
+
+/** Read the legacy MASTER_KEY / MASTER_KEY_FILE env vars. Returns null if neither is set. */
+function readLegacyKey(): string | null {
   const filePath = process.env.MASTER_KEY_FILE;
   if (filePath && filePath.length > 0) {
     return readFileSync(filePath, 'utf-8').trim();
@@ -37,8 +98,22 @@ function readMasterKeyBase64(): string {
   if (fromEnv && fromEnv.trim().length > 0) {
     return fromEnv.trim();
   }
-  throw new Error(
-    'MASTER_KEY_FILE or MASTER_KEY environment variable must be set. ' +
-      'Generate a key with: openssl rand -base64 32',
+  return null;
+}
+
+async function importRawKey(base64: string, kid: Kid): Promise<CryptoKey> {
+  const bytes = Uint8Array.from(Buffer.from(base64, 'base64'));
+  if (bytes.byteLength !== 32) {
+    throw new Error(
+      `Master key "${kid}" must decode to 32 bytes; got ${bytes.byteLength}. ` +
+        `Generate with: openssl rand -base64 32`,
+    );
+  }
+  return crypto.subtle.importKey(
+    'raw',
+    bytes,
+    { name: 'AES-GCM', length: 256 },
+    false,
+    ['encrypt', 'decrypt'],
   );
 }


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Extends `loadMasterKeyring()` to support multiple keys: `MASTER_KEY`/`MASTER_KEY_FILE` remain as KID `v1` (backward compatible), and `MASTER_KEY_<KID>`/`MASTER_KEY_FILE_<KID>` add extra keys for rotation.
- The lexicographically last KID is the active key for new encryptions; all keys are available for decryption by KID embedded in the JWE header.
- Adds `scripts/migrate-master-key.ts` — a standalone Bun CLI that re-encrypts all rows in `stack_secrets` and `agent_keypairs` from one KID to another, row by row in individual transactions (safe to interrupt and re-run).
- Adds `bun run migrate-secrets` script entry to `package.json`.
- Extends `master-key.test.ts` with 6 new tests covering multi-key loading, rotation window decryption, `MASTER_KEY_FILE_<KID>` priority, unknown KID error, bad key length for named KID, and lexicographic ordering.
- Adds a "Key Rotation" section to `CLAUDE.md` with the full rotation procedure.

## Test plan

- [ ] `bun run typecheck:all` passes (no type errors)
- [ ] `bun test --isolate src/lib/crypto/` — all 18 tests pass (11 for master-key, 7 for encrypted-value/agent-jwt)
- [ ] Single-key deployment: existing `MASTER_KEY`/`MASTER_KEY_FILE` setup loads as before with `activeKid = "v1"`
- [ ] Rotation window: both `MASTER_KEY=<old>` and `MASTER_KEY_v2=<new>` present — `activeKid` is `v2`, old ciphertext still decrypts
- [ ] `bun run migrate-secrets --from v1 --to v2` (with both keys set) prints migration summary and exits 0
- [ ] Missing KID throws: `bun run migrate-secrets --from v1 --to v2` with only one key exits non-zero with descriptive error

https://claude.ai/code/session_01GASjVnYwBc2xMy441usALW
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GASjVnYwBc2xMy441usALW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Master key rotation support to transition encryption keys while preserving access to existing encrypted data.
  * New CLI command to migrate/re-encrypt secrets between master keys.

* **Documentation**
  * Added a step-by-step key rotation guide and environment configuration details.

* **Tests**
  * Expanded tests covering multi-key rotation, precedence rules, validation, and encryption/decryption behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/177)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->