### PR TITLE
fix(deps): bump vite from 8.0.3 to 8.0.5

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -60,7 +60,7 @@
         "cross-env": "10.1.0",
         "typescript": "6.0.2",
         "undici": "8.0.2",
-        "vite": "8.0.3",
+        "vite": "8.0.5",
         "web-vitals": "5.2.0",
       },
     },
@@ -1056,7 +1056,7 @@
 
     "uuid": ["uuid@10.0.0", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ=="],
 
-    "vite": ["vite@8.0.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ=="],
+    "vite": ["vite@8.0.5", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.8", "rolldown": "1.0.0-rc.12", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ=="],
 
     "vite-tsconfig-paths": ["vite-tsconfig-paths@6.1.1", "", { "dependencies": { "debug": "^4.1.1", "globrex": "^0.1.2", "tsconfck": "^3.0.3" }, "peerDependencies": { "vite": "*" } }, "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg=="],
 

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "cross-env": "10.1.0",
     "typescript": "6.0.2",
     "undici": "8.0.2",
-    "vite": "8.0.3",
+    "vite": "8.0.5",
     "web-vitals": "5.2.0"
   }
 }


### PR DESCRIPTION
## Summary

- Bumps vite from 8.0.3 to 8.0.5 to address three Dependabot-flagged security vulnerabilities (2 high, 1 moderate)
- No config migration required; all fixes are internal to the vite dev server
- Replaces the stale Dependabot PR #157, which had CI failures and was out of date with main

## Vulnerabilities fixed (vite 8.0.5)

All four patches are dev-server-only and do not affect the production build:

- **Path traversal via optimize deps sourcemap handler**: the sourcemap endpoint could serve files outside the project root via `../` sequences
- **`server.fs` bypass via query string**: the allowlist check was skipped when a query string was appended to the URL
- **`server.fs` bypass via env transport**: the allowlist check was missing on the env variable transport endpoint entirely
- **Sourcemap referencing files outside the package**: sourcemaps could point to arbitrary paths on disk, leaking file contents to devtools

## Test plan

- [x] `bun run typecheck:all` passes
- [x] CI pipeline passes

https://claude.ai/code/session_01CUxrcW1WVyyzMTbhUGom3V