### PR TITLE
ci: add agent-updater job to catch lockfile/type failures on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,10 +119,66 @@ jobs:
           path: agent/license-report.json
           retention-days: 30
 
+  agent-updater:
+    name: Agent Updater Test & License Check
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 2
+
+      - name: Detect dependency changes
+        uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            dependencies:
+              - 'agent-updater/package.json'
+              - 'agent-updater/bun.lock'
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: cd agent-updater && bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: cd agent-updater && bun run typecheck
+
+      - name: Run tests with coverage check
+        run: cd agent-updater && bun run test:coverage
+        env:
+          NODE_ENV: test
+
+      - name: Check licenses
+        if: github.event_name == 'push' || steps.changes.outputs.dependencies == 'true'
+        run: |
+          cd agent-updater && bunx license-checker-rseidelsohn \
+            --excludePrivatePackages \
+            --onlyAllow "MIT;ISC;BSD-3-Clause;BSD-2-Clause;Apache-2.0;MIT-0;Unlicense;MPL-2.0;OFL-1.1;Python-2.0;CC-BY-4.0;BlueOak-1.0.0;CC0-1.0;0BSD" \
+            --summary
+
+      - name: Generate license report
+        if: github.event_name == 'push' || steps.changes.outputs.dependencies == 'true'
+        run: |
+          cd agent-updater
+          bunx license-checker-rseidelsohn --json > license-report.json
+          bunx license-checker-rseidelsohn --summary
+
+      - name: Upload license report
+        if: github.event_name == 'push' || steps.changes.outputs.dependencies == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-updater-license-report
+          path: agent-updater/license-report.json
+          retention-days: 30
+
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
-    needs: [build-test, agent]
+    needs: [build-test, agent, agent-updater]
     if: github.actor != 'dependabot[bot]'
 
     steps:
@@ -139,7 +195,7 @@ jobs:
   publish:
     name: Publish Docker Images
     runs-on: ubuntu-latest
-    needs: [build-test, agent]
+    needs: [build-test, agent, agent-updater]
     if: github.event_name == 'push'
     permissions:
       contents: read
@@ -249,7 +305,7 @@ jobs:
   deploy-demo:
     name: Deploy Demo to GitHub Pages
     runs-on: ubuntu-latest
-    needs: [build-test, agent]
+    needs: [build-test, agent, agent-updater]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     concurrency:
       group: pages


### PR DESCRIPTION
## Summary

- Adds an `Agent Updater Test & License Check` CI job mirroring the existing `agent` job
- Runs `bun install --frozen-lockfile`, typecheck, coverage check, and license report for `agent-updater/`
- `sonarcloud`, `publish`, and `deploy-demo` now all require this job to pass
- Catches stale `agent-updater/bun.lock` on PRs instead of after merging to main

## Context

The `agent-updater` lockfile was only exercised during Docker image builds in the `publish` job, which only runs on push to main. A stale lockfile would sail through all PR checks and only fail post-merge (as happened today when a dependabot merge broke the `agent-updater` Docker build on main).

## Test plan

- [ ] CI passes on this PR with the new job green
- [ ] Verify the new job appears in the PR checks list alongside Build/Agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline reliability and execution flow through infrastructure enhancements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/197)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->