### PR TITLE
fix(ci): skip SonarCloud on Dependabot PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
     needs: [build-test, agent]
+    if: github.actor != 'dependabot[bot]'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- Adds `if: github.actor != 'dependabot[bot]'` to the `sonarcloud` job
- GitHub withholds repository secrets from Dependabot workflow runs, so `SONAR_TOKEN` is always empty and the scan fails with "Project not found"
- SonarCloud continues to run on all human PRs and every push to `main`

## Test plan

- [ ] Merge this PR and verify a new Dependabot PR's CI run shows the SonarCloud job as skipped (not failed)
- [ ] Confirm a regular PR still runs SonarCloud successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow conditions to refine automated job execution.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/195)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->