### PR TITLE
fix(crypto): sanitize JWE decryption errors at repository boundary

### DIFF
--- a/src/lib/database/repositories/__tests__/agent-keypairs-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/agent-keypairs-repository.test.ts
@@ -57,6 +57,11 @@ describe('AgentKeypairsRepository', () => {
     expect(key).not.toBeNull();
   });
 
+  it('getPrivateKeyForHost throws controlled error when decryption fails', async () => {
+    pool.results.push({ rows: [{ private_jwk_jwe: 'not.a.valid.jwe.token' }] });
+    await expect(repo.getPrivateKeyForHost('h')).rejects.toThrow('Agent keypair decryption failed');
+  });
+
   it('getPrivateKeyForHost returns null when row missing', async () => {
     pool.results.push({ rows: [] });
     expect(await repo.getPrivateKeyForHost('absent')).toBeNull();

--- a/src/lib/database/repositories/__tests__/stack-secrets-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/stack-secrets-repository.test.ts
@@ -56,6 +56,11 @@ describe('StackSecretsRepository', () => {
     expect(await repo.get('s', 'V')).toBe('secret-value');
   });
 
+  it('get throws controlled error when decryption fails', async () => {
+    pool.results.push({ rows: [{ ciphertext_jwe: 'not.a.valid.jwe.token' }] });
+    await expect(repo.get('s', 'V')).rejects.toThrow('Secret decryption failed');
+  });
+
   it('set encrypts and upserts', async () => {
     pool.results.push({ rows: [] });
     await repo.set('s', 'V', 'plaintext');

--- a/src/lib/database/repositories/agent-keypairs-repository.ts
+++ b/src/lib/database/repositories/agent-keypairs-repository.ts
@@ -39,7 +39,12 @@ export class AgentKeypairsRepository {
     );
     if (result.rows.length === 0) return null;
     const jwe = (result.rows[0] as { private_jwk_jwe: string }).private_jwk_jwe;
-    const json = await decryptValue(jwe, this.keyring);
+    let json: string;
+    try {
+      json = await decryptValue(jwe, this.keyring);
+    } catch {
+      throw new Error('Agent keypair decryption failed');
+    }
     const jwk = JSON.parse(json) as JWK;
     return (await importJWK(jwk, 'EdDSA')) as CryptoKey;
   }

--- a/src/lib/database/repositories/stack-secrets-repository.ts
+++ b/src/lib/database/repositories/stack-secrets-repository.ts
@@ -22,7 +22,11 @@ export class StackSecretsRepository {
       [stackName, variableName],
     );
     if (result.rows.length === 0) return null;
-    return decryptValue((result.rows[0] as { ciphertext_jwe: string }).ciphertext_jwe, this.keyring);
+    try {
+      return await decryptValue((result.rows[0] as { ciphertext_jwe: string }).ciphertext_jwe, this.keyring);
+    } catch {
+      throw new Error('Secret decryption failed');
+    }
   }
 
   async set(stackName: string, variableName: string, value: string): Promise<void> {

--- a/src/lib/deploy/pipeline-factory.ts
+++ b/src/lib/deploy/pipeline-factory.ts
@@ -54,9 +54,16 @@ export async function createDeployPipeline(): Promise<DeployPipelineBundle> {
     secretResolver: {
       async resolve(stack: string, variables: string[]): Promise<Record<string, string>> {
         if (variables.length === 0) return {};
-        const entries = await Promise.all(
+        const results = await Promise.allSettled(
           variables.map(async (v) => [v, await stackSecrets.get(stack, v)] as const),
         );
+        const failed = results.filter((r) => r.status === 'rejected').length;
+        if (failed > 0) {
+          throw new Error(`Failed to decrypt ${failed} secret(s) for stack "${stack}". Check that MASTER_KEY is correct.`);
+        }
+        const entries = results
+          .filter((r): r is PromiseFulfilledResult<readonly [string, string | null]> => r.status === 'fulfilled')
+          .map((r) => r.value);
         const secrets: Record<string, string> = {};
         for (const [k, v] of entries) {
           if (v !== null) secrets[k] = v;

--- a/src/lib/deploy/pipeline-factory.ts
+++ b/src/lib/deploy/pipeline-factory.ts
@@ -57,9 +57,21 @@ export async function createDeployPipeline(): Promise<DeployPipelineBundle> {
         const results = await Promise.allSettled(
           variables.map(async (v) => [v, await stackSecrets.get(stack, v)] as const),
         );
-        const failed = results.filter((r) => r.status === 'rejected').length;
-        if (failed > 0) {
-          throw new Error(`Failed to decrypt ${failed} secret(s) for stack "${stack}". Check that MASTER_KEY is correct.`);
+        const rejected = results.filter((r): r is PromiseRejectedResult => r.status === 'rejected');
+        const decryptionFailures = rejected.filter(
+          (r) => r.reason instanceof Error && r.reason.message === 'Secret decryption failed',
+        );
+        const otherFailures = rejected.filter((r) => !decryptionFailures.includes(r));
+
+        if (otherFailures.length > 0) {
+          throw otherFailures[0].reason instanceof Error
+            ? otherFailures[0].reason
+            : new Error(String(otherFailures[0].reason));
+        }
+        if (decryptionFailures.length > 0) {
+          throw new Error(
+            `Failed to decrypt ${decryptionFailures.length} secret(s) for stack "${stack}". Check that MASTER_KEY is correct.`,
+          );
         }
         const entries = results
           .filter((r): r is PromiseFulfilledResult<readonly [string, string | null]> => r.status === 'fulfilled')


### PR DESCRIPTION
## Summary

Raw jose errors from `compactDecrypt` were propagating directly to API callers. The jose library includes internal details in error messages (KID values, crypto operation context) that should not be visible to callers.

- **Fix A (repository layer)**: `StackSecretsRepository.get()` and `AgentKeypairsRepository.getPrivateKeyForHost()` now wrap the `decryptValue()` call in try/catch and throw a controlled message instead of letting the raw jose error propagate. Only the decryption step is caught; other errors (DB query failures, JSON parse errors, `importJWK`) still propagate normally.
- **Fix B (pipeline)**: `pipeline-factory` `secretResolver.resolve()` now uses `Promise.allSettled` instead of `Promise.all`. A single bad secret no longer causes an unhandled rejection that short-circuits the others; the error written to `deploy_history` is a controlled message listing the count of failed secrets and a hint to check `MASTER_KEY`.

Tests added for both decryption-failure paths.

## Test plan

- [ ] `bun test --isolate src/lib/database/repositories/__tests__/stack-secrets-repository.test.ts` passes (includes new "throws controlled error" case)
- [ ] `bun test --isolate src/lib/database/repositories/__tests__/agent-keypairs-repository.test.ts` passes (includes new "throws controlled error" case)
- [ ] `bun run typecheck:all` passes
- [ ] CI build and test pass

https://claude.ai/code/session_01GASjVnYwBc2xMy441usALW

---
_Generated by [Claude Code](https://claude.ai/code/session_01GASjVnYwBc2xMy441usALW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized and clarified error messages for secret and key decryption failures.
  * Deployment resolution now aggregates decryption failures and surfaces actionable errors instead of failing fast.

* **Tests**
  * Added unit tests covering decryption error scenarios for repository operations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/178)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/178)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->