### PR TITLE
feat(demo): add simulated terminal session for demo mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 
 **First-time setup / dependency changes:**
 - Run `bun run setup` (installs homelab-manager and agent). The agent is NOT a workspace member; its lockfile is independent so the docker build (`context: ./agent`) stays self-consistent.
+- Always pin dependencies to an exact version (no `^` or `~`). All existing entries in `package.json` are pinned; new additions must follow the same pattern.
 
 **After editing files:**
 - When `<new-diagnostics>` appear with SonarQube issues on files you just edited, fix them before moving on. Only fix issues on files you modified, do not touch unrelated files.

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -11,8 +11,9 @@ import Toasts from '@/components/Toasts'
 import { useSettingsSync } from '@/hooks/useSettingsSync'
 import { useLightPaletteEffect } from '@/hooks/useLightPaletteEffect'
 import { queryClient } from '@/lib/query-client'
+import { IS_DEMO_MODE } from '@/lib/constants/demo'
 
-if (import.meta.env.VITE_DEMO_MODE === 'true' && typeof window !== 'undefined') {
+if (IS_DEMO_MODE && typeof window !== 'undefined') {
   // Use .then() instead of top-level await to avoid circular dependency deadlock.
   // The main chunk imports install-demo, which statically imports back from the main
   // chunk (for mock generators). TLA pauses main mid-evaluation, causing deadlock.

--- a/src/components/docker/ContainerLogsTerminalPanel.tsx
+++ b/src/components/docker/ContainerLogsTerminalPanel.tsx
@@ -11,6 +11,7 @@ import ContainerLogViewer from '@/components/docker/ContainerLogViewer';
 import ContainerTerminal from '@/components/docker/ContainerTerminal';
 import { useDockerSettings } from '@/hooks/useDockerSettings';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
+import { IS_DEMO_MODE } from '@/lib/constants/demo';
 
 interface ContainerLogsTerminalPanelProps {
   containerId: string;
@@ -84,7 +85,9 @@ export default memo(function ContainerLogsTerminalPanel({
               value={effectiveShell === 'auto' ? '' : effectiveShell}
               onChange={handleShellChange}
               displayEmpty
+              disabled={IS_DEMO_MODE}
               renderValue={(v) => {
+                if (IS_DEMO_MODE) return 'auto (demo)';
                 const setting = (v as string) || 'auto';
                 if (setting !== 'auto') return setting;
                 if (resolvedShell) return `auto (${resolvedShell})`;

--- a/src/components/docker/ContainerTerminal.tsx
+++ b/src/components/docker/ContainerTerminal.tsx
@@ -2,6 +2,10 @@ import { memo, useEffect, useState } from 'react';
 import { Button, Paper, Skeleton, Typography } from '@mui/material';
 import { useXtermSetup } from '@/hooks/useXtermSetup';
 import { useContainerTerminal } from '@/hooks/useContainerTerminal';
+import { useContainerTerminal as useDemoContainerTerminal } from '@/hooks/useDemoContainerTerminal';
+import { IS_DEMO_MODE } from '@/lib/constants/demo';
+
+const useTerminalSession = IS_DEMO_MODE ? useDemoContainerTerminal : useContainerTerminal;
 
 interface ContainerTerminalProps {
   containerId: string;
@@ -26,7 +30,7 @@ export default memo(function ContainerTerminal({
   });
   const [ready, setReady] = useState(false);
 
-  const { isConnected, error: wsError, resolvedShell, sessionEnded, reconnect } = useContainerTerminal({
+  const { isConnected, error: wsError, resolvedShell, sessionEnded, reconnect } = useTerminalSession({
     containerId,
     host,
     shell,

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -15,6 +15,7 @@ import {
 import { useCurrentTab, useMenuController } from '@/components/header/useMenuController'
 import { MenuContentFor, NavMenuCloseContext } from '@/components/header/menus'
 import { DemoBanner } from '@/components/header/DemoBanner'
+import { IS_DEMO_MODE } from '@/lib/constants/demo'
 
 // Brand SVGs (Docker, Proxmox) lack the small transparent padding that lucide icons
 // bake into their viewBoxes, so they sit too close to the tab label. This set marks
@@ -134,7 +135,7 @@ export default function Header() {
         )
       })}
 
-      {import.meta.env.VITE_DEMO_MODE === 'true' && <DemoBanner />}
+      {IS_DEMO_MODE && <DemoBanner />}
     </header>
   )
 }

--- a/src/hooks/useDemoContainerTerminal.ts
+++ b/src/hooks/useDemoContainerTerminal.ts
@@ -1,0 +1,76 @@
+import { useEffect, useRef } from 'react';
+import type { Terminal } from '@xterm/xterm';
+
+interface UseContainerTerminalOptions {
+  containerId: string;
+  host: string;
+  shell: string;
+  terminal: Terminal | null;
+  enabled?: boolean;
+}
+
+interface UseContainerTerminalResult {
+  isConnected: boolean;
+  error: Error | null;
+  resolvedShell?: string;
+  sessionEnded: boolean;
+  reconnect: () => void;
+}
+
+const BANNER = [
+  '\x1b[1;33m[Demo Mode]\x1b[0m This is a simulated terminal session.',
+  'No real shell is connected. Type anything and press Enter.',
+  '',
+].join('\r\n');
+
+const PROMPT = '$ ';
+
+export function useContainerTerminal({
+  terminal,
+  enabled = true,
+}: UseContainerTerminalOptions): UseContainerTerminalResult {
+  const activeRef = useRef(false);
+
+  useEffect(() => {
+    if (!terminal || !enabled || activeRef.current) return;
+    activeRef.current = true;
+
+    terminal.write(BANNER + PROMPT);
+
+    let line = '';
+
+    const dataListener = terminal.onData((data) => {
+      const code = data.charCodeAt(0);
+
+      if (data === '\r') {
+        terminal.write('\r\n');
+        if (line.trim()) terminal.write(`you typed: ${line}\r\n`);
+        line = '';
+        terminal.write(PROMPT);
+      } else if (code === 0x7f) {
+        // Backspace
+        if (line.length > 0) {
+          line = line.slice(0, -1);
+          terminal.write('\b \b');
+        }
+      } else if (code >= 0x20) {
+        // Printable character
+        line += data;
+        terminal.write(data);
+      }
+    });
+
+    return () => {
+      dataListener.dispose();
+      activeRef.current = false;
+    };
+  }, [terminal, enabled]);
+
+  return {
+    isConnected: true,
+    error: null,
+    resolvedShell: 'demo',
+    sessionEnded: false,
+    reconnect: () => {},
+  };
+}

--- a/src/lib/constants/demo.ts
+++ b/src/lib/constants/demo.ts
@@ -1,0 +1,1 @@
+export const IS_DEMO_MODE = import.meta.env.VITE_DEMO_MODE === 'true';


### PR DESCRIPTION
## Summary

- Adds `useDemoContainerTerminal` hook that writes a banner and echoes typed input directly via xterm.js, bypassing the WebSocket connection
- Locks the shell selector dropdown to `auto (demo)` in demo mode to prevent user confusion
- Extracts `IS_DEMO_MODE` constant to `src/lib/constants/demo.ts` replacing inline `import.meta.env.VITE_DEMO_MODE === 'true'` checks across all files
- Adds dependency pinning rule to CLAUDE.md

## Test plan

- [ ] Run `bun dev:demo`, open a container's Terminal tab, verify banner displays and typed input echoes back
- [ ] Verify empty Enter press produces no output
- [ ] Verify shell dropdown shows "auto (demo)" and is disabled
- [ ] Run `bun dev` (non-demo), verify terminal connects normally via WebSocket
- [ ] `bun run typecheck:all && bun run test:all` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive demo terminal simulation with input echoing and command feedback.

* **Improvements**
  * Shell selection is now disabled in demo mode for clarity.
  * Centralized demo mode detection across the application for consistency.

* **Chores**
  * Updated dependency management requirements to enforce exact version pinning.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/194)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->