### PR TITLE
feat(auth): add OIDC authentication with RBAC

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -55,3 +55,19 @@ HOMELAB_DEV_SEED="false"
 
 # Start management profile services (agent, socket-proxy)
 COMPOSE_PROFILES="management"
+
+# Auth (required unless disabled)
+DISABLE_AUTH="false"
+
+# OIDC Provider
+OIDC_ISSUER_URL="https://pocketid.example.com"
+OIDC_CLIENT_ID="homelab-manager"
+OIDC_REDIRECT_URI="http://localhost:3000/api/auth/callback"
+
+# Session
+SESSION_TTL_HOURS="8"
+
+# Role Mapping (OIDC group name -> role)
+OIDC_ROLE_ADMIN="homelab-admins"
+OIDC_ROLE_OPERATOR="homelab-operators"
+OIDC_ROLE_VIEWER="homelab-viewers"

--- a/.env.example
+++ b/.env.example
@@ -56,13 +56,13 @@ HOMELAB_DEV_SEED="false"
 # Start management profile services (agent, socket-proxy)
 COMPOSE_PROFILES="management"
 
-# Auth (required unless disabled)
-DISABLE_AUTH="false"
+# Auth (opt-in — set AUTH_ENABLED=true to require OIDC login)
+# AUTH_ENABLED="true"
 
-# OIDC Provider
-OIDC_ISSUER_URL="https://pocketid.example.com"
-OIDC_CLIENT_ID="homelab-manager"
-OIDC_REDIRECT_URI="http://localhost:3000/api/auth/callback"
+# OIDC Provider (required when AUTH_ENABLED=true)
+# OIDC_ISSUER_URL="https://pocketid.example.com"
+# OIDC_CLIENT_ID="homelab-manager"
+# OIDC_REDIRECT_URI="http://localhost:3000/api/auth/callback"
 
 # Session
 SESSION_TTL_HOURS="8"

--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,7 @@ COMPOSE_PROFILES="management"
 # OIDC Provider (required when AUTH_ENABLED=true)
 # OIDC_ISSUER_URL="https://pocketid.example.com"
 # OIDC_CLIENT_ID="homelab-manager"
+# OIDC_CLIENT_SECRET="replace-with-client-secret"
 # OIDC_REDIRECT_URI="http://localhost:3000/api/auth/callback"
 
 # Session

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -206,6 +206,7 @@ Non-obvious pitfalls from past sessions (not restated from rules above):
 11. **CSS vars empty on initial render**: CSS custom properties can resolve to empty strings before the theme applies. `CanvasGradient.addColorStop()` throws on empty color. Always guard canvas color operations.
 12. **Virtualizer remounting resets component state**: When `useVirtualizer` repositions rows after collapse, components remount and lose refs/state. Use entity-keyed external state (not component-local refs) for data that must survive remounting (e.g., sparkline accumulators).
 13. **Collapse + virtualizer can't sync**: MUI Collapse (CSS transitions) and virtualizer repositioning (JS `measureElement`) run on different systems. Don't virtualize the outer level (host rows); only virtualize inner levels (container rows).
+14. **MCP tool parameters are plain JSON strings**: Never use `$(cat <<'EOF'` or heredoc syntax in MCP tool call parameters (e.g., `mcp__github__create_pull_request` body). Heredoc is only for bash commands like `git commit -m` or `gh pr create` where the shell interprets the string. In MCP calls, it appears literally in the output.
 
 ## CI/CD
 

--- a/migrations/023_auth_tables.sql
+++ b/migrations/023_auth_tables.sql
@@ -1,4 +1,4 @@
--- migrations/017_auth_tables.sql
+-- migrations/023_auth_tables.sql
 -- OIDC authentication: users, sessions, and git tokens
 
 CREATE TABLE IF NOT EXISTS users (

--- a/migrations/023_auth_tables.sql
+++ b/migrations/023_auth_tables.sql
@@ -1,0 +1,38 @@
+-- migrations/017_auth_tables.sql
+-- OIDC authentication: users, sessions, and git tokens
+
+CREATE TABLE IF NOT EXISTS users (
+  id            SERIAL PRIMARY KEY,
+  oidc_subject  TEXT NOT NULL UNIQUE,
+  email         TEXT NOT NULL,
+  name          TEXT,
+  role          TEXT NOT NULL CHECK (role IN ('admin', 'operator', 'viewer')),
+  oidc_groups   JSONB NOT NULL DEFAULT '[]',
+  last_login    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS sessions (
+  id              TEXT PRIMARY KEY,
+  user_id         INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  encrypted_oidc  TEXT,
+  ip_address      INET,
+  user_agent      TEXT,
+  expires_at      TIMESTAMPTZ NOT NULL,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_sessions_user_id ON sessions(user_id);
+CREATE INDEX IF NOT EXISTS idx_sessions_expires_at ON sessions(expires_at);
+
+CREATE TABLE IF NOT EXISTS git_tokens (
+  id                  SERIAL PRIMARY KEY,
+  user_id             INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  encrypted_token     TEXT NOT NULL,
+  label               TEXT NOT NULL,
+  last_used_at        TIMESTAMPTZ,
+  created_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_git_tokens_user_id ON git_tokens(user_id);

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react'
 import { QueryClientProvider } from '@tanstack/react-query'
+import { CircularProgress } from '@mui/material'
 import {
   DOCKER_PRELOAD_KEY, ZFS_PRELOAD_KEY, PROXMOX_PRELOAD_KEY,
   PRELOAD_STALE_TIME,
@@ -12,6 +13,7 @@ import { useSettingsSync } from '@/hooks/useSettingsSync'
 import { useLightPaletteEffect } from '@/hooks/useLightPaletteEffect'
 import { queryClient } from '@/lib/query-client'
 import { IS_DEMO_MODE } from '@/lib/constants/demo'
+import { useAuth } from '@/hooks/useAuth'
 
 if (IS_DEMO_MODE && typeof window !== 'undefined') {
   // Use .then() instead of top-level await to avoid circular dependency deadlock.
@@ -23,6 +25,7 @@ if (IS_DEMO_MODE && typeof window !== 'undefined') {
 }
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
+  const { loading } = useAuth()
   useSettingsSync()
   useLightPaletteEffect()
 
@@ -32,6 +35,16 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
     queryClient.ensureQueryData({ queryKey: [...ZFS_PRELOAD_KEY], queryFn: preloadZFSStats, staleTime: PRELOAD_STALE_TIME }).catch((err) => console.error('Failed to preload ZFS stats:', err))
     queryClient.ensureQueryData({ queryKey: [...PROXMOX_PRELOAD_KEY], queryFn: preloadProxmoxStats, staleTime: PRELOAD_STALE_TIME }).catch((err) => console.error('Failed to preload Proxmox stats:', err))
   }, [])
+
+  if (loading) {
+    return (
+      <ThemeProvider>
+        <div className="flex items-center justify-center min-h-screen">
+          <CircularProgress />
+        </div>
+      </ThemeProvider>
+    )
+  }
 
   return (
     <ThemeProvider>

--- a/src/components/auth/DeniedPage.tsx
+++ b/src/components/auth/DeniedPage.tsx
@@ -1,0 +1,17 @@
+export default function DeniedPage() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-[var(--mui-palette-background-default)]">
+      <div className="flex flex-col items-center gap-4 p-8 rounded-xl bg-[var(--mui-palette-background-paper)] shadow-lg w-full max-w-md text-center">
+        <h1 className="text-2xl font-semibold text-[var(--mui-palette-text-primary)]">
+          You don&apos;t have access to this application
+        </h1>
+        <p className="text-[var(--mui-palette-text-secondary)]">
+          Your account is not assigned to any recognized role in your OIDC provider
+        </p>
+        <p className="text-[var(--mui-palette-text-secondary)]">
+          Please contact your administrator to be added to the appropriate group
+        </p>
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/LoginPage.tsx
+++ b/src/components/auth/LoginPage.tsx
@@ -1,0 +1,17 @@
+export default function LoginPage() {
+  return (
+    <div className="flex items-center justify-center min-h-screen bg-[var(--mui-palette-background-default)]">
+      <div className="flex flex-col items-center gap-6 p-8 rounded-xl bg-[var(--mui-palette-background-paper)] shadow-lg w-full max-w-sm">
+        <h1 className="text-2xl font-semibold text-[var(--mui-palette-text-primary)]">
+          Homelab Manager
+        </h1>
+        <a
+          href="/api/auth/login"
+          className="w-full text-center py-2 px-4 rounded-md bg-[var(--mui-palette-primary-main)] text-[var(--mui-palette-primary-contrastText)] font-medium hover:bg-[var(--mui-palette-primary-dark)] transition-colors"
+        >
+          Sign in
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/src/components/auth/__tests__/DeniedPage.test.tsx
+++ b/src/components/auth/__tests__/DeniedPage.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import DeniedPage from '../DeniedPage';
+
+describe('DeniedPage', () => {
+  it('renders the access denied heading', () => {
+    render(<DeniedPage />);
+    expect(screen.getByText(/You don't have access to this application/)).toBeDefined();
+  });
+
+  it('renders descriptive OIDC role message', () => {
+    render(<DeniedPage />);
+    expect(
+      screen.getByText(/Your account is not assigned to any recognized role in your OIDC provider/),
+    ).toBeDefined();
+  });
+
+  it('renders contact administrator text', () => {
+    render(<DeniedPage />);
+    expect(
+      screen.getByText(/Please contact your administrator to be added to the appropriate group/),
+    ).toBeDefined();
+  });
+});

--- a/src/components/auth/__tests__/DeniedPage.test.tsx
+++ b/src/components/auth/__tests__/DeniedPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import { render, screen } from '@testing-library/react';
-import DeniedPage from '../DeniedPage';
+import DeniedPage from '@/components/auth/DeniedPage';
 
 describe('DeniedPage', () => {
   it('renders the access denied heading', () => {

--- a/src/components/auth/__tests__/LoginPage.test.tsx
+++ b/src/components/auth/__tests__/LoginPage.test.tsx
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import LoginPage from '../LoginPage';
+
+describe('LoginPage', () => {
+  it('renders the app name heading', () => {
+    render(<LoginPage />);
+    expect(screen.getByText('Homelab Manager')).toBeDefined();
+  });
+
+  it('renders a Sign in link pointing to /api/auth/login', () => {
+    render(<LoginPage />);
+    const link = screen.getByRole('link', { name: 'Sign in' });
+    expect(link).toBeDefined();
+    expect((link as HTMLAnchorElement).href).toContain('/api/auth/login');
+  });
+});

--- a/src/components/auth/__tests__/LoginPage.test.tsx
+++ b/src/components/auth/__tests__/LoginPage.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
 import { render, screen } from '@testing-library/react';
-import LoginPage from '../LoginPage';
+import LoginPage from '@/components/auth/LoginPage';
 
 describe('LoginPage', () => {
   it('renders the app name heading', () => {

--- a/src/components/settings/AuthManagementCard.tsx
+++ b/src/components/settings/AuthManagementCard.tsx
@@ -21,21 +21,21 @@ import {
 } from '@mui/material'
 import { HelpCircle, Trash2 } from 'lucide-react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { listUsers, listSessions, revokeSession, revokeAllUserSessions } from '@/data/auth.functions'
+import { listUsers, listSessions, revokeSession, revokeAllUserSessions, getRoleMapping } from '@/data/auth.functions'
 import { listGitTokens, createGitToken, revokeGitToken } from '@/data/git-tokens.functions'
 
 // ----- Role Mapping Panel -----
 
-/**
- * Reads the role-to-OIDC-group mappings from Vite env vars.
- * These are set at build time via VITE_OIDC_ROLE_ADMIN, VITE_OIDC_ROLE_OPERATOR, VITE_OIDC_ROLE_VIEWER.
- * Falls back to the server-side defaults if not set.
- */
 function RoleMappingPanel() {
+  const { data: roleMapping } = useQuery({
+    queryKey: ['role-mapping'],
+    queryFn: () => getRoleMapping(),
+  })
+
   const roleMappings: { role: string; group: string }[] = [
-    { role: 'Admin', group: import.meta.env.VITE_OIDC_ROLE_ADMIN ?? 'homelab-admins' },
-    { role: 'Operator', group: import.meta.env.VITE_OIDC_ROLE_OPERATOR ?? 'homelab-operators' },
-    { role: 'Viewer', group: import.meta.env.VITE_OIDC_ROLE_VIEWER ?? 'homelab-viewers' },
+    { role: 'Admin', group: roleMapping?.admin ?? 'homelab-admins' },
+    { role: 'Operator', group: roleMapping?.operator ?? 'homelab-operators' },
+    { role: 'Viewer', group: roleMapping?.viewer ?? 'homelab-viewers' },
   ]
 
   const tooltipContent = (
@@ -451,11 +451,9 @@ export function AuthManagementCard() {
 
 function formatDate(date: Date | string | null | undefined): string {
   if (!date) return '—'
-  try {
-    return new Date(date).toLocaleString()
-  } catch {
-    return '—'
-  }
+  const parsed = new Date(date)
+  if (Number.isNaN(parsed.getTime())) return '—'
+  return parsed.toLocaleString()
 }
 
 function truncate(str: string, maxLen: number): string {

--- a/src/components/settings/AuthManagementCard.tsx
+++ b/src/components/settings/AuthManagementCard.tsx
@@ -80,7 +80,7 @@ function RoleMappingPanel() {
 // ----- Users Table -----
 
 function UsersTable() {
-  const { data: users = [], isLoading } = useQuery({
+  const { data: users = [], isLoading, isError, error } = useQuery({
     queryKey: ['auth-users'],
     queryFn: () => listUsers(),
   })
@@ -88,6 +88,11 @@ function UsersTable() {
   return (
     <div>
       <Typography variant="subtitle2" className="mb-2">Users</Typography>
+      {isError ? (
+        <Alert severity="error" className="mb-2">
+          Failed to load users: {error instanceof Error ? error.message : 'Unknown error'}
+        </Alert>
+      ) : null}
       {isLoading ? (
         <div className="flex items-center gap-2 py-2">
           <CircularProgress size={16} />
@@ -132,7 +137,7 @@ function UsersTable() {
 function SessionsTable() {
   const queryClient = useQueryClient()
 
-  const { data: sessions = [], isLoading } = useQuery({
+  const { data: sessions = [], isLoading, isError, error } = useQuery({
     queryKey: ['auth-sessions'],
     queryFn: () => listSessions(),
   })
@@ -156,6 +161,11 @@ function SessionsTable() {
       <Alert severity="info" className="mb-2">
         Role changes in your OIDC provider take effect on next login. To apply immediately, revoke the user&apos;s sessions.
       </Alert>
+      {isError ? (
+        <Alert severity="error" className="mb-2">
+          Failed to load sessions: {error instanceof Error ? error.message : 'Unknown error'}
+        </Alert>
+      ) : null}
       {isLoading ? (
         <div className="flex items-center gap-2 py-2">
           <CircularProgress size={16} />
@@ -315,7 +325,7 @@ function GitTokensTable() {
   const [generateDialogOpen, setGenerateDialogOpen] = useState(false)
   const [newToken, setNewToken] = useState<string | null>(null)
 
-  const { data: tokens = [], isLoading } = useQuery({
+  const { data: tokens = [], isLoading, isError, error } = useQuery({
     queryKey: ['git-tokens'],
     queryFn: () => listGitTokens(),
   })
@@ -350,6 +360,11 @@ function GitTokensTable() {
           Generate Token
         </Button>
       </div>
+      {isError ? (
+        <Alert severity="error" className="mb-2">
+          Failed to load tokens: {error instanceof Error ? error.message : 'Unknown error'}
+        </Alert>
+      ) : null}
       {isLoading ? (
         <div className="flex items-center gap-2 py-2">
           <CircularProgress size={16} />

--- a/src/components/settings/AuthManagementCard.tsx
+++ b/src/components/settings/AuthManagementCard.tsx
@@ -24,8 +24,6 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { listUsers, listSessions, revokeSession, revokeAllUserSessions, getRoleMapping } from '@/data/auth.functions'
 import { listGitTokens, createGitToken, revokeGitToken } from '@/data/git-tokens.functions'
 
-// ----- Role Mapping Panel -----
-
 function RoleMappingPanel() {
   const { data: roleMapping } = useQuery({
     queryKey: ['role-mapping'],
@@ -76,8 +74,6 @@ function RoleMappingPanel() {
     </div>
   )
 }
-
-// ----- Users Table -----
 
 function UsersTable() {
   const { data: users = [], isLoading, isError, error } = useQuery({
@@ -131,8 +127,6 @@ function UsersTable() {
     </div>
   )
 }
-
-// ----- Sessions Table -----
 
 function SessionsTable() {
   const queryClient = useQueryClient()
@@ -247,8 +241,6 @@ function SessionsTable() {
   )
 }
 
-// ----- Generate Token Dialog -----
-
 interface GenerateTokenDialogProps {
   open: boolean
   onClose: () => void
@@ -317,8 +309,6 @@ function GenerateTokenDialog({ open, onClose, onGenerate, isGenerating, newToken
     </Dialog>
   )
 }
-
-// ----- Git Tokens Table -----
 
 function GitTokensTable() {
   const queryClient = useQueryClient()
@@ -428,8 +418,6 @@ function GitTokensTable() {
   )
 }
 
-// ----- Main Card -----
-
 /**
  * Admin-only card for managing OIDC role mappings, users, sessions, and git tokens.
  */
@@ -446,8 +434,6 @@ export function AuthManagementCard() {
     </Card>
   )
 }
-
-// ----- Helpers -----
 
 function formatDate(date: Date | string | null | undefined): string {
   if (!date) return '—'

--- a/src/components/settings/AuthManagementCard.tsx
+++ b/src/components/settings/AuthManagementCard.tsx
@@ -283,7 +283,7 @@ function GenerateTokenDialog({ open, onClose, onGenerate, isGenerating, newToken
               size="small"
               disabled={isGenerating}
               fullWidth
-              inputProps={{ 'aria-label': 'Token label' }}
+              slotProps={{ htmlInput: { 'aria-label': 'Token label' } }}
             />
           </>
         )}

--- a/src/components/settings/AuthManagementCard.tsx
+++ b/src/components/settings/AuthManagementCard.tsx
@@ -1,0 +1,449 @@
+import { useState } from 'react'
+import {
+  Card,
+  Typography,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Button,
+  IconButton,
+  Tooltip,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogContentText,
+  DialogActions,
+  TextField,
+  Alert,
+  CircularProgress,
+} from '@mui/material'
+import { HelpCircle, Trash2 } from 'lucide-react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { listUsers, listSessions, revokeSession, revokeAllUserSessions } from '@/data/auth.functions'
+import { listGitTokens, createGitToken, revokeGitToken } from '@/data/git-tokens.functions'
+
+// ----- Role Mapping Panel -----
+
+/**
+ * Reads the role-to-OIDC-group mappings from Vite env vars.
+ * These are set at build time via VITE_OIDC_ROLE_ADMIN, VITE_OIDC_ROLE_OPERATOR, VITE_OIDC_ROLE_VIEWER.
+ * Falls back to the server-side defaults if not set.
+ */
+function RoleMappingPanel() {
+  const roleMappings: { role: string; group: string }[] = [
+    { role: 'Admin', group: import.meta.env.VITE_OIDC_ROLE_ADMIN ?? 'homelab-admins' },
+    { role: 'Operator', group: import.meta.env.VITE_OIDC_ROLE_OPERATOR ?? 'homelab-operators' },
+    { role: 'Viewer', group: import.meta.env.VITE_OIDC_ROLE_VIEWER ?? 'homelab-viewers' },
+  ]
+
+  const tooltipContent = (
+    <div className="flex flex-col gap-1 max-w-xs text-sm">
+      <span>Roles are managed in your OIDC provider.</span>
+      <span>Configure groups in your provider and assign users to them.</span>
+      {/* TODO: Link to documentation with PocketID setup screenshots */}
+      <span>Role changes take effect on next login, or immediately via session revocation.</span>
+    </div>
+  )
+
+  return (
+    <div>
+      <div className="flex items-center gap-1 mb-2">
+        <Typography variant="subtitle2">Role Mappings</Typography>
+        <Tooltip title={tooltipContent} arrow>
+          <IconButton size="small" aria-label="Role mapping info">
+            <HelpCircle size={16} />
+          </IconButton>
+        </Tooltip>
+      </div>
+      <Table size="small">
+        <TableHead>
+          <TableRow>
+            <TableCell>Role</TableCell>
+            <TableCell>OIDC Group</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {roleMappings.map(({ role, group }) => (
+            <TableRow key={role}>
+              <TableCell>{role}</TableCell>
+              <TableCell className="font-mono">{group}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+// ----- Users Table -----
+
+function UsersTable() {
+  const { data: users = [], isLoading } = useQuery({
+    queryKey: ['auth-users'],
+    queryFn: () => listUsers(),
+  })
+
+  return (
+    <div>
+      <Typography variant="subtitle2" className="mb-2">Users</Typography>
+      {isLoading ? (
+        <div className="flex items-center gap-2 py-2">
+          <CircularProgress size={16} />
+          <Typography variant="body2" className="text-[var(--mui-palette-text-secondary)]">Loading users…</Typography>
+        </div>
+      ) : (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Name</TableCell>
+              <TableCell>Email</TableCell>
+              <TableCell>Role</TableCell>
+              <TableCell>Last Login</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {users.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={4}>
+                  <Typography variant="body2" className="text-[var(--mui-palette-text-secondary)]">No users found.</Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              users.map((user) => (
+                <TableRow key={user.id}>
+                  <TableCell>{user.name ?? '—'}</TableCell>
+                  <TableCell>{user.email}</TableCell>
+                  <TableCell>{user.role}</TableCell>
+                  <TableCell>{formatDate(user.last_login)}</TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      )}
+    </div>
+  )
+}
+
+// ----- Sessions Table -----
+
+function SessionsTable() {
+  const queryClient = useQueryClient()
+
+  const { data: sessions = [], isLoading } = useQuery({
+    queryKey: ['auth-sessions'],
+    queryFn: () => listSessions(),
+  })
+
+  const revokeMutation = useMutation({
+    mutationFn: (sessionId: string) => revokeSession({ data: { sessionId } }),
+    onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ['auth-sessions'] }) },
+  })
+
+  const revokeAllMutation = useMutation({
+    mutationFn: (userId: number) => revokeAllUserSessions({ data: { userId } }),
+    onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ['auth-sessions'] }) },
+  })
+
+  // Group sessions by userId to support "Revoke All" per user
+  const userIds = [...new Set(sessions.map((s) => s.userId))].sort((a, b) => a - b)
+
+  return (
+    <div>
+      <Typography variant="subtitle2" className="mb-2">Active Sessions</Typography>
+      <Alert severity="info" className="mb-2">
+        Role changes in your OIDC provider take effect on next login. To apply immediately, revoke the user&apos;s sessions.
+      </Alert>
+      {isLoading ? (
+        <div className="flex items-center gap-2 py-2">
+          <CircularProgress size={16} />
+          <Typography variant="body2" className="text-[var(--mui-palette-text-secondary)]">Loading sessions…</Typography>
+        </div>
+      ) : sessions.length === 0 ? (
+        <Typography variant="body2" className="text-[var(--mui-palette-text-secondary)] py-2">No active sessions.</Typography>
+      ) : (
+        userIds.map((userId) => {
+          const userSessions = sessions.filter((s) => s.userId === userId)
+          const firstSession = userSessions[0]
+          const displayName = firstSession ? (firstSession.userName ?? firstSession.userEmail) : String(userId)
+
+          return (
+            <div key={userId} className="mb-4">
+              <div className="flex items-center justify-between mb-1">
+                <Typography variant="body2" className="font-semibold">{displayName}</Typography>
+                <Button
+                  size="small"
+                  color="error"
+                  variant="outlined"
+                  disabled={revokeAllMutation.isPending}
+                  onClick={() => revokeAllMutation.mutate(userId)}
+                  aria-label={`Revoke all sessions for ${displayName}`}
+                >
+                  Revoke All Sessions
+                </Button>
+              </div>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>User</TableCell>
+                    <TableCell>IP Address</TableCell>
+                    <TableCell>User Agent</TableCell>
+                    <TableCell>Created</TableCell>
+                    <TableCell>Expires</TableCell>
+                    <TableCell />
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {userSessions.map((session) => (
+                    <TableRow key={session.id}>
+                      <TableCell>
+                        <div>{session.userName ?? '—'}</div>
+                        <div className="text-xs text-[var(--mui-palette-text-secondary)]">{session.userEmail}</div>
+                      </TableCell>
+                      <TableCell>{session.ipAddress ?? '—'}</TableCell>
+                      <TableCell>
+                        <Tooltip title={session.userAgent ?? ''} arrow>
+                          <span>{truncate(session.userAgent ?? '', 50)}</span>
+                        </Tooltip>
+                      </TableCell>
+                      <TableCell>{formatDate(session.createdAt)}</TableCell>
+                      <TableCell>{formatDate(session.expiresAt)}</TableCell>
+                      <TableCell>
+                        <Tooltip title="Revoke session">
+                          <span>
+                            <IconButton
+                              size="small"
+                              color="error"
+                              disabled={revokeMutation.isPending}
+                              onClick={() => revokeMutation.mutate(session.id)}
+                              aria-label="Revoke session"
+                            >
+                              <Trash2 size={14} />
+                            </IconButton>
+                          </span>
+                        </Tooltip>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )
+        })
+      )}
+    </div>
+  )
+}
+
+// ----- Generate Token Dialog -----
+
+interface GenerateTokenDialogProps {
+  open: boolean
+  onClose: () => void
+  onGenerate: (label: string) => void
+  isGenerating: boolean
+  newToken: string | null
+}
+
+function GenerateTokenDialog({ open, onClose, onGenerate, isGenerating, newToken }: GenerateTokenDialogProps) {
+  const [label, setLabel] = useState('')
+
+  function handleGenerate() {
+    if (!label.trim() || isGenerating) return
+    onGenerate(label.trim())
+  }
+
+  function handleClose() {
+    setLabel('')
+    onClose()
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} maxWidth="sm" fullWidth>
+      <DialogTitle>Generate Git Token</DialogTitle>
+      <DialogContent className="flex flex-col gap-4 !pt-4">
+        {newToken ? (
+          <>
+            <Alert severity="warning">
+              Copy this token now — it will not be shown again.
+            </Alert>
+            <div className="p-3 rounded bg-[var(--mui-palette-background-level1)]">
+              <Typography variant="body2" className="font-mono break-all">{newToken}</Typography>
+            </div>
+          </>
+        ) : (
+          <>
+            <DialogContentText>Enter a label to identify this token.</DialogContentText>
+            <TextField
+              label="Label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              size="small"
+              disabled={isGenerating}
+              fullWidth
+              inputProps={{ 'aria-label': 'Token label' }}
+            />
+          </>
+        )}
+      </DialogContent>
+      <DialogActions>
+        {newToken ? (
+          <Button onClick={handleClose}>Done</Button>
+        ) : (
+          <>
+            <Button onClick={handleClose} disabled={isGenerating}>Cancel</Button>
+            <Button
+              onClick={handleGenerate}
+              variant="contained"
+              disabled={!label.trim() || isGenerating}
+            >
+              {isGenerating ? <CircularProgress size={16} /> : 'Generate'}
+            </Button>
+          </>
+        )}
+      </DialogActions>
+    </Dialog>
+  )
+}
+
+// ----- Git Tokens Table -----
+
+function GitTokensTable() {
+  const queryClient = useQueryClient()
+  const [generateDialogOpen, setGenerateDialogOpen] = useState(false)
+  const [newToken, setNewToken] = useState<string | null>(null)
+
+  const { data: tokens = [], isLoading } = useQuery({
+    queryKey: ['git-tokens'],
+    queryFn: () => listGitTokens(),
+  })
+
+  const generateMutation = useMutation({
+    mutationFn: (label: string) => createGitToken({ data: { label } }),
+    onSuccess: (result) => {
+      setNewToken(result.token)
+      void queryClient.invalidateQueries({ queryKey: ['git-tokens'] })
+    },
+  })
+
+  const revokeMutation = useMutation({
+    mutationFn: (tokenId: number) => revokeGitToken({ data: { tokenId } }),
+    onSuccess: () => { void queryClient.invalidateQueries({ queryKey: ['git-tokens'] }) },
+  })
+
+  function handleDialogClose() {
+    setGenerateDialogOpen(false)
+    setNewToken(null)
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-2">
+        <Typography variant="subtitle2">Git Tokens</Typography>
+        <Button
+          size="small"
+          variant="outlined"
+          onClick={() => setGenerateDialogOpen(true)}
+        >
+          Generate Token
+        </Button>
+      </div>
+      {isLoading ? (
+        <div className="flex items-center gap-2 py-2">
+          <CircularProgress size={16} />
+          <Typography variant="body2" className="text-[var(--mui-palette-text-secondary)]">Loading tokens…</Typography>
+        </div>
+      ) : (
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>User</TableCell>
+              <TableCell>Label</TableCell>
+              <TableCell>Last Used</TableCell>
+              <TableCell>Created</TableCell>
+              <TableCell />
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {tokens.length === 0 ? (
+              <TableRow>
+                <TableCell colSpan={5}>
+                  <Typography variant="body2" className="text-[var(--mui-palette-text-secondary)]">No tokens.</Typography>
+                </TableCell>
+              </TableRow>
+            ) : (
+              tokens.map((token) => (
+                <TableRow key={token.id}>
+                  <TableCell>{token.userName ?? token.userEmail}</TableCell>
+                  <TableCell>{token.label}</TableCell>
+                  <TableCell>{token.lastUsedAt ? formatDate(token.lastUsedAt) : '—'}</TableCell>
+                  <TableCell>{formatDate(token.createdAt)}</TableCell>
+                  <TableCell>
+                    <Tooltip title="Revoke token">
+                      <span>
+                        <IconButton
+                          size="small"
+                          color="error"
+                          disabled={revokeMutation.isPending}
+                          onClick={() => revokeMutation.mutate(token.id)}
+                          aria-label="Revoke token"
+                        >
+                          <Trash2 size={14} />
+                        </IconButton>
+                      </span>
+                    </Tooltip>
+                  </TableCell>
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      )}
+
+      <GenerateTokenDialog
+        open={generateDialogOpen}
+        onClose={handleDialogClose}
+        onGenerate={(label) => generateMutation.mutate(label)}
+        isGenerating={generateMutation.isPending}
+        newToken={newToken}
+      />
+    </div>
+  )
+}
+
+// ----- Main Card -----
+
+/**
+ * Admin-only card for managing OIDC role mappings, users, sessions, and git tokens.
+ */
+export function AuthManagementCard() {
+  return (
+    <Card variant="outlined" className="p-4">
+      <Typography variant="h6" className="mb-4">Auth Management</Typography>
+      <div className="flex flex-col gap-6">
+        <RoleMappingPanel />
+        <UsersTable />
+        <SessionsTable />
+        <GitTokensTable />
+      </div>
+    </Card>
+  )
+}
+
+// ----- Helpers -----
+
+function formatDate(date: Date | string | null | undefined): string {
+  if (!date) return '—'
+  try {
+    return new Date(date).toLocaleString()
+  } catch {
+    return '—'
+  }
+}
+
+function truncate(str: string, maxLen: number): string {
+  if (str.length <= maxLen) return str
+  return str.slice(0, maxLen) + '…'
+}

--- a/src/components/settings/AuthManagementCard.tsx
+++ b/src/components/settings/AuthManagementCard.tsx
@@ -116,7 +116,7 @@ function UsersTable() {
                   <TableCell>{user.name ?? '—'}</TableCell>
                   <TableCell>{user.email}</TableCell>
                   <TableCell>{user.role}</TableCell>
-                  <TableCell>{formatDate(user.last_login)}</TableCell>
+                  <TableCell>{formatDate(user.lastLogin)}</TableCell>
                 </TableRow>
               ))
             )}

--- a/src/components/settings/__tests__/AuthManagementCard.test.tsx
+++ b/src/components/settings/__tests__/AuthManagementCard.test.tsx
@@ -1,0 +1,307 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test'
+import { render, screen, fireEvent, act } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+// ----- Module mocks -----
+
+// Mock server functions before importing the component
+mock.module('@/data/auth.functions', () => ({
+  listUsers: mock(() => Promise.resolve([])),
+  listSessions: mock(() => Promise.resolve([])),
+  revokeSession: mock(() => Promise.resolve()),
+  revokeAllUserSessions: mock(() => Promise.resolve()),
+  getSession: mock(() => Promise.resolve(null)),
+  resetAuthFunctionsState: mock(() => {}),
+}))
+
+mock.module('@/data/git-tokens.functions', () => ({
+  listGitTokens: mock(() => Promise.resolve([])),
+  createGitToken: mock(() => Promise.resolve({ token: 'test-token-abc123' })),
+  revokeGitToken: mock(() => Promise.resolve()),
+}))
+
+// eslint-disable-next-line import/first
+import { AuthManagementCard } from '../AuthManagementCard'
+
+// ----- Test helpers -----
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+}
+
+function renderCard() {
+  const queryClient = makeQueryClient()
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthManagementCard />
+    </QueryClientProvider>
+  )
+}
+
+// ----- Fixtures -----
+
+const mockUsers = [
+  {
+    id: 1,
+    oidc_subject: 'sub1',
+    email: 'alice@example.com',
+    name: 'Alice',
+    role: 'admin' as const,
+    oidc_groups: ['homelab-admins'],
+    last_login: new Date('2024-01-15T10:00:00.000Z'),
+    created_at: new Date('2024-01-01T00:00:00.000Z'),
+    updated_at: new Date('2024-01-15T10:00:00.000Z'),
+  },
+  {
+    id: 2,
+    oidc_subject: 'sub2',
+    email: 'bob@example.com',
+    name: 'Bob',
+    role: 'viewer' as const,
+    oidc_groups: ['homelab-viewers'],
+    last_login: new Date('2024-02-01T08:00:00.000Z'),
+    created_at: new Date('2024-01-10T00:00:00.000Z'),
+    updated_at: new Date('2024-02-01T08:00:00.000Z'),
+  },
+]
+
+const mockSessions = [
+  {
+    id: 'session-abc',
+    userId: 1,
+    encryptedOidc: null,
+    ipAddress: '192.168.1.1',
+    userAgent: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
+    expiresAt: new Date('2099-01-01T00:00:00.000Z'),
+    createdAt: new Date('2024-01-15T10:00:00.000Z'),
+    userName: 'Alice',
+    userEmail: 'alice@example.com',
+  },
+]
+
+const mockTokens = [
+  {
+    id: 1,
+    userId: 1,
+    label: 'CI deploy key',
+    lastUsedAt: new Date('2024-02-10T12:00:00.000Z'),
+    createdAt: new Date('2024-01-20T09:00:00.000Z'),
+    userName: 'Alice',
+    userEmail: 'alice@example.com',
+  },
+]
+
+// ----- Tests -----
+
+describe('AuthManagementCard', () => {
+  beforeEach(() => {
+    // Reset mock implementations to empty defaults
+    const authFns = require('@/data/auth.functions') as {
+      listUsers: ReturnType<typeof mock>
+      listSessions: ReturnType<typeof mock>
+    }
+    const gitFns = require('@/data/git-tokens.functions') as {
+      listGitTokens: ReturnType<typeof mock>
+      createGitToken: ReturnType<typeof mock>
+      revokeGitToken: ReturnType<typeof mock>
+    }
+    authFns.listUsers.mockImplementation(() => Promise.resolve([]))
+    authFns.listSessions.mockImplementation(() => Promise.resolve([]))
+    gitFns.listGitTokens.mockImplementation(() => Promise.resolve([]))
+    gitFns.createGitToken.mockImplementation(() => Promise.resolve({ token: 'test-token-abc123' }))
+    gitFns.revokeGitToken.mockImplementation(() => Promise.resolve())
+  })
+
+  describe('card structure', () => {
+    it('renders card heading', () => {
+      renderCard()
+      expect(screen.getByText('Auth Management')).toBeDefined()
+    })
+  })
+
+  describe('role mapping panel', () => {
+    it('renders role mapping table headers', () => {
+      renderCard()
+      expect(screen.getByText('Role')).toBeDefined()
+      expect(screen.getByText('OIDC Group')).toBeDefined()
+    })
+
+    it('renders all three roles', () => {
+      renderCard()
+      expect(screen.getByText('Admin')).toBeDefined()
+      expect(screen.getByText('Operator')).toBeDefined()
+      expect(screen.getByText('Viewer')).toBeDefined()
+    })
+
+    it('renders ? icon button for role mapping info', () => {
+      renderCard()
+      expect(screen.getByLabelText('Role mapping info')).toBeDefined()
+    })
+
+    it('? icon button has correct tooltip text about OIDC provider', async () => {
+      renderCard()
+      const btn = screen.getByLabelText('Role mapping info')
+      // MUI Tooltip renders content on hover via aria — verify button exists with accessible name
+      expect(btn).toBeDefined()
+    })
+
+    it('renders default group names when env vars not set', () => {
+      renderCard()
+      expect(screen.getByText('homelab-admins')).toBeDefined()
+      expect(screen.getByText('homelab-operators')).toBeDefined()
+      expect(screen.getByText('homelab-viewers')).toBeDefined()
+    })
+  })
+
+  describe('users table', () => {
+    it('renders users table heading', () => {
+      renderCard()
+      expect(screen.getByText('Users')).toBeDefined()
+    })
+
+    it('renders users table column headers after load', async () => {
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      expect(screen.getByText('Name')).toBeDefined()
+      expect(screen.getByText('Email')).toBeDefined()
+      expect(screen.getByText('Last Login')).toBeDefined()
+    })
+
+    it('renders user rows when data is loaded', async () => {
+      const authFns = require('@/data/auth.functions') as { listUsers: ReturnType<typeof mock> }
+      authFns.listUsers.mockImplementation(() => Promise.resolve(mockUsers))
+
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      expect(screen.getByText('Alice')).toBeDefined()
+      expect(screen.getByText('alice@example.com')).toBeDefined()
+    })
+
+    it('shows empty state when no users', async () => {
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      expect(screen.getByText('No users found.')).toBeDefined()
+    })
+  })
+
+  describe('sessions table', () => {
+    it('renders sessions table heading', () => {
+      renderCard()
+      expect(screen.getByText('Active Sessions')).toBeDefined()
+    })
+
+    it('renders role change info banner', () => {
+      renderCard()
+      expect(screen.getByText(/Role changes in your OIDC provider take effect on next login/)).toBeDefined()
+    })
+
+    it('renders revoke session button when sessions exist', async () => {
+      const authFns = require('@/data/auth.functions') as { listSessions: ReturnType<typeof mock> }
+      authFns.listSessions.mockImplementation(() => Promise.resolve(mockSessions))
+
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      const revokeButtons = screen.getAllByLabelText('Revoke session')
+      expect(revokeButtons.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('renders Revoke All Sessions button per user group', async () => {
+      const authFns = require('@/data/auth.functions') as { listSessions: ReturnType<typeof mock> }
+      authFns.listSessions.mockImplementation(() => Promise.resolve(mockSessions))
+
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      expect(screen.getByText('Revoke All Sessions')).toBeDefined()
+    })
+
+    it('renders IP Address column header', async () => {
+      const authFns = require('@/data/auth.functions') as { listSessions: ReturnType<typeof mock> }
+      authFns.listSessions.mockImplementation(() => Promise.resolve(mockSessions))
+
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      expect(screen.getByText('IP Address')).toBeDefined()
+    })
+
+    it('shows empty state when no sessions', async () => {
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      expect(screen.getByText('No active sessions.')).toBeDefined()
+    })
+  })
+
+  describe('git tokens section', () => {
+    it('renders git tokens heading', () => {
+      renderCard()
+      expect(screen.getByText('Git Tokens')).toBeDefined()
+    })
+
+    it('renders git tokens table column headers', async () => {
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      expect(screen.getByText('Label')).toBeDefined()
+      expect(screen.getByText('Last Used')).toBeDefined()
+    })
+
+    it('renders Generate Token button', () => {
+      renderCard()
+      expect(screen.getByText('Generate Token')).toBeDefined()
+    })
+
+    it('renders token rows when data is loaded', async () => {
+      const gitFns = require('@/data/git-tokens.functions') as { listGitTokens: ReturnType<typeof mock> }
+      gitFns.listGitTokens.mockImplementation(() => Promise.resolve(mockTokens))
+
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      expect(screen.getByText('CI deploy key')).toBeDefined()
+    })
+
+    it('renders revoke token button for each token', async () => {
+      const gitFns = require('@/data/git-tokens.functions') as { listGitTokens: ReturnType<typeof mock> }
+      gitFns.listGitTokens.mockImplementation(() => Promise.resolve(mockTokens))
+
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      const revokeButtons = screen.getAllByLabelText('Revoke token')
+      expect(revokeButtons.length).toBeGreaterThanOrEqual(1)
+    })
+
+    it('opens generate token dialog when Generate Token is clicked', () => {
+      renderCard()
+      fireEvent.click(screen.getByText('Generate Token'))
+      expect(screen.getByText('Generate Git Token')).toBeDefined()
+    })
+
+    it('generate token dialog has label input', () => {
+      renderCard()
+      fireEvent.click(screen.getByText('Generate Token'))
+      expect(screen.getByLabelText('Token label')).toBeDefined()
+    })
+
+    it('shows generated token after generation with warning', async () => {
+      renderCard()
+      fireEvent.click(screen.getByText('Generate Token'))
+      const labelInput = screen.getByLabelText('Token label')
+      fireEvent.change(labelInput, { target: { value: 'My token' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Generate' }))
+
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      expect(screen.getByText('Copy this token now — it will not be shown again.')).toBeDefined()
+      expect(screen.getByText('test-token-abc123')).toBeDefined()
+    })
+  })
+})

--- a/src/components/settings/__tests__/AuthManagementCard.test.tsx
+++ b/src/components/settings/__tests__/AuthManagementCard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test'
-import { render, screen, fireEvent, act } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
 // ----- Module mocks -----
@@ -12,6 +12,7 @@ mock.module('@/data/auth.functions', () => ({
   revokeAllUserSessions: mock(() => Promise.resolve()),
   getSession: mock(() => Promise.resolve(null)),
   resetAuthFunctionsState: mock(() => {}),
+  getRoleMapping: mock(() => Promise.resolve({ admin: 'homelab-admins', operator: 'homelab-operators', viewer: 'homelab-viewers' })),
 }))
 
 mock.module('@/data/git-tokens.functions', () => ({
@@ -21,7 +22,7 @@ mock.module('@/data/git-tokens.functions', () => ({
 }))
 
 // eslint-disable-next-line import/first
-import { AuthManagementCard } from '../AuthManagementCard'
+import { AuthManagementCard } from '@/components/settings/AuthManagementCard'
 
 // ----- Test helpers -----
 
@@ -101,6 +102,7 @@ describe('AuthManagementCard', () => {
     const authFns = require('@/data/auth.functions') as {
       listUsers: ReturnType<typeof mock>
       listSessions: ReturnType<typeof mock>
+      getRoleMapping: ReturnType<typeof mock>
     }
     const gitFns = require('@/data/git-tokens.functions') as {
       listGitTokens: ReturnType<typeof mock>
@@ -109,6 +111,7 @@ describe('AuthManagementCard', () => {
     }
     authFns.listUsers.mockImplementation(() => Promise.resolve([]))
     authFns.listSessions.mockImplementation(() => Promise.resolve([]))
+    authFns.getRoleMapping.mockImplementation(() => Promise.resolve({ admin: 'homelab-admins', operator: 'homelab-operators', viewer: 'homelab-viewers' }))
     gitFns.listGitTokens.mockImplementation(() => Promise.resolve([]))
     gitFns.createGitToken.mockImplementation(() => Promise.resolve({ token: 'test-token-abc123' }))
     gitFns.revokeGitToken.mockImplementation(() => Promise.resolve())
@@ -147,11 +150,13 @@ describe('AuthManagementCard', () => {
       expect(btn).toBeDefined()
     })
 
-    it('renders default group names when env vars not set', () => {
+    it('renders default group names when env vars not set', async () => {
       renderCard()
-      expect(screen.getByText('homelab-admins')).toBeDefined()
-      expect(screen.getByText('homelab-operators')).toBeDefined()
-      expect(screen.getByText('homelab-viewers')).toBeDefined()
+      await waitFor(() => {
+        expect(screen.getByText('homelab-admins')).toBeDefined()
+        expect(screen.getByText('homelab-operators')).toBeDefined()
+        expect(screen.getByText('homelab-viewers')).toBeDefined()
+      })
     })
   })
 
@@ -163,11 +168,11 @@ describe('AuthManagementCard', () => {
 
     it('renders users table column headers after load', async () => {
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      expect(screen.getByText('Name')).toBeDefined()
-      expect(screen.getByText('Email')).toBeDefined()
-      expect(screen.getByText('Last Login')).toBeDefined()
+      await waitFor(() => {
+        expect(screen.getByText('Name')).toBeDefined()
+        expect(screen.getByText('Email')).toBeDefined()
+        expect(screen.getByText('Last Login')).toBeDefined()
+      })
     })
 
     it('renders user rows when data is loaded', async () => {
@@ -175,10 +180,10 @@ describe('AuthManagementCard', () => {
       authFns.listUsers.mockImplementation(() => Promise.resolve(mockUsers))
 
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      expect(screen.getByText('Alice')).toBeDefined()
-      expect(screen.getByText('alice@example.com')).toBeDefined()
+      await waitFor(() => {
+        expect(screen.getByText('Alice')).toBeDefined()
+        expect(screen.getByText('alice@example.com')).toBeDefined()
+      })
     })
 
     it('renders lastLogin date for users (not the fallback dash)', async () => {
@@ -186,20 +191,18 @@ describe('AuthManagementCard', () => {
       authFns.listUsers.mockImplementation(() => Promise.resolve(mockUsers))
 
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      const emailCell = screen.getByText('alice@example.com')
-      const row = emailCell.closest('tr')
-      const lastLoginCell = row?.querySelectorAll('td')[3]
-      expect(lastLoginCell?.textContent).not.toBe('—')
-      expect(lastLoginCell?.textContent?.length).toBeGreaterThan(0)
+      await waitFor(() => {
+        const emailCell = screen.getByText('alice@example.com')
+        const row = emailCell.closest('tr')
+        const lastLoginCell = row?.querySelectorAll('td')[3]
+        expect(lastLoginCell?.textContent).not.toBe('—')
+        expect(lastLoginCell?.textContent?.length).toBeGreaterThan(0)
+      })
     })
 
     it('shows empty state when no users', async () => {
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      expect(screen.getByText('No users found.')).toBeDefined()
+      await waitFor(() => expect(screen.getByText('No users found.')).toBeDefined())
     })
   })
 
@@ -219,10 +222,10 @@ describe('AuthManagementCard', () => {
       authFns.listSessions.mockImplementation(() => Promise.resolve(mockSessions))
 
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      const revokeButtons = screen.getAllByLabelText('Revoke session')
-      expect(revokeButtons.length).toBeGreaterThanOrEqual(1)
+      await waitFor(() => {
+        const revokeButtons = screen.getAllByLabelText('Revoke session')
+        expect(revokeButtons.length).toBeGreaterThanOrEqual(1)
+      })
     })
 
     it('renders Revoke All Sessions button per user group', async () => {
@@ -230,9 +233,7 @@ describe('AuthManagementCard', () => {
       authFns.listSessions.mockImplementation(() => Promise.resolve(mockSessions))
 
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      expect(screen.getByText('Revoke All Sessions')).toBeDefined()
+      await waitFor(() => expect(screen.getByText('Revoke All Sessions')).toBeDefined())
     })
 
     it('renders IP Address column header', async () => {
@@ -240,16 +241,12 @@ describe('AuthManagementCard', () => {
       authFns.listSessions.mockImplementation(() => Promise.resolve(mockSessions))
 
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      expect(screen.getByText('IP Address')).toBeDefined()
+      await waitFor(() => expect(screen.getByText('IP Address')).toBeDefined())
     })
 
     it('shows empty state when no sessions', async () => {
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      expect(screen.getByText('No active sessions.')).toBeDefined()
+      await waitFor(() => expect(screen.getByText('No active sessions.')).toBeDefined())
     })
   })
 
@@ -261,10 +258,10 @@ describe('AuthManagementCard', () => {
 
     it('renders git tokens table column headers', async () => {
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      expect(screen.getByText('Label')).toBeDefined()
-      expect(screen.getByText('Last Used')).toBeDefined()
+      await waitFor(() => {
+        expect(screen.getByText('Label')).toBeDefined()
+        expect(screen.getByText('Last Used')).toBeDefined()
+      })
     })
 
     it('renders Generate Token button', () => {
@@ -277,9 +274,7 @@ describe('AuthManagementCard', () => {
       gitFns.listGitTokens.mockImplementation(() => Promise.resolve(mockTokens))
 
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      expect(screen.getByText('CI deploy key')).toBeDefined()
+      await waitFor(() => expect(screen.getByText('CI deploy key')).toBeDefined())
     })
 
     it('renders revoke token button for each token', async () => {
@@ -287,10 +282,10 @@ describe('AuthManagementCard', () => {
       gitFns.listGitTokens.mockImplementation(() => Promise.resolve(mockTokens))
 
       renderCard()
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      const revokeButtons = screen.getAllByLabelText('Revoke token')
-      expect(revokeButtons.length).toBeGreaterThanOrEqual(1)
+      await waitFor(() => {
+        const revokeButtons = screen.getAllByLabelText('Revoke token')
+        expect(revokeButtons.length).toBeGreaterThanOrEqual(1)
+      })
     })
 
     it('opens generate token dialog when Generate Token is clicked', () => {
@@ -312,10 +307,10 @@ describe('AuthManagementCard', () => {
       fireEvent.change(labelInput, { target: { value: 'My token' } })
       fireEvent.click(screen.getByRole('button', { name: 'Generate' }))
 
-      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
-
-      expect(screen.getByText('Copy this token now — it will not be shown again.')).toBeDefined()
-      expect(screen.getByText('test-token-abc123')).toBeDefined()
+      await waitFor(() => {
+        expect(screen.getByText('Copy this token now — it will not be shown again.')).toBeDefined()
+        expect(screen.getByText('test-token-abc123')).toBeDefined()
+      })
     })
   })
 })

--- a/src/components/settings/__tests__/AuthManagementCard.test.tsx
+++ b/src/components/settings/__tests__/AuthManagementCard.test.tsx
@@ -2,8 +2,6 @@ import { describe, it, expect, mock, beforeEach } from 'bun:test'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 
-// ----- Module mocks -----
-
 // Mock server functions before importing the component
 mock.module('@/data/auth.functions', () => ({
   listUsers: mock(() => Promise.resolve([])),
@@ -24,8 +22,6 @@ mock.module('@/data/git-tokens.functions', () => ({
 // eslint-disable-next-line import/first
 import { AuthManagementCard } from '@/components/settings/AuthManagementCard'
 
-// ----- Test helpers -----
-
 function makeQueryClient() {
   return new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -40,8 +36,6 @@ function renderCard() {
     </QueryClientProvider>
   )
 }
-
-// ----- Fixtures -----
 
 const mockUsers = [
   {
@@ -93,8 +87,6 @@ const mockTokens = [
     userEmail: 'alice@example.com',
   },
 ]
-
-// ----- Tests -----
 
 describe('AuthManagementCard', () => {
   beforeEach(() => {

--- a/src/components/settings/__tests__/AuthManagementCard.test.tsx
+++ b/src/components/settings/__tests__/AuthManagementCard.test.tsx
@@ -45,25 +45,25 @@ function renderCard() {
 const mockUsers = [
   {
     id: 1,
-    oidc_subject: 'sub1',
+    oidcSubject: 'sub1',
     email: 'alice@example.com',
     name: 'Alice',
     role: 'admin' as const,
-    oidc_groups: ['homelab-admins'],
-    last_login: new Date('2024-01-15T10:00:00.000Z'),
-    created_at: new Date('2024-01-01T00:00:00.000Z'),
-    updated_at: new Date('2024-01-15T10:00:00.000Z'),
+    oidcGroups: ['homelab-admins'],
+    lastLogin: new Date('2024-01-15T10:00:00.000Z'),
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    updatedAt: new Date('2024-01-15T10:00:00.000Z'),
   },
   {
     id: 2,
-    oidc_subject: 'sub2',
+    oidcSubject: 'sub2',
     email: 'bob@example.com',
     name: 'Bob',
     role: 'viewer' as const,
-    oidc_groups: ['homelab-viewers'],
-    last_login: new Date('2024-02-01T08:00:00.000Z'),
-    created_at: new Date('2024-01-10T00:00:00.000Z'),
-    updated_at: new Date('2024-02-01T08:00:00.000Z'),
+    oidcGroups: ['homelab-viewers'],
+    lastLogin: new Date('2024-02-01T08:00:00.000Z'),
+    createdAt: new Date('2024-01-10T00:00:00.000Z'),
+    updatedAt: new Date('2024-02-01T08:00:00.000Z'),
   },
 ]
 
@@ -179,6 +179,20 @@ describe('AuthManagementCard', () => {
 
       expect(screen.getByText('Alice')).toBeDefined()
       expect(screen.getByText('alice@example.com')).toBeDefined()
+    })
+
+    it('renders lastLogin date for users (not the fallback dash)', async () => {
+      const authFns = require('@/data/auth.functions') as { listUsers: ReturnType<typeof mock> }
+      authFns.listUsers.mockImplementation(() => Promise.resolve(mockUsers))
+
+      renderCard()
+      await act(async () => { await new Promise((r) => setTimeout(r, 50)) })
+
+      const emailCell = screen.getByText('alice@example.com')
+      const row = emailCell.closest('tr')
+      const lastLoginCell = row?.querySelectorAll('td')[3]
+      expect(lastLoginCell?.textContent).not.toBe('—')
+      expect(lastLoginCell?.textContent?.length).toBeGreaterThan(0)
     })
 
     it('shows empty state when no users', async () => {

--- a/src/components/settings/__tests__/ManagedHostsCard.test.tsx
+++ b/src/components/settings/__tests__/ManagedHostsCard.test.tsx
@@ -4,8 +4,6 @@ import { ManagedHostsCardView } from '../ManagedHostsCard'
 import type { ManagedHostsCardProps } from '../ManagedHostsCard'
 import type { HostListItem } from '@/lib/hosts/host-utils'
 
-// ----- Fixtures -----
-
 const makeHost = (overrides?: Partial<HostListItem>): HostListItem => ({
   id: 1,
   name: 'server1',
@@ -37,8 +35,6 @@ function makeProps(overrides?: Partial<ManagedHostsCardProps>): ManagedHostsCard
     ...overrides,
   }
 }
-
-// ----- Tests -----
 
 describe('ManagedHostsCard', () => {
   describe('loading state', () => {

--- a/src/data/__tests__/auth.functions.test.ts
+++ b/src/data/__tests__/auth.functions.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { SYNTHETIC_ADMIN } from '@/lib/auth/types';
+import type { AuthUser } from '@/lib/auth/types';
+
+mock.module('@/middleware/auth-middleware', () => ({
+  authMiddleware: {
+    options: {
+      type: 'function',
+      client: async ({ next, sendContext }: { next: (opts: { sendContext: unknown }) => unknown; sendContext: unknown }) => {
+        return next({ sendContext: { ...(sendContext as Record<string, unknown>), user: SYNTHETIC_ADMIN } });
+      },
+      server: async ({ next, context }: { next: (opts: { context: unknown }) => unknown; context: unknown }) => {
+        return next({ context: { ...(context as Record<string, unknown>), user: SYNTHETIC_ADMIN } });
+      },
+    },
+  },
+  AuthError: class AuthError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = 'AuthError';
+    }
+  },
+  parseCookie: mock((_header: string | null, _name: string) => null as string | null),
+  resetAuthMiddlewareState: () => {},
+}));
+
+const mockPool = { query: mock(async () => ({ rows: [] })) };
+const mockGetClient = mock(async () => ({ getPool: () => mockPool }));
+
+mock.module('@/lib/clients/database-client', () => ({
+  databaseConnectionManager: { getClient: mockGetClient },
+}));
+mock.module('@/lib/config/database-config', () => ({
+  loadDatabaseConfig: () => ({}),
+}));
+
+const mockUserFindAll = mock(async () => [] as unknown[]);
+mock.module('@/lib/database/repositories/user-repository', () => ({
+  UserRepository: class MockUserRepository {
+    constructor() {}
+    findAll = mockUserFindAll;
+  },
+}));
+
+const mockSessionFindAllWithUser = mock(async () => [] as unknown[]);
+const mockSessionDeleteById = mock(async () => {});
+const mockSessionDeleteByUserId = mock(async () => {});
+mock.module('@/lib/database/repositories/session-repository', () => ({
+  SessionRepository: class MockSessionRepository {
+    constructor() {}
+    findAllWithUser = mockSessionFindAllWithUser;
+    deleteById = mockSessionDeleteById;
+    deleteByUserId = mockSessionDeleteByUserId;
+  },
+}));
+
+const mockValidateSession = mock(async (_token: string) => null as AuthUser | null);
+mock.module('@/lib/auth/session-manager', () => ({
+  buildSessionManager: mock(async () => ({ validateSession: mockValidateSession })),
+  resetSessionManagerState: () => {},
+  SessionManager: class {},
+}));
+
+mock.module('@/lib/config/auth-config', () => ({
+  isAuthDisabled: () => true,
+}));
+
+// createServerFn() wrappers do not return handler values in test context.
+// Tests verify delegation by asserting on mock call counts and arguments.
+describe('auth.functions', () => {
+  beforeEach(() => {
+    mockPool.query.mockClear();
+    mockGetClient.mockClear();
+    mockUserFindAll.mockClear();
+    mockSessionFindAllWithUser.mockClear();
+    mockSessionDeleteById.mockClear();
+    mockSessionDeleteByUserId.mockClear();
+    mockValidateSession.mockClear();
+  });
+
+  describe('getSession', () => {
+    it('is defined and callable without throwing', async () => {
+      const { getSession } = await import('@/data/auth.functions');
+      expect(typeof getSession).toBe('function');
+      await getSession();
+    });
+  });
+
+  describe('listUsers', () => {
+    it('delegates to UserRepository.findAll', async () => {
+      const { listUsers } = await import('@/data/auth.functions');
+      await listUsers({});
+      expect(mockUserFindAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates a UserRepository using the db pool', async () => {
+      const { listUsers } = await import('@/data/auth.functions');
+      await listUsers({});
+      expect(mockGetClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('listSessions', () => {
+    it('delegates to SessionRepository.findAllWithUser', async () => {
+      const { listSessions } = await import('@/data/auth.functions');
+      await listSessions({});
+      expect(mockSessionFindAllWithUser).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates a SessionRepository using the db pool', async () => {
+      const { listSessions } = await import('@/data/auth.functions');
+      await listSessions({});
+      expect(mockGetClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('revokeSession', () => {
+    it('calls deleteById with the given sessionId', async () => {
+      const { revokeSession } = await import('@/data/auth.functions');
+      await revokeSession({ data: { sessionId: 'abc123' } });
+      expect(mockSessionDeleteById).toHaveBeenCalledTimes(1);
+      expect(mockSessionDeleteById).toHaveBeenCalledWith('abc123');
+    });
+
+    it('passes a different sessionId through correctly', async () => {
+      const { revokeSession } = await import('@/data/auth.functions');
+      await revokeSession({ data: { sessionId: 'session-xyz' } });
+      expect(mockSessionDeleteById).toHaveBeenCalledWith('session-xyz');
+    });
+  });
+
+  describe('revokeAllUserSessions', () => {
+    it('calls deleteByUserId with the given userId', async () => {
+      const { revokeAllUserSessions } = await import('@/data/auth.functions');
+      await revokeAllUserSessions({ data: { userId: 42 } });
+      expect(mockSessionDeleteByUserId).toHaveBeenCalledTimes(1);
+      expect(mockSessionDeleteByUserId).toHaveBeenCalledWith(42);
+    });
+
+    it('passes a different userId through correctly', async () => {
+      const { revokeAllUserSessions } = await import('@/data/auth.functions');
+      await revokeAllUserSessions({ data: { userId: 99 } });
+      expect(mockSessionDeleteByUserId).toHaveBeenCalledWith(99);
+    });
+  });
+
+  describe('resetAuthFunctionsState', () => {
+    it('clears the cached session manager without throwing', () => {
+      const { resetAuthFunctionsState } = require('@/data/auth.functions');
+      expect(() => resetAuthFunctionsState()).not.toThrow();
+    });
+  });
+});

--- a/src/data/__tests__/git-tokens.functions.test.ts
+++ b/src/data/__tests__/git-tokens.functions.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { SYNTHETIC_ADMIN } from '@/lib/auth/types';
+import type { GitTokenWithUser } from '@/lib/database/repositories/git-token-repository';
+
+mock.module('@/middleware/auth-middleware', () => ({
+  authMiddleware: {
+    options: {
+      type: 'function',
+      client: async ({ next, sendContext }: { next: (opts: { sendContext: unknown }) => unknown; sendContext: unknown }) => {
+        return next({ sendContext: { ...(sendContext as Record<string, unknown>), user: SYNTHETIC_ADMIN } });
+      },
+      server: async ({ next, context }: { next: (opts: { context: unknown }) => unknown; context: unknown }) => {
+        return next({ context: { ...(context as Record<string, unknown>), user: SYNTHETIC_ADMIN } });
+      },
+    },
+  },
+  AuthError: class AuthError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = 'AuthError';
+    }
+  },
+  parseCookie: () => null,
+  resetAuthMiddlewareState: () => {},
+}));
+
+const mockPool = { query: mock(async () => ({ rows: [] })) };
+const mockGetClient = mock(async () => ({ getPool: () => mockPool }));
+
+mock.module('@/lib/clients/database-client', () => ({
+  databaseConnectionManager: { getClient: mockGetClient },
+}));
+mock.module('@/lib/config/database-config', () => ({
+  loadDatabaseConfig: () => ({}),
+}));
+
+const mockEncryptValue = mock(async (_plaintext: string, _keyring: unknown) => 'jwe:encrypted:token');
+mock.module('@/lib/crypto/encrypted-value', () => ({
+  encryptValue: mockEncryptValue,
+}));
+mock.module('@/lib/crypto/master-key', () => ({
+  loadMasterKeyring: mock(async () => ({ activeKid: 'v1', keys: new Map() })),
+}));
+
+const mockCreate = mock(async (input: { userId: number; encryptedToken: string; label: string }) => ({
+  id: 1,
+  userId: input.userId,
+  label: input.label,
+  lastUsedAt: null,
+  createdAt: new Date(),
+}));
+const mockFindAll = mock(async (): Promise<GitTokenWithUser[]> => []);
+const mockDeleteById = mock(async (_id: number) => {});
+
+mock.module('@/lib/database/repositories/git-token-repository', () => ({
+  GitTokenRepository: class MockGitTokenRepository {
+    constructor() {}
+    create = mockCreate;
+    findAll = mockFindAll;
+    deleteById = mockDeleteById;
+  },
+}));
+
+// createServerFn() wrappers do not return handler values in test context.
+// Tests verify delegation by asserting on mock call counts and arguments.
+describe('git-tokens.functions', () => {
+  beforeEach(() => {
+    mockPool.query.mockClear();
+    mockGetClient.mockClear();
+    mockEncryptValue.mockClear();
+    mockCreate.mockClear();
+    mockFindAll.mockClear();
+    mockDeleteById.mockClear();
+  });
+
+  describe('createGitToken', () => {
+    it('encrypts a random token before storing', async () => {
+      const { createGitToken } = await import('@/data/git-tokens.functions');
+      await createGitToken({ data: { label: 'deploy-key' } });
+      expect(mockEncryptValue).toHaveBeenCalledTimes(1);
+      const [plaintext] = mockEncryptValue.mock.calls[0] as [string, unknown];
+      expect(plaintext).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('stores the encrypted token and label via repository', async () => {
+      const { createGitToken } = await import('@/data/git-tokens.functions');
+      await createGitToken({ data: { label: 'ci-key' } });
+      expect(mockCreate).toHaveBeenCalledTimes(1);
+      const [createArg] = mockCreate.mock.calls[0] as [{ userId: number; encryptedToken: string; label: string }];
+      expect(createArg.userId).toBe(SYNTHETIC_ADMIN.id);
+      expect(createArg.encryptedToken).toBe('jwe:encrypted:token');
+      expect(createArg.label).toBe('ci-key');
+    });
+
+    it('uses a different random plaintext for each call', async () => {
+      const { createGitToken } = await import('@/data/git-tokens.functions');
+      await createGitToken({ data: { label: 'a' } });
+      await createGitToken({ data: { label: 'b' } });
+      const calls = mockEncryptValue.mock.calls as [string, unknown][];
+      expect(calls[0][0]).not.toBe(calls[1][0]);
+    });
+  });
+
+  describe('listGitTokens', () => {
+    it('delegates to GitTokenRepository.findAll', async () => {
+      const { listGitTokens } = await import('@/data/git-tokens.functions');
+      await listGitTokens({});
+      expect(mockFindAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('creates a GitTokenRepository using the db pool', async () => {
+      const { listGitTokens } = await import('@/data/git-tokens.functions');
+      await listGitTokens({});
+      expect(mockGetClient).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('revokeGitToken', () => {
+    it('calls deleteById with the given tokenId', async () => {
+      const { revokeGitToken } = await import('@/data/git-tokens.functions');
+      await revokeGitToken({ data: { tokenId: 7 } });
+      expect(mockDeleteById).toHaveBeenCalledTimes(1);
+      expect(mockDeleteById).toHaveBeenCalledWith(7);
+    });
+
+    it('passes a different tokenId through correctly', async () => {
+      const { revokeGitToken } = await import('@/data/git-tokens.functions');
+      await revokeGitToken({ data: { tokenId: 99 } });
+      expect(mockDeleteById).toHaveBeenCalledWith(99);
+    });
+  });
+});

--- a/src/data/auth.functions.tsx
+++ b/src/data/auth.functions.tsx
@@ -133,6 +133,23 @@ export const revokeAllUserSessions = createServerFn()
   });
 
 /**
+ * Returns the OIDC group names mapped to each role (admin only).
+ * Reads server-side OIDC_ROLE_* env vars so the UI shows the actual deployed values.
+ */
+export const getRoleMapping = createServerFn()
+  .middleware([authMiddleware])
+  .handler(async ({ context }): Promise<{ admin: string; operator: string; viewer: string }> => {
+    requireRole('admin')(context.user);
+
+    const { isAuthDisabled, loadAuthConfig } = await import('@/lib/config/auth-config');
+    if (isAuthDisabled()) {
+      return { admin: 'homelab-admins', operator: 'homelab-operators', viewer: 'homelab-viewers' };
+    }
+    const config = loadAuthConfig();
+    return config.roleMapping;
+  });
+
+/**
  * Reset cached session manager (for testing only).
  */
 export function resetAuthFunctionsState(): void {

--- a/src/data/auth.functions.tsx
+++ b/src/data/auth.functions.tsx
@@ -1,5 +1,8 @@
 import { createServerFn } from '@tanstack/react-start';
 import { createMiddleware } from '@tanstack/react-start';
+import { z } from 'zod';
+import { authMiddleware } from '@/middleware/auth-middleware';
+import { requireRole } from '@/lib/auth/require-role';
 import type { AuthUser } from '@/lib/auth/types';
 
 let cachedSessionManager: import('@/lib/auth/session-manager').SessionManager | null = null;
@@ -49,6 +52,84 @@ export const getSession = createServerFn()
   .handler(async ({ context }): Promise<AuthUser | null> => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     return (context as any).sessionUser as AuthUser | null;
+  });
+
+/**
+ * List all users (admin only).
+ */
+export const listUsers = createServerFn()
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    requireRole('admin')(context.user);
+
+    const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+    const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+    const { UserRepository } = await import('@/lib/database/repositories/user-repository');
+
+    const dbConfig = loadDatabaseConfig();
+    const dbClient = await databaseConnectionManager.getClient(dbConfig);
+    const repo = new UserRepository(dbClient.getPool());
+
+    return repo.findAll();
+  });
+
+/**
+ * List all active sessions with user info (admin only).
+ */
+export const listSessions = createServerFn()
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    requireRole('admin')(context.user);
+
+    const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+    const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+    const { SessionRepository } = await import('@/lib/database/repositories/session-repository');
+
+    const dbConfig = loadDatabaseConfig();
+    const dbClient = await databaseConnectionManager.getClient(dbConfig);
+    const repo = new SessionRepository(dbClient.getPool());
+
+    return repo.findAllWithUser();
+  });
+
+/**
+ * Revoke a session by ID (admin only).
+ */
+export const revokeSession = createServerFn()
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ sessionId: z.string() }))
+  .handler(async ({ data, context }): Promise<void> => {
+    requireRole('admin')(context.user);
+
+    const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+    const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+    const { SessionRepository } = await import('@/lib/database/repositories/session-repository');
+
+    const dbConfig = loadDatabaseConfig();
+    const dbClient = await databaseConnectionManager.getClient(dbConfig);
+    const repo = new SessionRepository(dbClient.getPool());
+
+    await repo.deleteById(data.sessionId);
+  });
+
+/**
+ * Revoke all sessions for a user (admin only).
+ */
+export const revokeAllUserSessions = createServerFn()
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ userId: z.number() }))
+  .handler(async ({ data, context }): Promise<void> => {
+    requireRole('admin')(context.user);
+
+    const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+    const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+    const { SessionRepository } = await import('@/lib/database/repositories/session-repository');
+
+    const dbConfig = loadDatabaseConfig();
+    const dbClient = await databaseConnectionManager.getClient(dbConfig);
+    const repo = new SessionRepository(dbClient.getPool());
+
+    await repo.deleteByUserId(data.userId);
   });
 
 /**

--- a/src/data/auth.functions.tsx
+++ b/src/data/auth.functions.tsx
@@ -1,0 +1,59 @@
+import { createServerFn } from '@tanstack/react-start';
+import { createMiddleware } from '@tanstack/react-start';
+import type { AuthUser } from '@/lib/auth/types';
+
+let cachedSessionManager: import('@/lib/auth/session-manager').SessionManager | null = null;
+
+/**
+ * Middleware that reads the session cookie and resolves the AuthUser (or null).
+ * Unlike authMiddleware, this never throws — it passes null when unauthenticated.
+ */
+const sessionReadMiddleware = createMiddleware().server(async ({ next, context }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ctx = context as any;
+
+  const { isAuthDisabled } = await import('@/lib/config/auth-config');
+  if (isAuthDisabled()) {
+    const { SYNTHETIC_ADMIN } = await import('@/lib/auth/types');
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return next({ context: { ...ctx, sessionUser: SYNTHETIC_ADMIN as AuthUser | null } });
+  }
+
+  const request = ctx.request as Request | undefined;
+  const cookieHeader = request?.headers.get('cookie') ?? null;
+
+  const { parseCookie } = await import('@/middleware/auth-middleware');
+  const sessionToken = parseCookie(cookieHeader, 'session');
+
+  if (!sessionToken) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return next({ context: { ...ctx, sessionUser: null as AuthUser | null } });
+  }
+
+  if (!cachedSessionManager) {
+    const { buildSessionManager } = await import('@/lib/auth/session-manager');
+    cachedSessionManager = await buildSessionManager();
+  }
+
+  const user = await cachedSessionManager.validateSession(sessionToken);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return next({ context: { ...ctx, sessionUser: user as AuthUser | null } });
+});
+
+/**
+ * Returns the currently authenticated user, or null if unauthenticated.
+ * Used by the client-side auth hook to check session state without throwing.
+ */
+export const getSession = createServerFn()
+  .middleware([sessionReadMiddleware])
+  .handler(async ({ context }): Promise<AuthUser | null> => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (context as any).sessionUser as AuthUser | null;
+  });
+
+/**
+ * Reset cached session manager (for testing only).
+ */
+export function resetAuthFunctionsState(): void {
+  cachedSessionManager = null;
+}

--- a/src/data/docker/functions.tsx
+++ b/src/data/docker/functions.tsx
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import type { DockerStatsRow } from '@/types/docker';
 import { databaseMiddleware } from '@/middleware/database-middleware';
+import { authMiddleware } from '@/middleware/auth-middleware';
 import {
   getHistoricalDockerStatsSchema,
   getContainerHistorySchema,
@@ -12,7 +13,7 @@ import {
  * Get historical Docker stats (wide rows) for preloading.
  */
 export const getHistoricalDockerStats = createServerFn()
-  .middleware([databaseMiddleware])
+  .middleware([authMiddleware, databaseMiddleware])
   .inputValidator(getHistoricalDockerStatsSchema)
   .handler(async ({ context, data }): Promise<DockerStatsRow[]> => {
     try {
@@ -35,7 +36,7 @@ export const getHistoricalDockerStats = createServerFn()
  * Icons are stored under the service_key entity so they survive container recreation.
  */
 export const getDockerEntityIcons = createServerFn()
-  .middleware([databaseMiddleware])
+  .middleware([authMiddleware, databaseMiddleware])
   .handler(async ({ context }): Promise<Record<string, { iconSlug: string | null; serviceKeyEntity: string }>> => {
     try {
       const { EntityMetadataRepository } = await import(
@@ -52,7 +53,7 @@ export const getDockerEntityIcons = createServerFn()
   });
 
 export const getContainerHistory = createServerFn()
-  .middleware([databaseMiddleware])
+  .middleware([authMiddleware, databaseMiddleware])
   .inputValidator(getContainerHistorySchema)
   .handler(async ({ context, data }): Promise<DockerStatsRow[]> => {
     try {
@@ -91,7 +92,7 @@ export const getContainerHistory = createServerFn()
   });
 
 export const getContainerInfo = createServerFn()
-  .middleware([databaseMiddleware])
+  .middleware([authMiddleware, databaseMiddleware])
   .inputValidator(getContainerInfoSchema)
   .handler(async ({ context, data }): Promise<{
     containerName: string;
@@ -132,7 +133,7 @@ export const getContainerInfo = createServerFn()
  * Stores the icon slug under the service_key entity so it persists across container recreations.
  */
 export const updateContainerIcon = createServerFn()
-  .middleware([databaseMiddleware])
+  .middleware([authMiddleware, databaseMiddleware])
   .inputValidator(updateContainerIconSchema)
   .handler(async ({ context, data }): Promise<void> => {
     const { EntityMetadataRepository } = await import(

--- a/src/data/git-tokens.functions.tsx
+++ b/src/data/git-tokens.functions.tsx
@@ -16,17 +16,16 @@ export const createGitToken = createServerFn()
     const { randomBytes } = await import('crypto');
     const { databaseConnectionManager } = await import('@/lib/clients/database-client');
     const { loadDatabaseConfig } = await import('@/lib/config/database-config');
-    const { TransitClient } = await import('@/lib/clients/transit-client');
-    const { loadOpenBaoConfig } = await import('@/lib/config/openbao-config');
+    const { loadMasterKeyring } = await import('@/lib/crypto/master-key');
+    const { encryptValue } = await import('@/lib/crypto/encrypted-value');
     const { GitTokenRepository } = await import(
       '@/lib/database/repositories/git-token-repository'
     );
 
     const rawToken = randomBytes(32).toString('hex');
 
-    const baoConfig = loadOpenBaoConfig();
-    const transit = new TransitClient(baoConfig);
-    const encryptedToken = await transit.encrypt('git-tokens', rawToken);
+    const keyring = await loadMasterKeyring();
+    const encryptedToken = await encryptValue(rawToken, keyring);
 
     const dbConfig = loadDatabaseConfig();
     const dbClient = await databaseConnectionManager.getClient(dbConfig);

--- a/src/data/git-tokens.functions.tsx
+++ b/src/data/git-tokens.functions.tsx
@@ -1,0 +1,85 @@
+import { createServerFn } from '@tanstack/react-start';
+import { z } from 'zod';
+import { authMiddleware } from '@/middleware/auth-middleware';
+import { requireRole } from '@/lib/auth/require-role';
+
+/**
+ * Create a new git token for the current admin user.
+ * The raw token is returned once — it is never stored in plaintext.
+ */
+export const createGitToken = createServerFn()
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ label: z.string().min(1).max(100) }))
+  .handler(async ({ data, context }): Promise<{ token: string }> => {
+    requireRole('admin')(context.user);
+
+    const { randomBytes } = await import('crypto');
+    const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+    const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+    const { TransitClient } = await import('@/lib/clients/transit-client');
+    const { loadOpenBaoConfig } = await import('@/lib/config/openbao-config');
+    const { GitTokenRepository } = await import(
+      '@/lib/database/repositories/git-token-repository'
+    );
+
+    const rawToken = randomBytes(32).toString('hex');
+
+    const baoConfig = loadOpenBaoConfig();
+    const transit = new TransitClient(baoConfig);
+    const encryptedToken = await transit.encrypt('git-tokens', rawToken);
+
+    const dbConfig = loadDatabaseConfig();
+    const dbClient = await databaseConnectionManager.getClient(dbConfig);
+    const repo = new GitTokenRepository(dbClient.getPool());
+
+    await repo.create({
+      userId: context.user.id,
+      encryptedToken,
+      label: data.label,
+    });
+
+    return { token: rawToken }; // Show once, never again
+  });
+
+/**
+ * List all git tokens (admin only). Does not return encrypted values.
+ */
+export const listGitTokens = createServerFn()
+  .middleware([authMiddleware])
+  .handler(async ({ context }) => {
+    requireRole('admin')(context.user);
+
+    const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+    const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+    const { GitTokenRepository } = await import(
+      '@/lib/database/repositories/git-token-repository'
+    );
+
+    const dbConfig = loadDatabaseConfig();
+    const dbClient = await databaseConnectionManager.getClient(dbConfig);
+    const repo = new GitTokenRepository(dbClient.getPool());
+
+    return repo.findAll();
+  });
+
+/**
+ * Revoke a git token by ID (admin only).
+ */
+export const revokeGitToken = createServerFn()
+  .middleware([authMiddleware])
+  .inputValidator(z.object({ tokenId: z.number() }))
+  .handler(async ({ data, context }): Promise<void> => {
+    requireRole('admin')(context.user);
+
+    const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+    const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+    const { GitTokenRepository } = await import(
+      '@/lib/database/repositories/git-token-repository'
+    );
+
+    const dbConfig = loadDatabaseConfig();
+    const dbClient = await databaseConnectionManager.getClient(dbConfig);
+    const repo = new GitTokenRepository(dbClient.getPool());
+
+    await repo.deleteById(data.tokenId);
+  });

--- a/src/data/hosts/functions.tsx
+++ b/src/data/hosts/functions.tsx
@@ -1,6 +1,8 @@
 import { createServerFn } from '@tanstack/react-start';
 import type { HostListItem } from '@/lib/hosts/host-utils';
 import { addHostSchema, removeHostSchema, updateAgentSchema, checkHostHealthSchema, registerExistingHostSchema, verifyHostSchema, updateHostSchema } from '@/data/hosts/schemas';
+import { authMiddleware } from '@/middleware/auth-middleware';
+import { requireRole } from '@/lib/auth/require-role';
 import {
   handleListHosts, handleCheckHostHealth, handleRemoveHost,
   handleUpdateAgent, handleAddHost, handleUpdateHost, handleRegisterExistingHost, handleVerifyHost,
@@ -41,8 +43,10 @@ async function loadDockerClient(socketProxyUrl: string) {
 }
 
 export const addHost = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(addHostSchema)
-  .handler(async ({ data }): Promise<AddHostResult> => {
+  .handler(async ({ data, context }): Promise<AddHostResult> => {
+    requireRole('admin')(context.user);
     const baseDeps = await loadDeps();
     const { AgentProvisioningService } = await import('@/lib/services/agent-provisioning-service');
     const { checkAgentHealth } = await import('@/lib/services/agent-health-service');
@@ -67,8 +71,10 @@ export const addHost = createServerFn()
   });
 
 export const registerExistingHost = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(registerExistingHostSchema)
-  .handler(async ({ data }): Promise<AddHostResult> => {
+  .handler(async ({ data, context }): Promise<AddHostResult> => {
+    requireRole('admin')(context.user);
     const baseDeps = await loadDeps();
     const keypairs = await loadKeypairsRepo();
     return handleRegisterExistingHost({
@@ -81,8 +87,10 @@ export const registerExistingHost = createServerFn()
   });
 
 export const verifyHost = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(verifyHostSchema)
-  .handler(async ({ data }): Promise<AddHostResult> => {
+  .handler(async ({ data, context }): Promise<AddHostResult> => {
+    requireRole('admin')(context.user);
     const baseDeps = await loadDeps();
     const keypairs = await loadKeypairsRepo();
     return handleVerifyHost({
@@ -95,8 +103,10 @@ export const verifyHost = createServerFn()
   });
 
 export const removeHost = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(removeHostSchema)
-  .handler(async ({ data }): Promise<{ success: boolean }> => {
+  .handler(async ({ data, context }): Promise<{ success: boolean }> => {
+    requireRole('admin')(context.user);
     const baseDeps = await loadDeps();
     return handleRemoveHost({
       ...baseDeps,
@@ -118,14 +128,17 @@ export const removeHost = createServerFn()
   });
 
 export const listHosts = createServerFn()
+  .middleware([authMiddleware])
   .handler(async (): Promise<HostListItem[]> => {
     const deps = await loadDeps();
     return handleListHosts(deps);
   });
 
 export const updateAgent = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(updateAgentSchema)
-  .handler(async ({ data }): Promise<HostOperationResult> => {
+  .handler(async ({ data, context }): Promise<HostOperationResult> => {
+    requireRole('admin')(context.user);
     const baseDeps = await loadDeps();
     const keypairs = await loadKeypairsRepo();
     const { checkAgentHealth } = await import('@/lib/services/agent-health-service');
@@ -142,6 +155,7 @@ export const updateAgent = createServerFn()
   });
 
 export const checkHostHealth = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(checkHostHealthSchema)
   .handler(async ({ data }): Promise<HostOperationResult> => {
     const baseDeps = await loadDeps();
@@ -150,8 +164,10 @@ export const checkHostHealth = createServerFn()
   });
 
 export const updateHost = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(updateHostSchema)
-  .handler(async ({ data }): Promise<HostListItem> => {
+  .handler(async ({ data, context }): Promise<HostListItem> => {
+    requireRole('admin')(context.user);
     const deps = await loadDeps();
     return handleUpdateHost(deps, data);
   });

--- a/src/data/proxmox/functions.tsx
+++ b/src/data/proxmox/functions.tsx
@@ -1,6 +1,7 @@
 import { createServerFn } from '@tanstack/react-start';
 import type { ProxmoxStatsRow } from '@/types/proxmox';
 import { databaseMiddleware } from '@/middleware/database-middleware';
+import { authMiddleware } from '@/middleware/auth-middleware';
 import { getHistoricalProxmoxStatsSchema } from '@/data/proxmox/schemas';
 
 /**
@@ -8,7 +9,7 @@ import { getHistoricalProxmoxStatsSchema } from '@/data/proxmox/schemas';
  * Used by useTimeSeriesStream to preload data before SSE streaming begins.
  */
 export const getHistoricalProxmoxStats = createServerFn()
-  .middleware([databaseMiddleware])
+  .middleware([authMiddleware, databaseMiddleware])
   .inputValidator(getHistoricalProxmoxStatsSchema)
   .handler(async ({ context, data }): Promise<ProxmoxStatsRow[]> => {
     try {
@@ -28,6 +29,7 @@ export const getHistoricalProxmoxStats = createServerFn()
  * Test the Proxmox API connection.
  */
 export const testProxmoxConnection = createServerFn()
+  .middleware([authMiddleware])
   .handler(async (): Promise<{ connected: boolean; error?: string }> => {
     try {
       const { isProxmoxConfigured, loadProxmoxConfig } = await import(

--- a/src/data/settings/functions.tsx
+++ b/src/data/settings/functions.tsx
@@ -1,11 +1,14 @@
 import { createServerFn } from '@tanstack/react-start';
 import { databaseMiddleware } from '@/middleware/database-middleware';
+import { authMiddleware } from '@/middleware/auth-middleware';
+import { requireRole } from '@/lib/auth/require-role';
 import { updateSettingSchema } from '@/data/settings/schemas';
 
 export const updateSetting = createServerFn()
-  .middleware([databaseMiddleware])
+  .middleware([authMiddleware, databaseMiddleware])
   .inputValidator(updateSettingSchema)
   .handler(async ({ context, data }): Promise<void> => {
+    requireRole('admin', 'operator')(context.user);
     const { SettingsRepository } = await import(
       '@/lib/database/repositories/settings-repository'
     );

--- a/src/data/stacks/__tests__/functions.test.ts
+++ b/src/data/stacks/__tests__/functions.test.ts
@@ -1,4 +1,57 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { SYNTHETIC_ADMIN } from '@/lib/auth/types';
+
+// Inject a synthetic admin user so requireRole checks pass in tests.
+//
+// In tests (no Babel transform), createServerFn's client middleware path calls
+// extractedFn(payload) where payload.context = sendContext (starts empty). The
+// server handler receives that empty context, so context.user is undefined unless
+// we also inject the user on the client path via options.client.
+//
+// The middleware shape must match TanStack's flattenMiddlewares expectations:
+// an object with options.server and/or options.client, and options.middleware undefined.
+mock.module('@/middleware/auth-middleware', () => ({
+  authMiddleware: {
+    options: {
+      type: 'function',
+      // client path: inject user into sendContext so handler receives context.user
+      client: async ({ next, sendContext }: { next: (opts: { sendContext: unknown }) => unknown; sendContext: unknown }) => {
+        return next({ sendContext: { ...(sendContext as Record<string, unknown>), user: SYNTHETIC_ADMIN } });
+      },
+      // server path: inject user into context (used when middleware runs server-side)
+      server: async ({ next, context }: { next: (opts: { context: unknown }) => unknown; context: unknown }) => {
+        return next({ context: { ...(context as Record<string, unknown>), user: SYNTHETIC_ADMIN } });
+      },
+    },
+  },
+  AuthError: class AuthError extends Error {
+    status: number;
+    constructor(status: number, message: string) {
+      super(message);
+      this.status = status;
+      this.name = 'AuthError';
+    }
+  },
+  parseCookie: () => null,
+  resetAuthMiddlewareState: () => {},
+}));
+
+// stackSecretsMiddleware is used by some stacks functions; mock it so it injects
+// a minimal context (pool/keyring) without needing a real DB connection.
+mock.module('@/middleware/stack-secrets-middleware', () => ({
+  stackSecretsMiddleware: {
+    options: {
+      type: 'function',
+      client: async ({ next, sendContext }: { next: (opts: { sendContext: unknown }) => unknown; sendContext: unknown }) => {
+        return next({ sendContext: { ...(sendContext as Record<string, unknown>), pool: null, keyring: null } });
+      },
+      server: async ({ next, context }: { next: (opts: { context: unknown }) => unknown; context: unknown }) => {
+        return next({ context: { ...(context as Record<string, unknown>), pool: null, keyring: null } });
+      },
+    },
+  },
+  resetStackSecretsMiddlewareState: () => {},
+}));
 
 const mockGetStackSummaries = mock(() => Promise.resolve([
   { name: 'nginx', status: 'running', host: 'server1', lastDeployed: '2026-01-01T00:00:00Z' },

--- a/src/data/stacks/functions.tsx
+++ b/src/data/stacks/functions.tsx
@@ -2,6 +2,8 @@ import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
 import type { StackSummary, StackDetail, StackDeployRecord } from '@/types/stacks';
 import { stackSecretsMiddleware } from '@/middleware/stack-secrets-middleware';
+import { authMiddleware } from '@/middleware/auth-middleware';
+import { requireRole } from '@/lib/auth/require-role';
 import {
   getStackDetailSchema,
   triggerDeploySchema,
@@ -17,6 +19,7 @@ import {
  * Reads the manifest via isomorphic-git, cross-references deploy_history for status.
  */
 export const listStacks = createServerFn()
+  .middleware([authMiddleware])
   .handler(async (): Promise<StackSummary[]> => {
     const { getStackSummaries } = await import('@/lib/stacks/stack-service');
     return getStackSummaries();
@@ -26,6 +29,7 @@ export const listStacks = createServerFn()
  * Get full detail for a single stack, including compose file content and variables.
  */
 export const getStackDetail = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(getStackDetailSchema)
   .handler(async ({ data }): Promise<StackDetail | null> => {
     const { getStackDetailByName } = await import('@/lib/stacks/stack-service');
@@ -39,8 +43,10 @@ export const getStackDetail = createServerFn()
  * Pass an optional commitSha to perform a rollback to that specific commit.
  */
 export const triggerDeploy = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(triggerDeploySchema)
-  .handler(async ({ data }): Promise<{ deployId: number }> => {
+  .handler(async ({ data, context }): Promise<{ deployId: number }> => {
+    requireRole('admin', 'operator')(context.user);
     const { triggerStackDeploy } = await import('@/lib/stacks/stack-service');
     return triggerStackDeploy(data);
   });
@@ -69,6 +75,7 @@ export const rejectDeploy = createServerFn({ method: 'POST' })
  * Get deploy history for a stack.
  */
 export const getDeployHistory = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(getDeployHistorySchema)
   .handler(async ({ data }): Promise<StackDeployRecord[]> => {
     const { getStackDeployHistory } = await import('@/lib/stacks/stack-service');
@@ -81,8 +88,10 @@ export const getDeployHistory = createServerFn()
  * Returns warnings if the secrets store is unavailable; the save itself still succeeds.
  */
 export const saveComposeFile = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(saveComposeFileSchema)
-  .handler(async ({ data }): Promise<{ commitSha: string; warnings?: string[] }> => {
+  .handler(async ({ data, context }): Promise<{ commitSha: string; warnings?: string[] }> => {
+    requireRole('admin', 'operator')(context.user);
     const { saveStackComposeFile } = await import('@/lib/stacks/stack-service');
     const { extractVariableNames } = await import('@/lib/stacks/stack-mappers');
     const result = await saveStackComposeFile(data.stackName, data.content);
@@ -112,8 +121,10 @@ export const saveComposeFile = createServerFn()
  * Update stack icon.
  */
 export const updateStackIcon = createServerFn()
+  .middleware([authMiddleware])
   .inputValidator(updateStackIconSchema)
-  .handler(async ({ data }): Promise<void> => {
+  .handler(async ({ data, context }): Promise<void> => {
+    requireRole('admin', 'operator')(context.user);
     const { updateStackIconSlug } = await import('@/lib/stacks/stack-service');
     return updateStackIconSlug(data.stackName, data.iconSlug);
   });
@@ -129,7 +140,7 @@ const stackVariablesSchema = z.object({
  * List all variable names stored for a stack.
  */
 export const getStackVariables = createServerFn({ method: 'GET' })
-  .middleware([stackSecretsMiddleware])
+  .middleware([authMiddleware, stackSecretsMiddleware])
   .inputValidator(stackVariablesSchema)
   .handler(async ({ context, data }): Promise<string[]> => {
     const { StackSecretsRepository } = await import('@/lib/database/repositories/stack-secrets-repository');
@@ -146,7 +157,7 @@ const getVariableValueSchema = z.object({
  * Fetch a single secret value. Returns null if the key does not exist.
  */
 export const getVariableValue = createServerFn({ method: 'GET' })
-  .middleware([stackSecretsMiddleware])
+  .middleware([authMiddleware, stackSecretsMiddleware])
   .inputValidator(getVariableValueSchema)
   .handler(async ({ context, data }): Promise<string | null> => {
     const { StackSecretsRepository } = await import('@/lib/database/repositories/stack-secrets-repository');
@@ -164,9 +175,10 @@ const setVariableValueSchema = z.object({
  * Create or update a secret value.
  */
 export const setVariableValue = createServerFn({ method: 'POST' })
-  .middleware([stackSecretsMiddleware])
+  .middleware([authMiddleware, stackSecretsMiddleware])
   .inputValidator(setVariableValueSchema)
   .handler(async ({ context, data }): Promise<void> => {
+    requireRole('admin', 'operator')(context.user);
     const { StackSecretsRepository } = await import('@/lib/database/repositories/stack-secrets-repository');
     const repo = new StackSecretsRepository(context.pool, context.keyring);
     await repo.set(data.stackName, data.variableName, data.value);
@@ -181,9 +193,10 @@ const deleteVariableSchema = z.object({
  * Delete a secret for a given stack variable.
  */
 export const deleteVariable = createServerFn({ method: 'POST' })
-  .middleware([stackSecretsMiddleware])
+  .middleware([authMiddleware, stackSecretsMiddleware])
   .inputValidator(deleteVariableSchema)
   .handler(async ({ context, data }): Promise<void> => {
+    requireRole('admin', 'operator')(context.user);
     const { StackSecretsRepository } = await import('@/lib/database/repositories/stack-secrets-repository');
     const repo = new StackSecretsRepository(context.pool, context.keyring);
     await repo.delete(data.stackName, data.variableName);
@@ -193,6 +206,7 @@ export const deleteVariable = createServerFn({ method: 'POST' })
  * List managed host names for use in the create stack dialog host selector.
  */
 export const listManagedHostNames = createServerFn({ method: 'GET' })
+  .middleware([authMiddleware])
   .handler(async (): Promise<string[]> => {
     const { getManagedHostNames } = await import('@/lib/stacks/stack-service');
     return getManagedHostNames();
@@ -208,8 +222,10 @@ const createStackSchema = z.object({
  * Create a new stack: adds an empty compose file and updates the manifest in one commit.
  */
 export const createStack = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
   .inputValidator(createStackSchema)
-  .handler(async ({ data }): Promise<{ commitSha: string }> => {
+  .handler(async ({ data, context }): Promise<{ commitSha: string }> => {
+    requireRole('admin', 'operator')(context.user);
     const { createStackInRepo } = await import('@/lib/stacks/stack-service');
     return createStackInRepo(data.stackName, data.host, data.autoDeploy);
   });
@@ -226,11 +242,13 @@ const deleteStackSchema = z.object({
  * If `teardown` is false, removes the stack from the manifest synchronously.
  */
 export const deleteStack = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
   .inputValidator(deleteStackSchema)
-  .handler(async ({ data }): Promise<
+  .handler(async ({ data, context }): Promise<
     | { status: 'removed'; commitSha: string }
     | { status: 'teardown-pending'; deployId: number }
   > => {
+    requireRole('admin', 'operator')(context.user);
     const { deleteStackFromRepo } = await import('@/lib/stacks/stack-service');
     return deleteStackFromRepo(data.stackName, data.teardown);
   });
@@ -245,8 +263,10 @@ const updateStackSettingsSchema = z.object({
  * Update stack settings (host assignment and deploy mode) by writing to manifest.yaml.
  */
 export const updateStackSettings = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
   .inputValidator(updateStackSettingsSchema)
-  .handler(async ({ data }): Promise<{ commitSha: string }> => {
+  .handler(async ({ data, context }): Promise<{ commitSha: string }> => {
+    requireRole('admin', 'operator')(context.user);
     const { loadGitConfig } = await import('@/lib/config/git-config');
     const { updateManifest } = await import('@/lib/git/editor-operations');
     const config = loadGitConfig();
@@ -269,9 +289,10 @@ const ensureVariablesExistSchema = z.object({
  * Variables that already exist are left untouched; missing ones are created with an empty value.
  */
 export const ensureVariablesExist = createServerFn({ method: 'POST' })
-  .middleware([stackSecretsMiddleware])
+  .middleware([authMiddleware, stackSecretsMiddleware])
   .inputValidator(ensureVariablesExistSchema)
   .handler(async ({ context, data }): Promise<void> => {
+    requireRole('admin', 'operator')(context.user);
     const { StackSecretsRepository } = await import('@/lib/database/repositories/stack-secrets-repository');
     const repo = new StackSecretsRepository(context.pool, context.keyring);
     await Promise.all(

--- a/src/data/zfs/functions.tsx
+++ b/src/data/zfs/functions.tsx
@@ -1,13 +1,14 @@
 import { createServerFn } from '@tanstack/react-start';
 import type { ZFSStatsRow } from '@/types/zfs';
 import { databaseMiddleware } from '@/middleware/database-middleware';
+import { authMiddleware } from '@/middleware/auth-middleware';
 import { getHistoricalZFSStatsSchema } from '@/data/zfs/schemas';
 
 /**
  * Get historical ZFS stats (wide rows) for preloading.
  */
 export const getHistoricalZFSStats = createServerFn()
-  .middleware([databaseMiddleware])
+  .middleware([authMiddleware, databaseMiddleware])
   .inputValidator(getHistoricalZFSStatsSchema)
   .handler(async ({ context, data }): Promise<ZFSStatsRow[]> => {
     try {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from '@tanstack/react-router';
+import { useServerFn } from '@tanstack/react-start';
+import { getSession } from '@/data/auth.functions';
+import type { AuthUser } from '@/lib/auth/types';
+
+/**
+ * Checks the current session on mount and redirects to /login if unauthenticated.
+ * Returns the authenticated user and a loading flag.
+ */
+export function useAuth(): { user: AuthUser | null; loading: boolean } {
+  const [user, setUser] = useState<AuthUser | null>(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+  const fetchSession = useServerFn(getSession);
+
+  useEffect(() => {
+    fetchSession()
+      .then((result) => {
+        if (!result) {
+          void navigate({ to: '/login' });
+        } else {
+          setUser(result);
+        }
+      })
+      .catch(() => {
+        void navigate({ to: '/login' });
+      })
+      .finally(() => setLoading(false));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { user, loading };
+}

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -23,7 +23,8 @@ export function useAuth(): { user: AuthUser | null; loading: boolean } {
           setUser(result);
         }
       })
-      .catch(() => {
+      .catch((error) => {
+        console.error('[useAuth] Session check failed:', error);
         void navigate({ to: '/login' });
       })
       .finally(() => setLoading(false));

--- a/src/lib/auth/__tests__/agent-token-migration.test.ts
+++ b/src/lib/auth/__tests__/agent-token-migration.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, mock, spyOn } from 'bun:test';
+import { migrateAgentTokensToTransit } from '../agent-token-migration';
+import type { Pool } from 'pg';
+import type { TransitClient } from '@/lib/clients/transit-client';
+
+function makePool(rows: Array<{ id: number; agent_token: string }>): Pool {
+  const queryMock = mock(async (sql: string, _params?: unknown[]) => {
+    if (sql.includes('SELECT')) {
+      return { rows };
+    }
+    return { rows: [] };
+  });
+  return { query: queryMock } as unknown as Pool;
+}
+
+function makeTransit(encryptImpl?: (key: string, plaintext: string) => Promise<string>): TransitClient {
+  return {
+    encrypt: mock(encryptImpl ?? (async (_key: string, plaintext: string) => `vault:v1:${btoa(plaintext)}`)),
+    decrypt: mock(async () => ''),
+  } as unknown as TransitClient;
+}
+
+describe('migrateAgentTokensToTransit', () => {
+  it('migrates rows with plaintext agent_token to agent_token_encrypted', async () => {
+    const rows = [
+      { id: 1, agent_token: 'token-abc' },
+      { id: 2, agent_token: 'token-xyz' },
+    ];
+    const pool = makePool(rows);
+    const transit = makeTransit();
+
+    await migrateAgentTokensToTransit(pool, transit);
+
+    expect(transit.encrypt).toHaveBeenCalledTimes(2);
+    expect(transit.encrypt).toHaveBeenCalledWith('agent-tokens', 'token-abc');
+    expect(transit.encrypt).toHaveBeenCalledWith('agent-tokens', 'token-xyz');
+
+    // Two SELECT calls + two UPDATE calls = 3 total (1 SELECT + 2 UPDATEs)
+    const queryMock = pool.query as ReturnType<typeof mock>;
+    expect(queryMock).toHaveBeenCalledTimes(3);
+
+    const updateCalls = queryMock.mock.calls.filter((c: unknown[]) =>
+      (c[0] as string).includes('UPDATE')
+    );
+    expect(updateCalls).toHaveLength(2);
+    expect(updateCalls[0][1]).toEqual([`vault:v1:${btoa('token-abc')}`, 1]);
+    expect(updateCalls[1][1]).toEqual([`vault:v1:${btoa('token-xyz')}`, 2]);
+  });
+
+  it('nulls out agent_token after successful encryption', async () => {
+    const rows = [{ id: 42, agent_token: 'secret-token' }];
+    const pool = makePool(rows);
+    const transit = makeTransit();
+
+    await migrateAgentTokensToTransit(pool, transit);
+
+    const queryMock = pool.query as ReturnType<typeof mock>;
+    const updateCall = queryMock.mock.calls.find((c: unknown[]) =>
+      (c[0] as string).includes('UPDATE')
+    );
+    expect(updateCall).toBeDefined();
+    // The UPDATE sets agent_token = NULL (via the SQL) and agent_token_encrypted = encrypted value
+    expect((updateCall![0] as string)).toContain('agent_token = NULL');
+  });
+
+  it('skips rows where agent_token is already null (query returns no such rows)', async () => {
+    // The SELECT filters WHERE agent_token IS NOT NULL, so null rows never appear.
+    // This test verifies that an empty result from the SELECT causes no encrypt/update calls.
+    const pool = makePool([]);
+    const transit = makeTransit();
+
+    await migrateAgentTokensToTransit(pool, transit);
+
+    expect(transit.encrypt).toHaveBeenCalledTimes(0);
+    const queryMock = pool.query as ReturnType<typeof mock>;
+    // Only the SELECT was called
+    expect(queryMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles empty result set (no rows to migrate)', async () => {
+    const pool = makePool([]);
+    const transit = makeTransit();
+
+    await expect(migrateAgentTokensToTransit(pool, transit)).resolves.toBeUndefined();
+    expect(transit.encrypt).toHaveBeenCalledTimes(0);
+  });
+
+  it('handles Transit encryption failure gracefully (logs error, does not crash)', async () => {
+    const rows = [
+      { id: 1, agent_token: 'will-fail' },
+      { id: 2, agent_token: 'will-succeed' },
+    ];
+    const pool = makePool(rows);
+    const transit = makeTransit(async (_key: string, plaintext: string) => {
+      if (plaintext === 'will-fail') {
+        throw new Error('Transit unavailable');
+      }
+      return `vault:v1:${btoa(plaintext)}`;
+    });
+
+    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(migrateAgentTokensToTransit(pool, transit)).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    expect(errorSpy.mock.calls[0][0]).toContain('[agent-token-migration]');
+    expect(errorSpy.mock.calls[0][0]).toContain('host 1');
+
+    // The second row should still have been processed
+    expect(transit.encrypt).toHaveBeenCalledTimes(2);
+    const queryMock = pool.query as ReturnType<typeof mock>;
+    const updateCalls = queryMock.mock.calls.filter((c: unknown[]) =>
+      (c[0] as string).includes('UPDATE')
+    );
+    expect(updateCalls).toHaveLength(1);
+    expect(updateCalls[0][1]).toEqual([`vault:v1:${btoa('will-succeed')}`, 2]);
+
+    errorSpy.mockRestore();
+  });
+});

--- a/src/lib/auth/__tests__/agent-token-migration.test.ts
+++ b/src/lib/auth/__tests__/agent-token-migration.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { migrateAgentTokensToTransit } from '../agent-token-migration';
+import { migrateAgentTokensToTransit } from '@/lib/auth/agent-token-migration';
 import type { Pool } from 'pg';
 
 describe('migrateAgentTokensToTransit', () => {

--- a/src/lib/auth/__tests__/agent-token-migration.test.ts
+++ b/src/lib/auth/__tests__/agent-token-migration.test.ts
@@ -28,8 +28,11 @@ describe('migrateAgentTokensToTransit', () => {
     ];
     const pool = makePool(rows);
     const transit = makeTransit();
+    const infoSpy = spyOn(console, 'info').mockImplementation(() => {});
 
-    await migrateAgentTokensToTransit(pool, transit);
+    const result = await migrateAgentTokensToTransit(pool, transit);
+    expect(result).toEqual({ migrated: 2, failed: 0 });
+    infoSpy.mockRestore();
 
     expect(transit.encrypt).toHaveBeenCalledTimes(2);
     expect(transit.encrypt).toHaveBeenCalledWith('agent-tokens', 'token-abc');
@@ -51,6 +54,7 @@ describe('migrateAgentTokensToTransit', () => {
     const rows = [{ id: 42, agent_token: 'secret-token' }];
     const pool = makePool(rows);
     const transit = makeTransit();
+    const infoSpy = spyOn(console, 'info').mockImplementation(() => {});
 
     await migrateAgentTokensToTransit(pool, transit);
 
@@ -61,6 +65,7 @@ describe('migrateAgentTokensToTransit', () => {
     expect(updateCall).toBeDefined();
     // The UPDATE sets agent_token = NULL (via the SQL) and agent_token_encrypted = encrypted value
     expect((updateCall![0] as string)).toContain('agent_token = NULL');
+    infoSpy.mockRestore();
   });
 
   it('skips rows where agent_token is already null (query returns no such rows)', async () => {
@@ -81,7 +86,8 @@ describe('migrateAgentTokensToTransit', () => {
     const pool = makePool([]);
     const transit = makeTransit();
 
-    await expect(migrateAgentTokensToTransit(pool, transit)).resolves.toBeUndefined();
+    const result = await migrateAgentTokensToTransit(pool, transit);
+    expect(result).toEqual({ migrated: 0, failed: 0 });
     expect(transit.encrypt).toHaveBeenCalledTimes(0);
   });
 
@@ -99,8 +105,10 @@ describe('migrateAgentTokensToTransit', () => {
     });
 
     const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    const infoSpy = spyOn(console, 'info').mockImplementation(() => {});
 
-    await expect(migrateAgentTokensToTransit(pool, transit)).resolves.toBeUndefined();
+    const result = await migrateAgentTokensToTransit(pool, transit);
+    expect(result).toEqual({ migrated: 1, failed: 1 });
 
     expect(errorSpy).toHaveBeenCalledTimes(1);
     const firstArg = errorSpy.mock.calls[0][0] as string;
@@ -117,6 +125,7 @@ describe('migrateAgentTokensToTransit', () => {
     expect(updateCalls).toHaveLength(1);
     expect(updateCalls[0][1]).toEqual([`vault:v1:${btoa('will-succeed')}`, 2]);
 
+    infoSpy.mockRestore();
     errorSpy.mockRestore();
   });
 });

--- a/src/lib/auth/__tests__/agent-token-migration.test.ts
+++ b/src/lib/auth/__tests__/agent-token-migration.test.ts
@@ -103,8 +103,10 @@ describe('migrateAgentTokensToTransit', () => {
     await expect(migrateAgentTokensToTransit(pool, transit)).resolves.toBeUndefined();
 
     expect(errorSpy).toHaveBeenCalledTimes(1);
-    expect(errorSpy.mock.calls[0][0]).toContain('[agent-token-migration]');
-    expect(errorSpy.mock.calls[0][0]).toContain('host 1');
+    const firstArg = errorSpy.mock.calls[0][0] as string;
+    expect(firstArg).toContain('[agent-token-migration]');
+    expect(firstArg).toContain('host 1');
+    expect(errorSpy.mock.calls[0][1]).toBeInstanceOf(Error);
 
     // The second row should still have been processed
     expect(transit.encrypt).toHaveBeenCalledTimes(2);

--- a/src/lib/auth/__tests__/agent-token-migration.test.ts
+++ b/src/lib/auth/__tests__/agent-token-migration.test.ts
@@ -1,131 +1,13 @@
-import { describe, it, expect, mock, spyOn } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { migrateAgentTokensToTransit } from '../agent-token-migration';
 import type { Pool } from 'pg';
-import type { TransitClient } from '@/lib/clients/transit-client';
-
-function makePool(rows: Array<{ id: number; agent_token: string }>): Pool {
-  const queryMock = mock(async (sql: string, _params?: unknown[]) => {
-    if (sql.includes('SELECT')) {
-      return { rows };
-    }
-    return { rows: [] };
-  });
-  return { query: queryMock } as unknown as Pool;
-}
-
-function makeTransit(encryptImpl?: (key: string, plaintext: string) => Promise<string>): TransitClient {
-  return {
-    encrypt: mock(encryptImpl ?? (async (_key: string, plaintext: string) => `vault:v1:${btoa(plaintext)}`)),
-    decrypt: mock(async () => ''),
-  } as unknown as TransitClient;
-}
 
 describe('migrateAgentTokensToTransit', () => {
-  it('migrates rows with plaintext agent_token to agent_token_encrypted', async () => {
-    const rows = [
-      { id: 1, agent_token: 'token-abc' },
-      { id: 2, agent_token: 'token-xyz' },
-    ];
-    const pool = makePool(rows);
-    const transit = makeTransit();
-    const infoSpy = spyOn(console, 'info').mockImplementation(() => {});
-
-    const result = await migrateAgentTokensToTransit(pool, transit);
-    expect(result).toEqual({ migrated: 2, failed: 0 });
-    infoSpy.mockRestore();
-
-    expect(transit.encrypt).toHaveBeenCalledTimes(2);
-    expect(transit.encrypt).toHaveBeenCalledWith('agent-tokens', 'token-abc');
-    expect(transit.encrypt).toHaveBeenCalledWith('agent-tokens', 'token-xyz');
-
-    // Two SELECT calls + two UPDATE calls = 3 total (1 SELECT + 2 UPDATEs)
-    const queryMock = pool.query as ReturnType<typeof mock>;
-    expect(queryMock).toHaveBeenCalledTimes(3);
-
-    const updateCalls = queryMock.mock.calls.filter((c: unknown[]) =>
-      (c[0] as string).includes('UPDATE')
-    );
-    expect(updateCalls).toHaveLength(2);
-    expect(updateCalls[0][1]).toEqual([`vault:v1:${btoa('token-abc')}`, 1]);
-    expect(updateCalls[1][1]).toEqual([`vault:v1:${btoa('token-xyz')}`, 2]);
-  });
-
-  it('nulls out agent_token after successful encryption', async () => {
-    const rows = [{ id: 42, agent_token: 'secret-token' }];
-    const pool = makePool(rows);
-    const transit = makeTransit();
-    const infoSpy = spyOn(console, 'info').mockImplementation(() => {});
-
-    await migrateAgentTokensToTransit(pool, transit);
-
-    const queryMock = pool.query as ReturnType<typeof mock>;
-    const updateCall = queryMock.mock.calls.find((c: unknown[]) =>
-      (c[0] as string).includes('UPDATE')
-    );
-    expect(updateCall).toBeDefined();
-    // The UPDATE sets agent_token = NULL (via the SQL) and agent_token_encrypted = encrypted value
-    expect((updateCall![0] as string)).toContain('agent_token = NULL');
-    infoSpy.mockRestore();
-  });
-
-  it('skips rows where agent_token is already null (query returns no such rows)', async () => {
-    // The SELECT filters WHERE agent_token IS NOT NULL, so null rows never appear.
-    // This test verifies that an empty result from the SELECT causes no encrypt/update calls.
-    const pool = makePool([]);
-    const transit = makeTransit();
-
-    await migrateAgentTokensToTransit(pool, transit);
-
-    expect(transit.encrypt).toHaveBeenCalledTimes(0);
-    const queryMock = pool.query as ReturnType<typeof mock>;
-    // Only the SELECT was called
-    expect(queryMock).toHaveBeenCalledTimes(1);
-  });
-
-  it('handles empty result set (no rows to migrate)', async () => {
-    const pool = makePool([]);
-    const transit = makeTransit();
-
-    const result = await migrateAgentTokensToTransit(pool, transit);
+  it('is a no-op — agent tokens are now Ed25519 keypairs', async () => {
+    // managed_hosts no longer has an agent_token column; tokens are Ed25519 keypairs
+    // stored in the agent_keypairs table (migration 022). This function exists only
+    // for backward compat with callers that were written before the keypair migration.
+    const result = await migrateAgentTokensToTransit({} as Pool, undefined);
     expect(result).toEqual({ migrated: 0, failed: 0 });
-    expect(transit.encrypt).toHaveBeenCalledTimes(0);
-  });
-
-  it('handles Transit encryption failure gracefully (logs error, does not crash)', async () => {
-    const rows = [
-      { id: 1, agent_token: 'will-fail' },
-      { id: 2, agent_token: 'will-succeed' },
-    ];
-    const pool = makePool(rows);
-    const transit = makeTransit(async (_key: string, plaintext: string) => {
-      if (plaintext === 'will-fail') {
-        throw new Error('Transit unavailable');
-      }
-      return `vault:v1:${btoa(plaintext)}`;
-    });
-
-    const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
-    const infoSpy = spyOn(console, 'info').mockImplementation(() => {});
-
-    const result = await migrateAgentTokensToTransit(pool, transit);
-    expect(result).toEqual({ migrated: 1, failed: 1 });
-
-    expect(errorSpy).toHaveBeenCalledTimes(1);
-    const firstArg = errorSpy.mock.calls[0][0] as string;
-    expect(firstArg).toContain('[agent-token-migration]');
-    expect(firstArg).toContain('host 1');
-    expect(errorSpy.mock.calls[0][1]).toBeInstanceOf(Error);
-
-    // The second row should still have been processed
-    expect(transit.encrypt).toHaveBeenCalledTimes(2);
-    const queryMock = pool.query as ReturnType<typeof mock>;
-    const updateCalls = queryMock.mock.calls.filter((c: unknown[]) =>
-      (c[0] as string).includes('UPDATE')
-    );
-    expect(updateCalls).toHaveLength(1);
-    expect(updateCalls[0][1]).toEqual([`vault:v1:${btoa('will-succeed')}`, 2]);
-
-    infoSpy.mockRestore();
-    errorSpy.mockRestore();
   });
 });

--- a/src/lib/auth/__tests__/oidc-client.test.ts
+++ b/src/lib/auth/__tests__/oidc-client.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
-import { OidcClient } from '../oidc-client';
-import type { OidcConfig } from '../oidc-client';
+import { OidcClient } from '@/lib/auth/oidc-client';
+import type { OidcConfig } from '@/lib/auth/oidc-client';
 
 // Bun's `typeof fetch` includes a `preconnect` property that arrow functions lack.
 // Cast helpers through `unknown` to satisfy the type constraint.

--- a/src/lib/auth/__tests__/oidc-client.test.ts
+++ b/src/lib/auth/__tests__/oidc-client.test.ts
@@ -84,6 +84,32 @@ describe('OidcClient', () => {
       const client = new OidcClient(config, failingFetch);
       await expect(client.discoverEndpoints()).rejects.toThrow('OIDC discovery failed (HTTP 503)');
     });
+
+    it('throws when discovery response is missing required endpoint fields', async () => {
+      const missingFetch = asFetch(async () =>
+        makeResponse({ authorization_endpoint: 'https://auth.example.com/authorize' }),
+      );
+
+      const client = new OidcClient(config, missingFetch);
+      await expect(client.discoverEndpoints()).rejects.toThrow(
+        'OIDC discovery response missing required endpoints (authorization_endpoint, token_endpoint, userinfo_endpoint)',
+      );
+    });
+
+    it('throws when discovery response has non-string endpoint fields', async () => {
+      const badFetch = asFetch(async () =>
+        makeResponse({
+          authorization_endpoint: 42,
+          token_endpoint: 'https://auth.example.com/token',
+          userinfo_endpoint: 'https://auth.example.com/userinfo',
+        }),
+      );
+
+      const client = new OidcClient(config, badFetch);
+      await expect(client.discoverEndpoints()).rejects.toThrow(
+        'OIDC discovery response missing required endpoints (authorization_endpoint, token_endpoint, userinfo_endpoint)',
+      );
+    });
   });
 
   describe('getAuthorizationUrl', () => {
@@ -176,6 +202,30 @@ describe('OidcClient', () => {
       const client = new OidcClient(config, mockFetch);
       await expect(client.exchangeCode('bad-code')).rejects.toThrow(
         'OIDC token exchange failed (HTTP 400): invalid_grant',
+      );
+    });
+
+    it('throws when token response is missing access_token or id_token', async () => {
+      const mockFetch = makeDiscoveryFetch({
+        'https://auth.example.com/token': () =>
+          makeResponse({ access_token: 'at' /* no id_token */ }),
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      await expect(client.exchangeCode('code')).rejects.toThrow(
+        'OIDC token response missing required fields (access_token, id_token)',
+      );
+    });
+
+    it('throws when token response fields are not strings', async () => {
+      const mockFetch = makeDiscoveryFetch({
+        'https://auth.example.com/token': () =>
+          makeResponse({ access_token: 123, id_token: true }),
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      await expect(client.exchangeCode('code')).rejects.toThrow(
+        'OIDC token response missing required fields (access_token, id_token)',
       );
     });
   });

--- a/src/lib/auth/__tests__/oidc-client.test.ts
+++ b/src/lib/auth/__tests__/oidc-client.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect } from 'bun:test';
+import { OidcClient } from '../oidc-client';
+import type { OidcConfig } from '../oidc-client';
+
+// Bun's `typeof fetch` includes a `preconnect` property that arrow functions lack.
+// Cast helpers through `unknown` to satisfy the type constraint.
+type FetchFn = typeof fetch;
+function asFetch(fn: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>): FetchFn {
+  return fn as unknown as FetchFn;
+}
+
+const DISCOVERY_URL = 'https://auth.example.com/.well-known/openid-configuration';
+
+const DISCOVERY_BODY = {
+  authorization_endpoint: 'https://auth.example.com/authorize',
+  token_endpoint: 'https://auth.example.com/token',
+  userinfo_endpoint: 'https://auth.example.com/userinfo',
+};
+
+const config: OidcConfig = {
+  issuerUrl: 'https://auth.example.com',
+  clientId: 'my-client',
+  clientSecret: 'my-secret',
+  redirectUri: 'https://app.example.com/callback',
+};
+
+function makeResponse(body: unknown, status = 200): Response {
+  const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
+  return new Response(bodyStr, {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function makeDiscoveryFetch(extraHandlers?: Record<string, () => Response>): FetchFn {
+  return asFetch(async (input, init) => {
+    void init;
+    const url = input.toString();
+
+    if (url === DISCOVERY_URL) {
+      return makeResponse(DISCOVERY_BODY);
+    }
+
+    if (extraHandlers?.[url]) {
+      return extraHandlers[url]();
+    }
+
+    return makeResponse({ error: 'not_found' }, 404);
+  });
+}
+
+describe('OidcClient', () => {
+  describe('discoverEndpoints', () => {
+    it('fetches .well-known/openid-configuration and returns endpoints', async () => {
+      const client = new OidcClient(config, makeDiscoveryFetch());
+      const endpoints = await client.discoverEndpoints();
+
+      expect(endpoints.authorizationEndpoint).toBe('https://auth.example.com/authorize');
+      expect(endpoints.tokenEndpoint).toBe('https://auth.example.com/token');
+      expect(endpoints.userinfoEndpoint).toBe('https://auth.example.com/userinfo');
+    });
+
+    it('caches result so fetch is only called once on repeated calls', async () => {
+      let callCount = 0;
+      const countingFetch = asFetch(async (input) => {
+        if (input.toString() === DISCOVERY_URL) {
+          callCount++;
+          return makeResponse(DISCOVERY_BODY);
+        }
+        return makeResponse({}, 404);
+      });
+
+      const client = new OidcClient(config, countingFetch);
+      await client.discoverEndpoints();
+      await client.discoverEndpoints();
+      await client.discoverEndpoints();
+
+      expect(callCount).toBe(1);
+    });
+
+    it('throws on network error (non-ok response)', async () => {
+      const failingFetch = asFetch(async () => makeResponse('Service Unavailable', 503));
+
+      const client = new OidcClient(config, failingFetch);
+      await expect(client.discoverEndpoints()).rejects.toThrow('OIDC discovery failed (HTTP 503)');
+    });
+  });
+
+  describe('getAuthorizationUrl', () => {
+    it('builds correct URL with required params', async () => {
+      const client = new OidcClient(config, makeDiscoveryFetch());
+      const url = await client.getAuthorizationUrl('state-abc', 'nonce-xyz');
+
+      const parsed = new URL(url);
+      expect(parsed.origin + parsed.pathname).toBe('https://auth.example.com/authorize');
+      expect(parsed.searchParams.get('client_id')).toBe('my-client');
+      expect(parsed.searchParams.get('redirect_uri')).toBe('https://app.example.com/callback');
+      expect(parsed.searchParams.get('response_type')).toBe('code');
+      expect(parsed.searchParams.get('scope')).toBe('openid profile email groups');
+      expect(parsed.searchParams.get('state')).toBe('state-abc');
+      expect(parsed.searchParams.get('nonce')).toBe('nonce-xyz');
+    });
+
+    it('does not include prompt param when not specified', async () => {
+      const client = new OidcClient(config, makeDiscoveryFetch());
+      const url = await client.getAuthorizationUrl('s', 'n');
+
+      expect(new URL(url).searchParams.has('prompt')).toBe(false);
+    });
+
+    it('includes prompt=none for silent re-auth', async () => {
+      const client = new OidcClient(config, makeDiscoveryFetch());
+      const url = await client.getAuthorizationUrl('state-abc', 'nonce-xyz', 'none');
+
+      expect(new URL(url).searchParams.get('prompt')).toBe('none');
+    });
+  });
+
+  describe('exchangeCode', () => {
+    const TOKEN_RESPONSE = {
+      access_token: 'access-tok',
+      refresh_token: 'refresh-tok',
+      id_token: 'header.e30K.sig',
+    };
+
+    it('calls token endpoint with correct params and returns tokens', async () => {
+      let capturedInit: RequestInit | undefined;
+
+      const mockFetch = asFetch(async (input, init) => {
+        const url = input.toString();
+        if (url === DISCOVERY_URL) return makeResponse(DISCOVERY_BODY);
+        if (url === 'https://auth.example.com/token') {
+          capturedInit = init;
+          return makeResponse(TOKEN_RESPONSE);
+        }
+        return makeResponse({}, 404);
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      const tokens = await client.exchangeCode('auth-code-123');
+
+      expect(tokens.accessToken).toBe('access-tok');
+      expect(tokens.refreshToken).toBe('refresh-tok');
+      expect(tokens.idToken).toBe('header.e30K.sig');
+
+      expect(capturedInit?.method).toBe('POST');
+      expect((capturedInit?.headers as Record<string, string>)['Content-Type']).toBe(
+        'application/x-www-form-urlencoded',
+      );
+
+      const body = new URLSearchParams(capturedInit?.body as string);
+      expect(body.get('grant_type')).toBe('authorization_code');
+      expect(body.get('client_id')).toBe('my-client');
+      expect(body.get('client_secret')).toBe('my-secret');
+      expect(body.get('redirect_uri')).toBe('https://app.example.com/callback');
+      expect(body.get('code')).toBe('auth-code-123');
+    });
+
+    it('sets refreshToken to null when not present in response', async () => {
+      const mockFetch = makeDiscoveryFetch({
+        'https://auth.example.com/token': () =>
+          makeResponse({ access_token: 'at', id_token: 'it' }),
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      const tokens = await client.exchangeCode('code');
+
+      expect(tokens.refreshToken).toBeNull();
+    });
+
+    it('throws on error response', async () => {
+      const mockFetch = makeDiscoveryFetch({
+        'https://auth.example.com/token': () => new Response('invalid_grant', { status: 400 }),
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      await expect(client.exchangeCode('bad-code')).rejects.toThrow(
+        'OIDC token exchange failed (HTTP 400): invalid_grant',
+      );
+    });
+  });
+
+  describe('getUserGroups', () => {
+    it('fetches userinfo and returns groups claim', async () => {
+      const mockFetch = makeDiscoveryFetch({
+        'https://auth.example.com/userinfo': () =>
+          makeResponse({ sub: 'user1', groups: ['admins', 'developers'] }),
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      const groups = await client.getUserGroups('my-access-token');
+
+      expect(groups).toEqual(['admins', 'developers']);
+    });
+
+    it('returns empty array when groups claim is absent', async () => {
+      const mockFetch = makeDiscoveryFetch({
+        'https://auth.example.com/userinfo': () =>
+          makeResponse({ sub: 'user1', email: 'user@example.com' }),
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      const groups = await client.getUserGroups('my-access-token');
+
+      expect(groups).toEqual([]);
+    });
+
+    it('returns empty array when groups claim is not an array', async () => {
+      const mockFetch = makeDiscoveryFetch({
+        'https://auth.example.com/userinfo': () =>
+          makeResponse({ sub: 'user1', groups: 'admins' }),
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      const groups = await client.getUserGroups('my-access-token');
+
+      expect(groups).toEqual([]);
+    });
+
+    it('returns empty array on non-ok userinfo response', async () => {
+      const mockFetch = makeDiscoveryFetch({
+        'https://auth.example.com/userinfo': () => makeResponse({ error: 'unauthorized' }, 401),
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      const groups = await client.getUserGroups('expired-token');
+
+      expect(groups).toEqual([]);
+    });
+
+    it('sends Authorization: Bearer header', async () => {
+      let capturedHeaders: HeadersInit | undefined;
+
+      const mockFetch = asFetch(async (input, init) => {
+        const url = input.toString();
+        if (url === DISCOVERY_URL) return makeResponse(DISCOVERY_BODY);
+        if (url === 'https://auth.example.com/userinfo') {
+          capturedHeaders = init?.headers;
+          return makeResponse({ groups: [] });
+        }
+        return makeResponse({}, 404);
+      });
+
+      const client = new OidcClient(config, mockFetch);
+      await client.getUserGroups('tok-abc');
+
+      expect((capturedHeaders as Record<string, string>)['Authorization']).toBe('Bearer tok-abc');
+    });
+  });
+
+  describe('extractIdTokenClaims', () => {
+    it('decodes JWT payload without verification', () => {
+      const payload = { sub: 'user-123', email: 'user@example.com', nonce: 'abc' };
+      const encoded = btoa(JSON.stringify(payload));
+      const idToken = `header.${encoded}.signature`;
+
+      const claims = OidcClient.extractIdTokenClaims(idToken);
+
+      expect(claims['sub']).toBe('user-123');
+      expect(claims['email']).toBe('user@example.com');
+      expect(claims['nonce']).toBe('abc');
+    });
+
+    it('throws on invalid JWT format (fewer than 3 parts)', () => {
+      expect(() => OidcClient.extractIdTokenClaims('header.payload')).toThrow(
+        'Invalid ID token format',
+      );
+    });
+
+    it('throws on invalid JWT format (more than 3 parts)', () => {
+      expect(() => OidcClient.extractIdTokenClaims('a.b.c.d')).toThrow('Invalid ID token format');
+    });
+  });
+});
+
+describe('OidcClient discovery isolation', () => {
+  it('each instance has its own endpoint cache', async () => {
+    let callCount = 0;
+    const countingFetch = asFetch(async () => {
+      callCount++;
+      return makeResponse(DISCOVERY_BODY);
+    });
+
+    const client1 = new OidcClient(config, countingFetch);
+    const client2 = new OidcClient(config, countingFetch);
+
+    await client1.discoverEndpoints();
+    await client2.discoverEndpoints();
+
+    // Each instance fetches once independently
+    expect(callCount).toBe(2);
+  });
+});

--- a/src/lib/auth/__tests__/require-role.test.ts
+++ b/src/lib/auth/__tests__/require-role.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'bun:test';
+import { requireRole, ForbiddenError } from '@/lib/auth/require-role';
+import type { AuthUser } from '@/lib/auth/types';
+
+function makeUser(role: AuthUser['role']): AuthUser {
+  return {
+    id: 1,
+    email: `${role}@example.com`,
+    name: role,
+    role,
+  };
+}
+
+describe('requireRole', () => {
+  describe('single allowed role', () => {
+    it('does not throw when user has the required role', () => {
+      const guard = requireRole('admin');
+      expect(() => guard(makeUser('admin'))).not.toThrow();
+    });
+
+    it('throws ForbiddenError when user has a different role', () => {
+      const guard = requireRole('admin');
+      expect(() => guard(makeUser('operator'))).toThrow(ForbiddenError);
+    });
+
+    it('throws ForbiddenError when viewer tries to access admin route', () => {
+      const guard = requireRole('admin');
+      expect(() => guard(makeUser('viewer'))).toThrow(ForbiddenError);
+    });
+  });
+
+  describe('multiple allowed roles', () => {
+    it('does not throw when user is admin and both admin and operator are allowed', () => {
+      const guard = requireRole('admin', 'operator');
+      expect(() => guard(makeUser('admin'))).not.toThrow();
+    });
+
+    it('does not throw when user is operator and both admin and operator are allowed', () => {
+      const guard = requireRole('admin', 'operator');
+      expect(() => guard(makeUser('operator'))).not.toThrow();
+    });
+
+    it('throws ForbiddenError when viewer tries to access admin/operator route', () => {
+      const guard = requireRole('admin', 'operator');
+      expect(() => guard(makeUser('viewer'))).toThrow(ForbiddenError);
+    });
+  });
+
+  describe('all roles allowed', () => {
+    it('does not throw for any role when all are allowed', () => {
+      const guard = requireRole('admin', 'operator', 'viewer');
+      expect(() => guard(makeUser('admin'))).not.toThrow();
+      expect(() => guard(makeUser('operator'))).not.toThrow();
+      expect(() => guard(makeUser('viewer'))).not.toThrow();
+    });
+  });
+});
+
+describe('ForbiddenError', () => {
+  it('has status 403', () => {
+    const err = new ForbiddenError();
+    expect(err.status).toBe(403);
+  });
+
+  it('has default message "Insufficient permissions"', () => {
+    const err = new ForbiddenError();
+    expect(err.message).toBe('Insufficient permissions');
+  });
+
+  it('accepts a custom message', () => {
+    const err = new ForbiddenError('Custom forbidden message');
+    expect(err.message).toBe('Custom forbidden message');
+  });
+
+  it('is an instance of Error', () => {
+    expect(new ForbiddenError()).toBeInstanceOf(Error);
+  });
+
+  it('name is ForbiddenError', () => {
+    expect(new ForbiddenError().name).toBe('ForbiddenError');
+  });
+});

--- a/src/lib/auth/__tests__/role-mapper.test.ts
+++ b/src/lib/auth/__tests__/role-mapper.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'bun:test';
-import { mapGroupsToRole } from '../role-mapper';
-import type { RoleMappingConfig } from '../types';
+import { mapGroupsToRole } from '@/lib/auth/role-mapper';
+import type { RoleMappingConfig } from '@/lib/auth/types';
 
 const mockMapping: RoleMappingConfig = {
   admin: 'group-admin',

--- a/src/lib/auth/__tests__/role-mapper.test.ts
+++ b/src/lib/auth/__tests__/role-mapper.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'bun:test';
+import { mapGroupsToRole } from '../role-mapper';
+import type { RoleMappingConfig } from '../types';
+
+const mockMapping: RoleMappingConfig = {
+  admin: 'group-admin',
+  operator: 'group-operator',
+  viewer: 'group-viewer',
+};
+
+describe('mapGroupsToRole', () => {
+  it('returns "admin" when user groups contain the admin group name', () => {
+    const groups = ['group-admin', 'other-group'];
+    expect(mapGroupsToRole(groups, mockMapping)).toBe('admin');
+  });
+
+  it('returns "operator" when user groups contain the operator group name', () => {
+    const groups = ['group-operator', 'other-group'];
+    expect(mapGroupsToRole(groups, mockMapping)).toBe('operator');
+  });
+
+  it('returns "viewer" when user groups contain the viewer group name', () => {
+    const groups = ['group-viewer', 'other-group'];
+    expect(mapGroupsToRole(groups, mockMapping)).toBe('viewer');
+  });
+
+  it('returns "admin" (highest) when user belongs to both admin and viewer groups', () => {
+    const groups = ['group-admin', 'group-viewer'];
+    expect(mapGroupsToRole(groups, mockMapping)).toBe('admin');
+  });
+
+  it('returns "operator" when user belongs to both operator and viewer groups', () => {
+    const groups = ['group-operator', 'group-viewer'];
+    expect(mapGroupsToRole(groups, mockMapping)).toBe('operator');
+  });
+
+  it('returns null when user belongs to no mapped groups', () => {
+    const groups = ['group-other', 'another-group'];
+    expect(mapGroupsToRole(groups, mockMapping)).toBeNull();
+  });
+
+  it('handles empty groups array', () => {
+    const groups: string[] = [];
+    expect(mapGroupsToRole(groups, mockMapping)).toBeNull();
+  });
+
+  it('handles case sensitivity (exact match)', () => {
+    const groups = ['Group-Admin', 'GROUP-VIEWER'];
+    expect(mapGroupsToRole(groups, mockMapping)).toBeNull();
+  });
+});

--- a/src/lib/auth/__tests__/session-manager.test.ts
+++ b/src/lib/auth/__tests__/session-manager.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { createHash } from 'crypto';
+import { SessionManager, resetSessionManagerState } from '../session-manager';
+import type { SessionManagerDeps } from '../session-manager';
+import type { AuthUser, OidcTokens } from '@/lib/auth/types';
+
+function makeUser(overrides?: Partial<AuthUser>): AuthUser {
+  return {
+    id: 1,
+    email: 'test@example.com',
+    name: 'Test User',
+    role: 'viewer',
+    ...overrides,
+  };
+}
+
+function makeTokens(overrides?: Partial<OidcTokens>): OidcTokens {
+  return {
+    accessToken: 'access-abc',
+    refreshToken: 'refresh-xyz',
+    idToken: 'id-token-123',
+    ...overrides,
+  };
+}
+
+function makeDeps(overrides?: Partial<SessionManagerDeps>): SessionManagerDeps {
+  return {
+    sessionRepo: {
+      create: mock(async () => {}),
+      findById: mock(async () => null),
+      findByUserId: mock(async () => []),
+      deleteById: mock(async () => {}),
+      deleteByUserId: mock(async () => {}),
+      deleteExpired: mock(async () => {}),
+    } as unknown as SessionManagerDeps['sessionRepo'],
+    transitClient: {
+      encrypt: mock(async (_key: string, plaintext: string) => `vault:v1:${btoa(plaintext)}`),
+      decrypt: mock(async (_key: string, ciphertext: string) => atob(ciphertext.replace('vault:v1:', ''))),
+    } as unknown as SessionManagerDeps['transitClient'],
+    sessionTtlHours: 8,
+    ...overrides,
+  };
+}
+
+describe('SessionManager', () => {
+  beforeEach(() => {
+    resetSessionManagerState();
+  });
+
+  describe('createSession', () => {
+    it('generates a random token and returns it as raw hex', async () => {
+      const deps = makeDeps();
+      const manager = new SessionManager(deps);
+
+      const token = await manager.createSession(1, makeTokens(), null, null);
+
+      expect(typeof token).toBe('string');
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it('hashes the token before storing as session id', async () => {
+      const deps = makeDeps();
+      const manager = new SessionManager(deps);
+
+      const rawToken = await manager.createSession(1, makeTokens(), '127.0.0.1', 'Mozilla/5.0');
+
+      const expectedHash = createHash('sha256').update(rawToken).digest('hex');
+      expect(deps.sessionRepo.create).toHaveBeenCalledTimes(1);
+      const callArg = (deps.sessionRepo.create as ReturnType<typeof mock>).mock.calls[0][0] as { id: string };
+      expect(callArg.id).toBe(expectedHash);
+    });
+
+    it('stores userId, ipAddress, and userAgent in the session row', async () => {
+      const deps = makeDeps();
+      const manager = new SessionManager(deps);
+
+      await manager.createSession(42, makeTokens(), '10.0.0.1', 'TestAgent/1.0');
+
+      const callArg = (deps.sessionRepo.create as ReturnType<typeof mock>).mock.calls[0][0] as {
+        userId: number;
+        ipAddress: string | null;
+        userAgent: string | null;
+      };
+      expect(callArg.userId).toBe(42);
+      expect(callArg.ipAddress).toBe('10.0.0.1');
+      expect(callArg.userAgent).toBe('TestAgent/1.0');
+    });
+
+    it('encrypts OIDC tokens via Transit before storing', async () => {
+      const deps = makeDeps();
+      const manager = new SessionManager(deps);
+      const tokens = makeTokens();
+
+      await manager.createSession(1, tokens, null, null);
+
+      expect(deps.transitClient.encrypt).toHaveBeenCalledTimes(1);
+      const [keyName, plaintext] = (deps.transitClient.encrypt as ReturnType<typeof mock>).mock.calls[0] as [string, string];
+      expect(keyName).toBe('session-tokens');
+      expect(JSON.parse(plaintext)).toEqual(tokens);
+
+      const createArg = (deps.sessionRepo.create as ReturnType<typeof mock>).mock.calls[0][0] as { encryptedOidc: string };
+      expect(createArg.encryptedOidc).toMatch(/^vault:v1:/);
+    });
+
+    it('sets expiresAt based on sessionTtlHours', async () => {
+      const deps = makeDeps({ sessionTtlHours: 4 });
+      const manager = new SessionManager(deps);
+      const before = new Date();
+
+      await manager.createSession(1, makeTokens(), null, null);
+
+      const after = new Date();
+      const createArg = (deps.sessionRepo.create as ReturnType<typeof mock>).mock.calls[0][0] as { expiresAt: Date };
+      const expiresAt = createArg.expiresAt;
+
+      const minExpected = new Date(before.getTime() + 4 * 60 * 60 * 1000);
+      const maxExpected = new Date(after.getTime() + 4 * 60 * 60 * 1000);
+      expect(expiresAt.getTime()).toBeGreaterThanOrEqual(minExpected.getTime());
+      expect(expiresAt.getTime()).toBeLessThanOrEqual(maxExpected.getTime());
+    });
+
+    it('returns distinct tokens on each call', async () => {
+      const deps = makeDeps();
+      const manager = new SessionManager(deps);
+
+      const token1 = await manager.createSession(1, makeTokens(), null, null);
+      const token2 = await manager.createSession(1, makeTokens(), null, null);
+
+      expect(token1).not.toBe(token2);
+    });
+  });
+
+  describe('validateSession', () => {
+    it('hashes the raw token, looks up the session, and returns the AuthUser', async () => {
+      const user = makeUser({ id: 5, email: 'alice@example.com', role: 'admin' });
+      const deps = makeDeps({
+        sessionRepo: {
+          create: mock(async () => {}),
+          findById: mock(async () => ({ session: {} as never, user })),
+          findByUserId: mock(async () => []),
+          deleteById: mock(async () => {}),
+          deleteByUserId: mock(async () => {}),
+          deleteExpired: mock(async () => {}),
+        } as unknown as SessionManagerDeps['sessionRepo'],
+      });
+      const manager = new SessionManager(deps);
+      const rawToken = 'a'.repeat(64);
+
+      const result = await manager.validateSession(rawToken);
+
+      const expectedHash = createHash('sha256').update(rawToken).digest('hex');
+      expect(deps.sessionRepo.findById).toHaveBeenCalledWith(expectedHash);
+      expect(result).toEqual(user);
+    });
+
+    it('returns null when session is not found', async () => {
+      const deps = makeDeps();
+      const manager = new SessionManager(deps);
+
+      const result = await manager.validateSession('no-such-token');
+
+      expect(result).toBeNull();
+    });
+
+    it('returns null for an expired session (repo returns null)', async () => {
+      const deps = makeDeps({
+        sessionRepo: {
+          create: mock(async () => {}),
+          findById: mock(async () => null),
+          findByUserId: mock(async () => []),
+          deleteById: mock(async () => {}),
+          deleteByUserId: mock(async () => {}),
+          deleteExpired: mock(async () => {}),
+        } as unknown as SessionManagerDeps['sessionRepo'],
+      });
+      const manager = new SessionManager(deps);
+
+      const result = await manager.validateSession('expired-token');
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('revokeSession', () => {
+    it('deletes the session by hashed id', async () => {
+      const deps = makeDeps();
+      const manager = new SessionManager(deps);
+      const hashedId = 'abc123hash';
+
+      await manager.revokeSession(hashedId);
+
+      expect(deps.sessionRepo.deleteById).toHaveBeenCalledWith(hashedId);
+    });
+  });
+
+  describe('revokeAllUserSessions', () => {
+    it('deletes all sessions for a given user id', async () => {
+      const deps = makeDeps();
+      const manager = new SessionManager(deps);
+
+      await manager.revokeAllUserSessions(99);
+
+      expect(deps.sessionRepo.deleteByUserId).toHaveBeenCalledWith(99);
+    });
+  });
+
+  describe('cleanupExpired', () => {
+    it('delegates to sessionRepo.deleteExpired', async () => {
+      const deps = makeDeps();
+      const manager = new SessionManager(deps);
+
+      await manager.cleanupExpired();
+
+      expect(deps.sessionRepo.deleteExpired).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/lib/auth/__tests__/session-manager.test.ts
+++ b/src/lib/auth/__tests__/session-manager.test.ts
@@ -4,6 +4,17 @@ import { SessionManager, resetSessionManagerState } from '../session-manager';
 import type { SessionManagerDeps } from '../session-manager';
 import type { AuthUser, OidcTokens } from '@/lib/auth/types';
 
+// Mock the JWE encryption module so tests don't need real crypto keys
+const mockEncryptValue = mock(async (_plaintext: string, _keyring: unknown) => 'jwe:mock:encrypted');
+const mockDecryptValue = mock(async (ciphertext: string, _keyring: unknown) =>
+  ciphertext.replace('jwe:mock:', ''),
+);
+
+mock.module('@/lib/crypto/encrypted-value', () => ({
+  encryptValue: mockEncryptValue,
+  decryptValue: mockDecryptValue,
+}));
+
 function makeUser(overrides?: Partial<AuthUser>): AuthUser {
   return {
     id: 1,
@@ -23,6 +34,8 @@ function makeTokens(overrides?: Partial<OidcTokens>): OidcTokens {
   };
 }
 
+const mockKeyring = { activeKid: 'v1', keys: new Map() } as unknown as SessionManagerDeps['keyring'];
+
 function makeDeps(overrides?: Partial<SessionManagerDeps>): SessionManagerDeps {
   return {
     sessionRepo: {
@@ -33,10 +46,7 @@ function makeDeps(overrides?: Partial<SessionManagerDeps>): SessionManagerDeps {
       deleteByUserId: mock(async () => {}),
       deleteExpired: mock(async () => {}),
     } as unknown as SessionManagerDeps['sessionRepo'],
-    transitClient: {
-      encrypt: mock(async (_key: string, plaintext: string) => `vault:v1:${btoa(plaintext)}`),
-      decrypt: mock(async (_key: string, ciphertext: string) => atob(ciphertext.replace('vault:v1:', ''))),
-    } as unknown as SessionManagerDeps['transitClient'],
+    keyring: mockKeyring,
     sessionTtlHours: 8,
     ...overrides,
   };
@@ -45,6 +55,8 @@ function makeDeps(overrides?: Partial<SessionManagerDeps>): SessionManagerDeps {
 describe('SessionManager', () => {
   beforeEach(() => {
     resetSessionManagerState();
+    mockEncryptValue.mockClear();
+    mockDecryptValue.mockClear();
   });
 
   describe('createSession', () => {
@@ -86,20 +98,19 @@ describe('SessionManager', () => {
       expect(callArg.userAgent).toBe('TestAgent/1.0');
     });
 
-    it('encrypts OIDC tokens via Transit before storing', async () => {
+    it('encrypts OIDC tokens via JWE before storing', async () => {
       const deps = makeDeps();
       const manager = new SessionManager(deps);
       const tokens = makeTokens();
 
       await manager.createSession(1, tokens, null, null);
 
-      expect(deps.transitClient.encrypt).toHaveBeenCalledTimes(1);
-      const [keyName, plaintext] = (deps.transitClient.encrypt as ReturnType<typeof mock>).mock.calls[0] as [string, string];
-      expect(keyName).toBe('session-tokens');
+      expect(mockEncryptValue).toHaveBeenCalledTimes(1);
+      const [plaintext] = mockEncryptValue.mock.calls[0] as [string, unknown];
       expect(JSON.parse(plaintext)).toEqual(tokens);
 
       const createArg = (deps.sessionRepo.create as ReturnType<typeof mock>).mock.calls[0][0] as { encryptedOidc: string };
-      expect(createArg.encryptedOidc).toMatch(/^vault:v1:/);
+      expect(createArg.encryptedOidc).toBe('jwe:mock:encrypted');
     });
 
     it('sets expiresAt based on sessionTtlHours', async () => {

--- a/src/lib/auth/__tests__/session-manager.test.ts
+++ b/src/lib/auth/__tests__/session-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
 import { createHash } from 'crypto';
 import { SessionManager, resetSessionManagerState } from '../session-manager';
 import type { SessionManagerDeps } from '../session-manager';
@@ -13,6 +13,21 @@ const mockDecryptValue = mock(async (ciphertext: string, _keyring: unknown) =>
 mock.module('@/lib/crypto/encrypted-value', () => ({
   encryptValue: mockEncryptValue,
   decryptValue: mockDecryptValue,
+}));
+
+// Module mocks for buildSessionManager's dynamic imports
+const mockBuiltPool = { query: mock(async () => ({ rows: [] })) };
+const mockGetClient = mock(async () => ({ getPool: () => mockBuiltPool }));
+const mockLoadMasterKeyring = mock(async () => ({ activeKid: 'v1', keys: new Map() }));
+
+mock.module('@/lib/clients/database-client', () => ({
+  databaseConnectionManager: { getClient: mockGetClient },
+}));
+mock.module('@/lib/config/database-config', () => ({
+  loadDatabaseConfig: () => ({}),
+}));
+mock.module('@/lib/crypto/master-key', () => ({
+  loadMasterKeyring: mockLoadMasterKeyring,
 }));
 
 function makeUser(overrides?: Partial<AuthUser>): AuthUser {
@@ -224,5 +239,48 @@ describe('SessionManager', () => {
 
       expect(deps.sessionRepo.deleteExpired).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+describe('buildSessionManager', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    resetSessionManagerState();
+    mockGetClient.mockClear();
+    mockLoadMasterKeyring.mockClear();
+    // loadAuthConfig requires these vars; set them here instead of mocking the module
+    // (module mocks for auth-config leak across test files despite --isolate)
+    process.env.OIDC_ISSUER_URL = 'https://pocketid.example.com';
+    process.env.OIDC_CLIENT_ID = 'homelab-manager';
+    process.env.OIDC_REDIRECT_URI = 'http://localhost/callback';
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    resetSessionManagerState();
+  });
+
+  it('builds a SessionManager with injected dependencies', async () => {
+    const { buildSessionManager } = await import('../session-manager');
+    const manager = await buildSessionManager();
+    expect(manager).toBeInstanceOf(SessionManager);
+  });
+
+  it('caches the manager and returns the same instance on subsequent calls', async () => {
+    const { buildSessionManager } = await import('../session-manager');
+    const first = await buildSessionManager();
+    const second = await buildSessionManager();
+    expect(first).toBe(second);
+    // getClient is called once — second call hits the cache
+    expect(mockGetClient).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates a fresh manager after resetSessionManagerState', async () => {
+    const { buildSessionManager } = await import('../session-manager');
+    const first = await buildSessionManager();
+    resetSessionManagerState();
+    const second = await buildSessionManager();
+    expect(first).not.toBe(second);
   });
 });

--- a/src/lib/auth/__tests__/sse-auth.test.ts
+++ b/src/lib/auth/__tests__/sse-auth.test.ts
@@ -2,6 +2,19 @@ import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
 import { resetSSEAuthState } from '@/lib/auth/sse-auth';
 import type { AuthUser } from '@/lib/auth/types';
 
+const mockValidateSession = mock(async (_token: string) => null as AuthUser | null);
+const mockBuildSessionManager = mock(async () => ({ validateSession: mockValidateSession }));
+
+mock.module('@/lib/auth/session-manager', () => ({
+  buildSessionManager: mockBuildSessionManager,
+  resetSessionManagerState: mock(() => {}),
+  // Include SessionManager class so other test files importing this module still compile
+  // (bun applies mock.module globally across files run together)
+  SessionManager: class MockSessionManager {
+    constructor() {}
+  },
+}));
+
 function makeUser(overrides?: Partial<AuthUser>): AuthUser {
   return {
     id: 1,
@@ -73,6 +86,29 @@ describe('authenticateSSE', () => {
     const result = await authenticateSSE(makeMockRequest('other=abc; foo=bar'));
 
     expect(result).toBeNull();
+  });
+
+  it('calls buildSessionManager and validateSession when a session cookie is present', async () => {
+    process.env.AUTH_ENABLED = 'true';
+    const user: AuthUser = { id: 3, email: 'bob@example.com', name: 'Bob', role: 'viewer' };
+    mockValidateSession.mockImplementation(async () => user);
+
+    const { authenticateSSE } = await import('@/lib/auth/sse-auth');
+    const result = await authenticateSSE(makeMockRequest('session=valid-token-abc'));
+
+    expect(result).toEqual(user);
+    expect(mockValidateSession).toHaveBeenCalledWith('valid-token-abc');
+  });
+
+  it('returns null when validateSession returns null for invalid token', async () => {
+    process.env.AUTH_ENABLED = 'true';
+    mockValidateSession.mockImplementation(async () => null);
+
+    const { authenticateSSE } = await import('@/lib/auth/sse-auth');
+    const result = await authenticateSSE(makeMockRequest('session=bad-token'));
+
+    expect(result).toBeNull();
+    expect(mockValidateSession).toHaveBeenCalledWith('bad-token');
   });
 });
 

--- a/src/lib/auth/__tests__/sse-auth.test.ts
+++ b/src/lib/auth/__tests__/sse-auth.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { resetSSEAuthState } from '@/lib/auth/sse-auth';
+import type { AuthUser } from '@/lib/auth/types';
+
+function makeUser(overrides?: Partial<AuthUser>): AuthUser {
+  return {
+    id: 1,
+    email: 'user@example.com',
+    name: 'Test User',
+    role: 'viewer',
+    ...overrides,
+  };
+}
+
+/**
+ * Create a mock Request-like object. We cannot use `new Request()` with cookie
+ * headers in bun tests because Happy-DOM (test preload) registers globally and
+ * strips the "cookie" header per browser forbidden-header rules.
+ */
+function makeMockRequest(cookieHeader?: string): Request {
+  return {
+    headers: {
+      get: (name: string) => {
+        if (name === 'cookie') return cookieHeader ?? null;
+        return null;
+      },
+    },
+  } as unknown as Request;
+}
+
+// Since authenticateSSE uses dynamic imports for both auth-config and
+// session-manager, we test it by controlling the DISABLE_AUTH env var
+// and by extracting the core logic for session-manager injection.
+
+describe('authenticateSSE', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    resetSSEAuthState();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    resetSSEAuthState();
+  });
+
+  it('returns SYNTHETIC_ADMIN when auth is disabled', async () => {
+    process.env.DISABLE_AUTH = 'true';
+
+    const { authenticateSSE } = await import('@/lib/auth/sse-auth');
+    const result = await authenticateSSE(makeMockRequest());
+
+    expect(result).toMatchObject({
+      id: 0,
+      email: 'admin@local',
+      role: 'admin',
+    });
+  });
+
+  it('returns null when no cookie header and auth enabled', async () => {
+    delete process.env.DISABLE_AUTH;
+
+    const { authenticateSSE } = await import('@/lib/auth/sse-auth');
+    const result = await authenticateSSE(makeMockRequest());
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when cookie header has no session cookie', async () => {
+    delete process.env.DISABLE_AUTH;
+
+    const { authenticateSSE } = await import('@/lib/auth/sse-auth');
+    const result = await authenticateSSE(makeMockRequest('other=abc; foo=bar'));
+
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Core SSE auth logic tested directly (cookie parsing + session validation)
+// ---------------------------------------------------------------------------
+describe('SSE auth logic', () => {
+  it('returns null when no session cookie in header', async () => {
+    const cookieHeader = 'other=abc';
+    const match = cookieHeader.match(/(?:^|;\s*)session=([^;]*)/);
+    const token = match ? decodeURIComponent(match[1]) : null;
+    expect(token).toBeNull();
+  });
+
+  it('extracts session token correctly from cookie header', () => {
+    const cookieHeader = 'foo=bar; session=my-token-abc; other=xyz';
+    const match = cookieHeader.match(/(?:^|;\s*)session=([^;]*)/);
+    const token = match ? decodeURIComponent(match[1]) : null;
+    expect(token).toBe('my-token-abc');
+  });
+
+  it('URL-decodes the session token', () => {
+    const rawToken = 'token with spaces';
+    const cookieHeader = `session=${encodeURIComponent(rawToken)}`;
+    const match = cookieHeader.match(/(?:^|;\s*)session=([^;]*)/);
+    const token = match ? decodeURIComponent(match[1]) : null;
+    expect(token).toBe(rawToken);
+  });
+
+  it('returns AuthUser when validateSession returns a user', async () => {
+    const user = makeUser({ id: 3, email: 'bob@example.com', role: 'operator' });
+    const mockValidateSession = mock((_token: string) => Promise.resolve(user as AuthUser | null));
+    const mockSessionManager = { validateSession: mockValidateSession };
+
+    const cookieHeader = 'session=valid-token-123';
+    const match = cookieHeader.match(/(?:^|;\s*)session=([^;]*)/);
+    const token = match ? decodeURIComponent(match[1]) : null;
+
+    const result = token ? await mockSessionManager.validateSession(token) : null;
+
+    expect(result).toEqual(user);
+    expect(mockValidateSession).toHaveBeenCalledWith('valid-token-123');
+  });
+
+  it('returns null when validateSession returns null (invalid session)', async () => {
+    const mockValidateSession = mock((_token: string) => Promise.resolve(null as AuthUser | null));
+    const mockSessionManager = { validateSession: mockValidateSession };
+
+    const cookieHeader = 'session=bad-token';
+    const match = cookieHeader.match(/(?:^|;\s*)session=([^;]*)/);
+    const token = match ? decodeURIComponent(match[1]) : null;
+
+    const result = token ? await mockSessionManager.validateSession(token) : null;
+
+    expect(result).toBeNull();
+    expect(mockValidateSession).toHaveBeenCalledWith('bad-token');
+  });
+});

--- a/src/lib/auth/__tests__/sse-auth.test.ts
+++ b/src/lib/auth/__tests__/sse-auth.test.ts
@@ -29,7 +29,7 @@ function makeMockRequest(cookieHeader?: string): Request {
 }
 
 // Since authenticateSSE uses dynamic imports for both auth-config and
-// session-manager, we test it by controlling the DISABLE_AUTH env var
+// session-manager, we test it by controlling the AUTH_ENABLED env var
 // and by extracting the core logic for session-manager injection.
 
 describe('authenticateSSE', () => {
@@ -45,7 +45,7 @@ describe('authenticateSSE', () => {
   });
 
   it('returns SYNTHETIC_ADMIN when auth is disabled', async () => {
-    process.env.DISABLE_AUTH = 'true';
+    delete process.env.AUTH_ENABLED;
 
     const { authenticateSSE } = await import('@/lib/auth/sse-auth');
     const result = await authenticateSSE(makeMockRequest());
@@ -58,7 +58,7 @@ describe('authenticateSSE', () => {
   });
 
   it('returns null when no cookie header and auth enabled', async () => {
-    delete process.env.DISABLE_AUTH;
+    process.env.AUTH_ENABLED = 'true';
 
     const { authenticateSSE } = await import('@/lib/auth/sse-auth');
     const result = await authenticateSSE(makeMockRequest());
@@ -67,7 +67,7 @@ describe('authenticateSSE', () => {
   });
 
   it('returns null when cookie header has no session cookie', async () => {
-    delete process.env.DISABLE_AUTH;
+    process.env.AUTH_ENABLED = 'true';
 
     const { authenticateSSE } = await import('@/lib/auth/sse-auth');
     const result = await authenticateSSE(makeMockRequest('other=abc; foo=bar'));

--- a/src/lib/auth/agent-token-migration.ts
+++ b/src/lib/auth/agent-token-migration.ts
@@ -1,35 +1,16 @@
 import type { Pool } from 'pg';
-import type { TransitClient } from '@/lib/clients/transit-client';
 
+/**
+ * Agent tokens are now stored as Ed25519 keypairs in the `agent_keypairs` table
+ * (see migration 022_agent_keypairs.sql). There are no plaintext agent tokens to
+ * migrate.
+ *
+ * This function is kept as a no-op so any callers written before the keypair
+ * migration continue to compile without changes.
+ */
 export async function migrateAgentTokensToTransit(
-  pool: Pool,
-  transit: TransitClient,
+  _pool: Pool,
+  _transit: unknown,
 ): Promise<{ migrated: number; failed: number }> {
-  const result = await pool.query(
-    'SELECT id, agent_token FROM managed_hosts WHERE agent_token IS NOT NULL AND agent_token_encrypted IS NULL'
-  );
-
-  let migrated = 0;
-  let failed = 0;
-
-  for (const row of result.rows) {
-    try {
-      const encrypted = await transit.encrypt('agent-tokens', row.agent_token as string);
-      await pool.query(
-        'UPDATE managed_hosts SET agent_token_encrypted = $1, agent_token = NULL WHERE id = $2',
-        [encrypted, row.id]
-      );
-      migrated++;
-    } catch (error) {
-      console.error(`[agent-token-migration] Failed to migrate token for host ${row.id}:`, error);
-      // Continue with other rows — don't crash
-      failed++;
-    }
-  }
-
-  if (migrated > 0 || failed > 0) {
-    console.info(`[agent-token-migration] Complete: ${migrated} migrated, ${failed} failed`);
-  }
-
-  return { migrated, failed };
+  return { migrated: 0, failed: 0 };
 }

--- a/src/lib/auth/agent-token-migration.ts
+++ b/src/lib/auth/agent-token-migration.ts
@@ -1,10 +1,16 @@
 import type { Pool } from 'pg';
 import type { TransitClient } from '@/lib/clients/transit-client';
 
-export async function migrateAgentTokensToTransit(pool: Pool, transit: TransitClient): Promise<void> {
+export async function migrateAgentTokensToTransit(
+  pool: Pool,
+  transit: TransitClient,
+): Promise<{ migrated: number; failed: number }> {
   const result = await pool.query(
     'SELECT id, agent_token FROM managed_hosts WHERE agent_token IS NOT NULL AND agent_token_encrypted IS NULL'
   );
+
+  let migrated = 0;
+  let failed = 0;
 
   for (const row of result.rows) {
     try {
@@ -13,9 +19,17 @@ export async function migrateAgentTokensToTransit(pool: Pool, transit: TransitCl
         'UPDATE managed_hosts SET agent_token_encrypted = $1, agent_token = NULL WHERE id = $2',
         [encrypted, row.id]
       );
+      migrated++;
     } catch (error) {
       console.error(`[agent-token-migration] Failed to migrate token for host ${row.id}:`, error);
       // Continue with other rows — don't crash
+      failed++;
     }
   }
+
+  if (migrated > 0 || failed > 0) {
+    console.info(`[agent-token-migration] Complete: ${migrated} migrated, ${failed} failed`);
+  }
+
+  return { migrated, failed };
 }

--- a/src/lib/auth/agent-token-migration.ts
+++ b/src/lib/auth/agent-token-migration.ts
@@ -1,0 +1,21 @@
+import type { Pool } from 'pg';
+import type { TransitClient } from '@/lib/clients/transit-client';
+
+export async function migrateAgentTokensToTransit(pool: Pool, transit: TransitClient): Promise<void> {
+  const result = await pool.query(
+    'SELECT id, agent_token FROM managed_hosts WHERE agent_token IS NOT NULL AND agent_token_encrypted IS NULL'
+  );
+
+  for (const row of result.rows) {
+    try {
+      const encrypted = await transit.encrypt('agent-tokens', row.agent_token as string);
+      await pool.query(
+        'UPDATE managed_hosts SET agent_token_encrypted = $1, agent_token = NULL WHERE id = $2',
+        [encrypted, row.id]
+      );
+    } catch (error) {
+      console.error(`[agent-token-migration] Failed to migrate token for host ${row.id}:`, error);
+      // Continue with other rows — don't crash
+    }
+  }
+}

--- a/src/lib/auth/oidc-client.ts
+++ b/src/lib/auth/oidc-client.ts
@@ -24,11 +24,25 @@ export class OidcClient {
     this.fetchFn = fetchFn;
   }
 
+  private async fetchWithTimeout(
+    input: string,
+    init?: RequestInit,
+    timeoutMs = 10_000,
+  ): Promise<Response> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+    try {
+      return await this.fetchFn(input, { ...init, signal: controller.signal });
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
   async discoverEndpoints(): Promise<OidcEndpoints> {
     if (this.endpoints) return this.endpoints;
 
     const url = `${this.config.issuerUrl}/.well-known/openid-configuration`;
-    const response = await this.fetchFn(url);
+    const response = await this.fetchWithTimeout(url);
     if (!response.ok) {
       throw new Error(`OIDC discovery failed (HTTP ${response.status})`);
     }
@@ -61,7 +75,7 @@ export class OidcClient {
   async exchangeCode(code: string): Promise<OidcTokens> {
     const endpoints = await this.discoverEndpoints();
 
-    const response = await this.fetchFn(endpoints.tokenEndpoint, {
+    const response = await this.fetchWithTimeout(endpoints.tokenEndpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
       body: new URLSearchParams({
@@ -92,7 +106,7 @@ export class OidcClient {
   async getUserGroups(accessToken: string): Promise<string[]> {
     const endpoints = await this.discoverEndpoints();
 
-    const response = await this.fetchFn(endpoints.userinfoEndpoint, {
+    const response = await this.fetchWithTimeout(endpoints.userinfoEndpoint, {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
 
@@ -109,6 +123,9 @@ export class OidcClient {
   static extractIdTokenClaims(idToken: string): Record<string, unknown> {
     const parts = idToken.split('.');
     if (parts.length !== 3) throw new Error('Invalid ID token format');
-    return JSON.parse(atob(parts[1]));
+    // JWT payloads are base64url-encoded (RFC 7519): replace - and _ then pad to 4-char boundary
+    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
+    return JSON.parse(atob(padded));
   }
 }

--- a/src/lib/auth/oidc-client.ts
+++ b/src/lib/auth/oidc-client.ts
@@ -34,11 +34,13 @@ export class OidcClient {
     }
 
     const body = await response.json();
-    this.endpoints = {
-      authorizationEndpoint: body.authorization_endpoint,
-      tokenEndpoint: body.token_endpoint,
-      userinfoEndpoint: body.userinfo_endpoint,
-    };
+    const authEndpoint = body.authorization_endpoint;
+    const tokenEndpoint = body.token_endpoint;
+    const userinfoEndpoint = body.userinfo_endpoint;
+    if (typeof authEndpoint !== 'string' || typeof tokenEndpoint !== 'string' || typeof userinfoEndpoint !== 'string') {
+      throw new Error('OIDC discovery response missing required endpoints (authorization_endpoint, token_endpoint, userinfo_endpoint)');
+    }
+    this.endpoints = { authorizationEndpoint: authEndpoint, tokenEndpoint, userinfoEndpoint };
     return this.endpoints;
   }
 
@@ -77,6 +79,9 @@ export class OidcClient {
     }
 
     const body = await response.json();
+    if (typeof body.access_token !== 'string' || typeof body.id_token !== 'string') {
+      throw new Error('OIDC token response missing required fields (access_token, id_token)');
+    }
     return {
       accessToken: body.access_token,
       refreshToken: body.refresh_token ?? null,
@@ -91,7 +96,10 @@ export class OidcClient {
       headers: { Authorization: `Bearer ${accessToken}` },
     });
 
-    if (!response.ok) return [];
+    if (!response.ok) {
+      console.error(`[OidcClient] Userinfo endpoint returned HTTP ${response.status} — proceeding with empty groups`);
+      return [];
+    }
 
     const body = await response.json();
     return Array.isArray(body.groups) ? body.groups : [];

--- a/src/lib/auth/oidc-client.ts
+++ b/src/lib/auth/oidc-client.ts
@@ -1,0 +1,106 @@
+import type { OidcTokens } from '@/lib/auth/types';
+
+export interface OidcConfig {
+  issuerUrl: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}
+
+interface OidcEndpoints {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  userinfoEndpoint: string;
+}
+
+export class OidcClient {
+  private endpoints: OidcEndpoints | null = null;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(
+    private readonly config: OidcConfig,
+    fetchFn: typeof fetch = globalThis.fetch,
+  ) {
+    this.fetchFn = fetchFn;
+  }
+
+  async discoverEndpoints(): Promise<OidcEndpoints> {
+    if (this.endpoints) return this.endpoints;
+
+    const url = `${this.config.issuerUrl}/.well-known/openid-configuration`;
+    const response = await this.fetchFn(url);
+    if (!response.ok) {
+      throw new Error(`OIDC discovery failed (HTTP ${response.status})`);
+    }
+
+    const body = await response.json();
+    this.endpoints = {
+      authorizationEndpoint: body.authorization_endpoint,
+      tokenEndpoint: body.token_endpoint,
+      userinfoEndpoint: body.userinfo_endpoint,
+    };
+    return this.endpoints;
+  }
+
+  async getAuthorizationUrl(state: string, nonce: string, prompt?: string): Promise<string> {
+    const endpoints = await this.discoverEndpoints();
+    const params = new URLSearchParams({
+      client_id: this.config.clientId,
+      redirect_uri: this.config.redirectUri,
+      response_type: 'code',
+      scope: 'openid profile email groups',
+      state,
+      nonce,
+    });
+    if (prompt) params.set('prompt', prompt);
+    return `${endpoints.authorizationEndpoint}?${params.toString()}`;
+  }
+
+  async exchangeCode(code: string): Promise<OidcTokens> {
+    const endpoints = await this.discoverEndpoints();
+
+    const response = await this.fetchFn(endpoints.tokenEndpoint, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'authorization_code',
+        client_id: this.config.clientId,
+        client_secret: this.config.clientSecret,
+        redirect_uri: this.config.redirectUri,
+        code,
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.text();
+      throw new Error(`OIDC token exchange failed (HTTP ${response.status}): ${body}`);
+    }
+
+    const body = await response.json();
+    return {
+      accessToken: body.access_token,
+      refreshToken: body.refresh_token ?? null,
+      idToken: body.id_token,
+    };
+  }
+
+  async getUserGroups(accessToken: string): Promise<string[]> {
+    const endpoints = await this.discoverEndpoints();
+
+    const response = await this.fetchFn(endpoints.userinfoEndpoint, {
+      headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (!response.ok) return [];
+
+    const body = await response.json();
+    return Array.isArray(body.groups) ? body.groups : [];
+  }
+
+  /** Decode JWT payload without verification (server already verified via token endpoint) */
+  static extractIdTokenClaims(idToken: string): Record<string, unknown> {
+    const parts = idToken.split('.');
+    if (parts.length !== 3) throw new Error('Invalid ID token format');
+    return JSON.parse(atob(parts[1]));
+  }
+}

--- a/src/lib/auth/oidc-secrets.ts
+++ b/src/lib/auth/oidc-secrets.ts
@@ -1,24 +1,15 @@
-let cachedClientSecret: string | null = null;
-
+/**
+ * Load the OIDC client secret from the environment.
+ * Reads OIDC_CLIENT_SECRET at startup.
+ */
 export async function getOidcClientSecret(): Promise<string> {
-  if (cachedClientSecret) return cachedClientSecret;
-
-  const { OpenBaoClient } = await import('@/lib/clients/openbao-client');
-  const { loadOpenBaoConfig } = await import('@/lib/config/openbao-config');
-  const { initializeOpenBao } = await import('@/lib/services/openbao-init');
-
-  const client = new OpenBaoClient(loadOpenBaoConfig());
-  await initializeOpenBao(client);
-
-  const secret = await client.getSecret('oidc', 'client-secret');
-  if (!secret) {
-    throw new Error('OIDC client secret not found in OpenBao at secret/stacks/oidc/client-secret');
+  const secret = process.env.OIDC_CLIENT_SECRET;
+  if (!secret || secret.trim().length === 0) {
+    throw new Error('OIDC_CLIENT_SECRET environment variable must be set when auth is enabled');
   }
-
-  cachedClientSecret = secret;
-  return secret;
+  return secret.trim();
 }
 
 export function resetOidcSecretsCache(): void {
-  cachedClientSecret = null;
+  // No-op: env var reading is stateless
 }

--- a/src/lib/auth/oidc-secrets.ts
+++ b/src/lib/auth/oidc-secrets.ts
@@ -1,0 +1,24 @@
+let cachedClientSecret: string | null = null;
+
+export async function getOidcClientSecret(): Promise<string> {
+  if (cachedClientSecret) return cachedClientSecret;
+
+  const { OpenBaoClient } = await import('@/lib/clients/openbao-client');
+  const { loadOpenBaoConfig } = await import('@/lib/config/openbao-config');
+  const { initializeOpenBao } = await import('@/lib/services/openbao-init');
+
+  const client = new OpenBaoClient(loadOpenBaoConfig());
+  await initializeOpenBao(client);
+
+  const secret = await client.getSecret('oidc', 'client-secret');
+  if (!secret) {
+    throw new Error('OIDC client secret not found in OpenBao at secret/stacks/oidc/client-secret');
+  }
+
+  cachedClientSecret = secret;
+  return secret;
+}
+
+export function resetOidcSecretsCache(): void {
+  cachedClientSecret = null;
+}

--- a/src/lib/auth/require-role.ts
+++ b/src/lib/auth/require-role.ts
@@ -10,12 +10,12 @@ export class ForbiddenError extends Error {
 }
 
 /**
- * Returns a guard function that throws ForbiddenError if the user's role
- * is not among the allowed roles.
+ * Returns a guard function that throws ForbiddenError if the user is absent
+ * or their role is not among the allowed roles.
  */
 export function requireRole(...allowed: Role[]) {
-  return (user: AuthUser): void => {
-    if (!allowed.includes(user.role)) {
+  return (user: AuthUser | null | undefined): void => {
+    if (!user || !allowed.includes(user.role)) {
       throw new ForbiddenError();
     }
   };

--- a/src/lib/auth/require-role.ts
+++ b/src/lib/auth/require-role.ts
@@ -1,0 +1,22 @@
+import type { AuthUser, Role } from '@/lib/auth/types';
+
+export class ForbiddenError extends Error {
+  public readonly status = 403;
+
+  constructor(message = 'Insufficient permissions') {
+    super(message);
+    this.name = 'ForbiddenError';
+  }
+}
+
+/**
+ * Returns a guard function that throws ForbiddenError if the user's role
+ * is not among the allowed roles.
+ */
+export function requireRole(...allowed: Role[]) {
+  return (user: AuthUser): void => {
+    if (!allowed.includes(user.role)) {
+      throw new ForbiddenError();
+    }
+  };
+}

--- a/src/lib/auth/role-mapper.ts
+++ b/src/lib/auth/role-mapper.ts
@@ -1,0 +1,12 @@
+import type { Role, RoleMappingConfig } from '@/lib/auth/types';
+
+const ROLE_PRIORITY: Role[] = ['admin', 'operator', 'viewer'];
+
+export function mapGroupsToRole(groups: string[], mapping: RoleMappingConfig): Role | null {
+  for (const role of ROLE_PRIORITY) {
+    if (groups.includes(mapping[role])) {
+      return role;
+    }
+  }
+  return null;
+}

--- a/src/lib/auth/session-manager.ts
+++ b/src/lib/auth/session-manager.ts
@@ -1,0 +1,90 @@
+import { createHash, randomBytes } from 'crypto';
+import type { AuthUser, OidcTokens } from '@/lib/auth/types';
+import type { SessionRepository } from '@/lib/database/repositories/session-repository';
+import type { TransitClient } from '@/lib/clients/transit-client';
+
+export interface SessionManagerDeps {
+  sessionRepo: SessionRepository;
+  transitClient: TransitClient;
+  sessionTtlHours: number;
+}
+
+export class SessionManager {
+  constructor(private readonly deps: SessionManagerDeps) {}
+
+  async createSession(
+    userId: number,
+    tokens: OidcTokens,
+    ipAddress: string | null,
+    userAgent: string | null,
+  ): Promise<string> {
+    const rawToken = randomBytes(32).toString('hex');
+    const hashedId = createHash('sha256').update(rawToken).digest('hex');
+
+    const encryptedOidc = await this.deps.transitClient.encrypt(
+      'session-tokens',
+      JSON.stringify(tokens),
+    );
+
+    const expiresAt = new Date();
+    expiresAt.setHours(expiresAt.getHours() + this.deps.sessionTtlHours);
+
+    await this.deps.sessionRepo.create({
+      id: hashedId,
+      userId,
+      encryptedOidc,
+      ipAddress,
+      userAgent,
+      expiresAt,
+    });
+
+    return rawToken;
+  }
+
+  async validateSession(rawToken: string): Promise<AuthUser | null> {
+    const hashedId = createHash('sha256').update(rawToken).digest('hex');
+    const result = await this.deps.sessionRepo.findById(hashedId);
+    return result?.user ?? null;
+  }
+
+  async revokeSession(hashedId: string): Promise<void> {
+    await this.deps.sessionRepo.deleteById(hashedId);
+  }
+
+  async revokeAllUserSessions(userId: number): Promise<void> {
+    await this.deps.sessionRepo.deleteByUserId(userId);
+  }
+
+  async cleanupExpired(): Promise<void> {
+    await this.deps.sessionRepo.deleteExpired();
+  }
+}
+
+let cachedManager: SessionManager | null = null;
+
+export async function buildSessionManager(): Promise<SessionManager> {
+  if (cachedManager) return cachedManager;
+
+  const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+  const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+  const { TransitClient } = await import('@/lib/clients/transit-client');
+  const { loadOpenBaoConfig } = await import('@/lib/config/openbao-config');
+  const { loadAuthConfig } = await import('@/lib/config/auth-config');
+  const { SessionRepository } = await import('@/lib/database/repositories/session-repository');
+
+  const dbConfig = loadDatabaseConfig();
+  const dbClient = await databaseConnectionManager.getClient(dbConfig);
+  const baoConfig = loadOpenBaoConfig();
+  const authConfig = loadAuthConfig();
+
+  cachedManager = new SessionManager({
+    sessionRepo: new SessionRepository(dbClient.getPool()),
+    transitClient: new TransitClient(baoConfig),
+    sessionTtlHours: authConfig.sessionTtlHours,
+  });
+  return cachedManager;
+}
+
+export function resetSessionManagerState(): void {
+  cachedManager = null;
+}

--- a/src/lib/auth/session-manager.ts
+++ b/src/lib/auth/session-manager.ts
@@ -1,11 +1,11 @@
 import { createHash, randomBytes } from 'crypto';
 import type { AuthUser, OidcTokens } from '@/lib/auth/types';
 import type { SessionRepository } from '@/lib/database/repositories/session-repository';
-import type { TransitClient } from '@/lib/clients/transit-client';
+import type { MasterKeyring } from '@/lib/crypto/master-key';
 
 export interface SessionManagerDeps {
   sessionRepo: SessionRepository;
-  transitClient: TransitClient;
+  keyring: MasterKeyring;
   sessionTtlHours: number;
 }
 
@@ -21,10 +21,8 @@ export class SessionManager {
     const rawToken = randomBytes(32).toString('hex');
     const hashedId = createHash('sha256').update(rawToken).digest('hex');
 
-    const encryptedOidc = await this.deps.transitClient.encrypt(
-      'session-tokens',
-      JSON.stringify(tokens),
-    );
+    const { encryptValue } = await import('@/lib/crypto/encrypted-value');
+    const encryptedOidc = await encryptValue(JSON.stringify(tokens), this.deps.keyring);
 
     const expiresAt = new Date();
     expiresAt.setHours(expiresAt.getHours() + this.deps.sessionTtlHours);
@@ -67,19 +65,18 @@ export async function buildSessionManager(): Promise<SessionManager> {
 
   const { databaseConnectionManager } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
-  const { TransitClient } = await import('@/lib/clients/transit-client');
-  const { loadOpenBaoConfig } = await import('@/lib/config/openbao-config');
+  const { loadMasterKeyring } = await import('@/lib/crypto/master-key');
   const { loadAuthConfig } = await import('@/lib/config/auth-config');
   const { SessionRepository } = await import('@/lib/database/repositories/session-repository');
 
   const dbConfig = loadDatabaseConfig();
   const dbClient = await databaseConnectionManager.getClient(dbConfig);
-  const baoConfig = loadOpenBaoConfig();
+  const keyring = await loadMasterKeyring();
   const authConfig = loadAuthConfig();
 
   cachedManager = new SessionManager({
     sessionRepo: new SessionRepository(dbClient.getPool()),
-    transitClient: new TransitClient(baoConfig),
+    keyring,
     sessionTtlHours: authConfig.sessionTtlHours,
   });
   return cachedManager;

--- a/src/lib/auth/sse-auth.ts
+++ b/src/lib/auth/sse-auth.ts
@@ -6,7 +6,7 @@ let cachedSessionManager: SessionManager | null = null;
 /**
  * Authenticates an SSE request by extracting and validating the session cookie.
  * Returns the AuthUser on success, or null if unauthenticated.
- * When auth is disabled (DISABLE_AUTH=true), returns the synthetic admin user.
+ * When auth is disabled (AUTH_ENABLED not set to "true"), returns the synthetic admin user.
  */
 export async function authenticateSSE(request: Request): Promise<AuthUser | null> {
   const { isAuthDisabled } = await import('@/lib/config/auth-config');

--- a/src/lib/auth/sse-auth.ts
+++ b/src/lib/auth/sse-auth.ts
@@ -1,0 +1,37 @@
+import type { AuthUser } from '@/lib/auth/types';
+import type { SessionManager } from '@/lib/auth/session-manager';
+
+let cachedSessionManager: SessionManager | null = null;
+
+/**
+ * Authenticates an SSE request by extracting and validating the session cookie.
+ * Returns the AuthUser on success, or null if unauthenticated.
+ * When auth is disabled (DISABLE_AUTH=true), returns the synthetic admin user.
+ */
+export async function authenticateSSE(request: Request): Promise<AuthUser | null> {
+  const { isAuthDisabled } = await import('@/lib/config/auth-config');
+  if (isAuthDisabled()) {
+    const { SYNTHETIC_ADMIN } = await import('@/lib/auth/types');
+    return SYNTHETIC_ADMIN;
+  }
+
+  const cookieHeader = request.headers.get('cookie');
+  if (!cookieHeader) return null;
+
+  const match = cookieHeader.match(/(?:^|;\s*)session=([^;]*)/);
+  const token = match ? decodeURIComponent(match[1]) : null;
+  if (!token) return null;
+
+  if (!cachedSessionManager) {
+    const { buildSessionManager } = await import('@/lib/auth/session-manager');
+    cachedSessionManager = await buildSessionManager();
+  }
+  return cachedSessionManager.validateSession(token);
+}
+
+/**
+ * Reset cached session manager (for testing only).
+ */
+export function resetSSEAuthState(): void {
+  cachedSessionManager = null;
+}

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -1,0 +1,46 @@
+export type Role = 'admin' | 'operator' | 'viewer';
+
+export interface AuthUser {
+  id: number;
+  email: string;
+  name: string | null;
+  role: Role;
+}
+
+export interface SessionData {
+  id: string;
+  userId: number;
+  encryptedOidc: string | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+export interface OidcTokens {
+  accessToken: string;
+  refreshToken: string | null;
+  idToken: string;
+}
+
+export interface RoleMappingConfig {
+  admin: string;
+  operator: string;
+  viewer: string;
+}
+
+export interface AuthConfig {
+  issuerUrl: string;
+  clientId: string;
+  redirectUri: string;
+  sessionTtlHours: number;
+  roleMapping: RoleMappingConfig;
+}
+
+/** Synthetic admin user injected when auth is disabled */
+export const SYNTHETIC_ADMIN: AuthUser = {
+  id: 0,
+  email: 'admin@local',
+  name: 'Admin',
+  role: 'admin',
+};

--- a/src/lib/auth/types.ts
+++ b/src/lib/auth/types.ts
@@ -7,27 +7,13 @@ export interface AuthUser {
   role: Role;
 }
 
-export interface SessionData {
-  id: string;
-  userId: number;
-  encryptedOidc: string | null;
-  ipAddress: string | null;
-  userAgent: string | null;
-  expiresAt: Date;
-  createdAt: Date;
-}
-
 export interface OidcTokens {
   accessToken: string;
   refreshToken: string | null;
   idToken: string;
 }
 
-export interface RoleMappingConfig {
-  admin: string;
-  operator: string;
-  viewer: string;
-}
+export type RoleMappingConfig = Record<Role, string>;
 
 export interface AuthConfig {
   issuerUrl: string;

--- a/src/lib/clients/__tests__/transit-client.test.ts
+++ b/src/lib/clients/__tests__/transit-client.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, test, beforeEach, mock } from 'bun:test';
+import { TransitClient } from '@/lib/clients/transit-client';
+
+describe('TransitClient', () => {
+  let client: TransitClient;
+  let mockFetch: ReturnType<typeof mock>;
+
+  beforeEach(() => {
+    mockFetch = mock();
+    client = new TransitClient(
+      { url: 'http://openbao:8200', token: 'dev-root-token' },
+      mockFetch as unknown as typeof fetch,
+    );
+  });
+
+  describe('encrypt', () => {
+    test('calls Transit encrypt endpoint with correct URL, headers, and base64-encoded plaintext', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { ciphertext: 'vault:v1:abc123' } }),
+          { status: 200 },
+        ),
+      );
+
+      await client.encrypt('my-key', 'hello world');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://openbao:8200/v1/transit/encrypt/my-key');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers).toEqual({
+        'X-Vault-Token': 'dev-root-token',
+        'Content-Type': 'application/json',
+      });
+      expect(JSON.parse(opts.body as string)).toEqual({
+        plaintext: btoa('hello world'),
+      });
+    });
+
+    test('returns ciphertext from response', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { ciphertext: 'vault:v1:abc123' } }),
+          { status: 200 },
+        ),
+      );
+
+      const result = await client.encrypt('my-key', 'hello world');
+      expect(result).toBe('vault:v1:abc123');
+    });
+
+    test('throws on non-OK response with error detail', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ errors: ['encryption key not found'] }),
+          { status: 400 },
+        ),
+      );
+
+      await expect(client.encrypt('missing-key', 'data')).rejects.toThrow(
+        'Transit encrypt failed for key "missing-key" (HTTP 400): encryption key not found',
+      );
+    });
+
+    test('throws on non-OK response without JSON body', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response('Internal Server Error', { status: 500 }),
+      );
+
+      await expect(client.encrypt('my-key', 'data')).rejects.toThrow(
+        'Transit encrypt failed for key "my-key" (HTTP 500)',
+      );
+    });
+
+    test('throws on unexpected response shape (missing ciphertext)', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: {} }), { status: 200 }),
+      );
+
+      await expect(client.encrypt('my-key', 'data')).rejects.toThrow(
+        'unexpected response shape',
+      );
+    });
+
+    test('validates key name against safe path pattern', async () => {
+      await expect(client.encrypt('bad/key', 'data')).rejects.toThrow(
+        'Invalid Transit key name',
+      );
+      await expect(client.encrypt('../traversal', 'data')).rejects.toThrow(
+        'Invalid Transit key name',
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('decrypt', () => {
+    test('calls Transit decrypt endpoint with correct ciphertext', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { plaintext: btoa('hello world') } }),
+          { status: 200 },
+        ),
+      );
+
+      await client.decrypt('my-key', 'vault:v1:abc123');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      const [url, opts] = mockFetch.mock.calls[0] as [string, RequestInit];
+      expect(url).toBe('http://openbao:8200/v1/transit/decrypt/my-key');
+      expect(opts.method).toBe('POST');
+      expect(opts.headers).toEqual({
+        'X-Vault-Token': 'dev-root-token',
+        'Content-Type': 'application/json',
+      });
+      expect(JSON.parse(opts.body as string)).toEqual({
+        ciphertext: 'vault:v1:abc123',
+      });
+    });
+
+    test('returns decoded plaintext from response', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ data: { plaintext: btoa('hello world') } }),
+          { status: 200 },
+        ),
+      );
+
+      const result = await client.decrypt('my-key', 'vault:v1:abc123');
+      expect(result).toBe('hello world');
+    });
+
+    test('throws on non-OK response', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({ errors: ['permission denied'] }),
+          { status: 403 },
+        ),
+      );
+
+      await expect(client.decrypt('my-key', 'vault:v1:abc123')).rejects.toThrow(
+        'Transit decrypt failed for key "my-key" (HTTP 403): permission denied',
+      );
+    });
+
+    test('throws on non-OK response without JSON body', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response('Service Unavailable', { status: 503 }),
+      );
+
+      await expect(client.decrypt('my-key', 'vault:v1:abc123')).rejects.toThrow(
+        'Transit decrypt failed for key "my-key" (HTTP 503)',
+      );
+    });
+
+    test('throws on unexpected response shape (missing plaintext)', async () => {
+      mockFetch.mockResolvedValueOnce(
+        new Response(JSON.stringify({ data: {} }), { status: 200 }),
+      );
+
+      await expect(client.decrypt('my-key', 'vault:v1:abc123')).rejects.toThrow(
+        'unexpected response shape',
+      );
+    });
+
+    test('validates key name against safe path pattern', async () => {
+      await expect(client.decrypt('bad/key', 'vault:v1:abc')).rejects.toThrow(
+        'Invalid Transit key name',
+      );
+      await expect(client.decrypt('key with spaces', 'vault:v1:abc')).rejects.toThrow(
+        'Invalid Transit key name',
+      );
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/clients/transit-client.ts
+++ b/src/lib/clients/transit-client.ts
@@ -12,6 +12,7 @@ export interface TransitConfig {
  * Key name convention: matches SAFE_PATH_SEGMENT_PATTERN ([a-zA-Z0-9_-]+)
  */
 export class TransitClient {
+  private static readonly REQUEST_TIMEOUT_MS = 5_000;
   private readonly url: string;
   private readonly token: string;
   private readonly fetchFn: typeof fetch;
@@ -47,6 +48,31 @@ export class TransitClient {
   }
 
   /**
+   * POST JSON payload to a Transit API path with a 5s timeout.
+   * Wraps transport-level errors with path context.
+   */
+  private async post(path: string, payload: Record<string, string>): Promise<Response> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), TransitClient.REQUEST_TIMEOUT_MS);
+    try {
+      return await this.fetchFn(`${this.url}${path}`, {
+        method: 'POST',
+        headers: {
+          'X-Vault-Token': this.token,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+        signal: controller.signal,
+      });
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      throw new Error(`Transit request failed for path "${path}": ${message}`);
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  /**
    * Encrypt plaintext using the named Transit key.
    * The plaintext is base64-encoded before transmission as required by the API.
    * Returns the ciphertext string (e.g. "vault:v1:...").
@@ -55,14 +81,7 @@ export class TransitClient {
     this.validateKeyName(keyName);
     const encoded = Buffer.from(plaintext).toString('base64');
 
-    const response = await this.fetchFn(`${this.url}/v1/transit/encrypt/${keyName}`, {
-      method: 'POST',
-      headers: {
-        'X-Vault-Token': this.token,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ plaintext: encoded }),
-    });
+    const response = await this.post(`/v1/transit/encrypt/${keyName}`, { plaintext: encoded });
 
     if (!response.ok) {
       const detail = await this.extractError(response);
@@ -85,14 +104,7 @@ export class TransitClient {
   async decrypt(keyName: string, ciphertext: string): Promise<string> {
     this.validateKeyName(keyName);
 
-    const response = await this.fetchFn(`${this.url}/v1/transit/decrypt/${keyName}`, {
-      method: 'POST',
-      headers: {
-        'X-Vault-Token': this.token,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ ciphertext }),
-    });
+    const response = await this.post(`/v1/transit/decrypt/${keyName}`, { ciphertext });
 
     if (!response.ok) {
       const detail = await this.extractError(response);

--- a/src/lib/clients/transit-client.ts
+++ b/src/lib/clients/transit-client.ts
@@ -53,7 +53,7 @@ export class TransitClient {
    */
   async encrypt(keyName: string, plaintext: string): Promise<string> {
     this.validateKeyName(keyName);
-    const encoded = btoa(plaintext);
+    const encoded = Buffer.from(plaintext).toString('base64');
 
     const response = await this.fetchFn(`${this.url}/v1/transit/encrypt/${keyName}`, {
       method: 'POST',
@@ -104,6 +104,6 @@ export class TransitClient {
     if (typeof encoded !== 'string') {
       throw new Error(`Transit decrypt failed for key "${keyName}": unexpected response shape`);
     }
-    return atob(encoded);
+    return Buffer.from(encoded, 'base64').toString();
   }
 }

--- a/src/lib/clients/transit-client.ts
+++ b/src/lib/clients/transit-client.ts
@@ -1,4 +1,4 @@
-import { SAFE_PATH_SEGMENT_PATTERN } from '@/lib/constants/openbao';
+const SAFE_PATH_SEGMENT_PATTERN = /^[a-zA-Z0-9_-]+$/;
 
 export interface TransitConfig {
   url: string;

--- a/src/lib/clients/transit-client.ts
+++ b/src/lib/clients/transit-client.ts
@@ -1,0 +1,109 @@
+import { SAFE_PATH_SEGMENT_PATTERN } from '@/lib/constants/openbao';
+
+export interface TransitConfig {
+  url: string;
+  token: string;
+}
+
+/**
+ * Thin wrapper around OpenBao Transit secrets engine HTTP API.
+ * Provides encrypt/decrypt operations using native fetch() — no SDK dependency.
+ *
+ * Key name convention: matches SAFE_PATH_SEGMENT_PATTERN ([a-zA-Z0-9_-]+)
+ */
+export class TransitClient {
+  private readonly url: string;
+  private readonly token: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(config: TransitConfig, fetchFn: typeof fetch = globalThis.fetch) {
+    this.url = config.url;
+    this.token = config.token;
+    this.fetchFn = fetchFn;
+  }
+
+  /**
+   * Validate that a Transit key name contains only safe characters.
+   * Prevents path traversal and injection attacks in OpenBao API URLs.
+   */
+  private validateKeyName(keyName: string): void {
+    if (!SAFE_PATH_SEGMENT_PATTERN.test(keyName)) {
+      throw new Error(`Invalid Transit key name: must match ${SAFE_PATH_SEGMENT_PATTERN}`);
+    }
+  }
+
+  /**
+   * Extract error detail from a non-OK OpenBao response body.
+   * Returns `: <errors>` if errors are present, empty string otherwise.
+   */
+  private async extractError(response: Response): Promise<string> {
+    try {
+      const body = await response.json();
+      if (body.errors) return `: ${(body.errors as string[]).join(', ')}`;
+    } catch {
+      // Not JSON — ignore
+    }
+    return '';
+  }
+
+  /**
+   * Encrypt plaintext using the named Transit key.
+   * The plaintext is base64-encoded before transmission as required by the API.
+   * Returns the ciphertext string (e.g. "vault:v1:...").
+   */
+  async encrypt(keyName: string, plaintext: string): Promise<string> {
+    this.validateKeyName(keyName);
+    const encoded = btoa(plaintext);
+
+    const response = await this.fetchFn(`${this.url}/v1/transit/encrypt/${keyName}`, {
+      method: 'POST',
+      headers: {
+        'X-Vault-Token': this.token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ plaintext: encoded }),
+    });
+
+    if (!response.ok) {
+      const detail = await this.extractError(response);
+      throw new Error(`Transit encrypt failed for key "${keyName}" (HTTP ${response.status})${detail}`);
+    }
+
+    const body = await response.json() as { data?: { ciphertext?: string } };
+    const ciphertext = body?.data?.ciphertext;
+    if (typeof ciphertext !== 'string') {
+      throw new Error(`Transit encrypt failed for key "${keyName}": unexpected response shape`);
+    }
+    return ciphertext;
+  }
+
+  /**
+   * Decrypt ciphertext using the named Transit key.
+   * The response plaintext is base64-decoded before returning.
+   * Returns the original plaintext string.
+   */
+  async decrypt(keyName: string, ciphertext: string): Promise<string> {
+    this.validateKeyName(keyName);
+
+    const response = await this.fetchFn(`${this.url}/v1/transit/decrypt/${keyName}`, {
+      method: 'POST',
+      headers: {
+        'X-Vault-Token': this.token,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ ciphertext }),
+    });
+
+    if (!response.ok) {
+      const detail = await this.extractError(response);
+      throw new Error(`Transit decrypt failed for key "${keyName}" (HTTP ${response.status})${detail}`);
+    }
+
+    const body = await response.json() as { data?: { plaintext?: string } };
+    const encoded = body?.data?.plaintext;
+    if (typeof encoded !== 'string') {
+      throw new Error(`Transit decrypt failed for key "${keyName}": unexpected response shape`);
+    }
+    return atob(encoded);
+  }
+}

--- a/src/lib/config/__tests__/auth-config.test.ts
+++ b/src/lib/config/__tests__/auth-config.test.ts
@@ -89,23 +89,23 @@ describe('isAuthDisabled', () => {
     process.env = { ...originalEnv };
   });
 
-  it('returns true when DISABLE_AUTH is "true"', () => {
-    process.env.DISABLE_AUTH = 'true';
+  it('returns true when AUTH_ENABLED is not set', () => {
+    delete process.env.AUTH_ENABLED;
     expect(isAuthDisabled()).toBe(true);
   });
 
-  it('returns false when DISABLE_AUTH is not set', () => {
-    delete process.env.DISABLE_AUTH;
-    expect(isAuthDisabled()).toBe(false);
+  it('returns true when AUTH_ENABLED is "false"', () => {
+    process.env.AUTH_ENABLED = 'false';
+    expect(isAuthDisabled()).toBe(true);
   });
 
-  it('returns false when DISABLE_AUTH is "false"', () => {
-    process.env.DISABLE_AUTH = 'false';
-    expect(isAuthDisabled()).toBe(false);
+  it('returns true when AUTH_ENABLED is an empty string', () => {
+    process.env.AUTH_ENABLED = '';
+    expect(isAuthDisabled()).toBe(true);
   });
 
-  it('returns false when DISABLE_AUTH is an empty string', () => {
-    process.env.DISABLE_AUTH = '';
+  it('returns false when AUTH_ENABLED is "true"', () => {
+    process.env.AUTH_ENABLED = 'true';
     expect(isAuthDisabled()).toBe(false);
   });
 });

--- a/src/lib/config/__tests__/auth-config.test.ts
+++ b/src/lib/config/__tests__/auth-config.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { loadAuthConfig, isAuthDisabled } from '../auth-config';
+
+describe('loadAuthConfig', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('throws when OIDC_ISSUER_URL is missing', () => {
+    delete process.env.OIDC_ISSUER_URL;
+    process.env.OIDC_CLIENT_ID = 'homelab-manager';
+    process.env.OIDC_REDIRECT_URI = 'http://localhost:3000/api/auth/callback';
+
+    expect(() => loadAuthConfig()).toThrow(
+      'OIDC configuration incomplete. Required: OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_REDIRECT_URI'
+    );
+  });
+
+  it('throws when OIDC_CLIENT_ID is missing', () => {
+    process.env.OIDC_ISSUER_URL = 'https://pocketid.example.com';
+    delete process.env.OIDC_CLIENT_ID;
+    process.env.OIDC_REDIRECT_URI = 'http://localhost:3000/api/auth/callback';
+
+    expect(() => loadAuthConfig()).toThrow(
+      'OIDC configuration incomplete. Required: OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_REDIRECT_URI'
+    );
+  });
+
+  it('throws when OIDC_REDIRECT_URI is missing', () => {
+    process.env.OIDC_ISSUER_URL = 'https://pocketid.example.com';
+    process.env.OIDC_CLIENT_ID = 'homelab-manager';
+    delete process.env.OIDC_REDIRECT_URI;
+
+    expect(() => loadAuthConfig()).toThrow(
+      'OIDC configuration incomplete. Required: OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_REDIRECT_URI'
+    );
+  });
+
+  it('returns correct config with all vars set', () => {
+    process.env.OIDC_ISSUER_URL = 'https://pocketid.example.com';
+    process.env.OIDC_CLIENT_ID = 'homelab-manager';
+    process.env.OIDC_REDIRECT_URI = 'http://localhost:3000/api/auth/callback';
+    process.env.SESSION_TTL_HOURS = '12';
+    process.env.OIDC_ROLE_ADMIN = 'my-admins';
+    process.env.OIDC_ROLE_OPERATOR = 'my-operators';
+    process.env.OIDC_ROLE_VIEWER = 'my-viewers';
+
+    const config = loadAuthConfig();
+    expect(config.issuerUrl).toBe('https://pocketid.example.com');
+    expect(config.clientId).toBe('homelab-manager');
+    expect(config.redirectUri).toBe('http://localhost:3000/api/auth/callback');
+    expect(config.sessionTtlHours).toBe(12);
+    expect(config.roleMapping.admin).toBe('my-admins');
+    expect(config.roleMapping.operator).toBe('my-operators');
+    expect(config.roleMapping.viewer).toBe('my-viewers');
+  });
+
+  it('defaults SESSION_TTL_HOURS to 8 when not set', () => {
+    process.env.OIDC_ISSUER_URL = 'https://pocketid.example.com';
+    process.env.OIDC_CLIENT_ID = 'homelab-manager';
+    process.env.OIDC_REDIRECT_URI = 'http://localhost:3000/api/auth/callback';
+    delete process.env.SESSION_TTL_HOURS;
+
+    const config = loadAuthConfig();
+    expect(config.sessionTtlHours).toBe(8);
+  });
+
+  it('defaults role mapping group names when not set', () => {
+    process.env.OIDC_ISSUER_URL = 'https://pocketid.example.com';
+    process.env.OIDC_CLIENT_ID = 'homelab-manager';
+    process.env.OIDC_REDIRECT_URI = 'http://localhost:3000/api/auth/callback';
+    delete process.env.OIDC_ROLE_ADMIN;
+    delete process.env.OIDC_ROLE_OPERATOR;
+    delete process.env.OIDC_ROLE_VIEWER;
+
+    const config = loadAuthConfig();
+    expect(config.roleMapping.admin).toBe('homelab-admins');
+    expect(config.roleMapping.operator).toBe('homelab-operators');
+    expect(config.roleMapping.viewer).toBe('homelab-viewers');
+  });
+});
+
+describe('isAuthDisabled', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('returns true when DISABLE_AUTH is "true"', () => {
+    process.env.DISABLE_AUTH = 'true';
+    expect(isAuthDisabled()).toBe(true);
+  });
+
+  it('returns false when DISABLE_AUTH is not set', () => {
+    delete process.env.DISABLE_AUTH;
+    expect(isAuthDisabled()).toBe(false);
+  });
+
+  it('returns false when DISABLE_AUTH is "false"', () => {
+    process.env.DISABLE_AUTH = 'false';
+    expect(isAuthDisabled()).toBe(false);
+  });
+
+  it('returns false when DISABLE_AUTH is an empty string', () => {
+    process.env.DISABLE_AUTH = '';
+    expect(isAuthDisabled()).toBe(false);
+  });
+});

--- a/src/lib/config/__tests__/auth-config.test.ts
+++ b/src/lib/config/__tests__/auth-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'bun:test';
-import { loadAuthConfig, isAuthDisabled } from '../auth-config';
+import { loadAuthConfig, isAuthDisabled } from '@/lib/config/auth-config';
 
 describe('loadAuthConfig', () => {
   const originalEnv = { ...process.env };

--- a/src/lib/config/auth-config.ts
+++ b/src/lib/config/auth-config.ts
@@ -15,7 +15,11 @@ export function loadAuthConfig(): AuthConfig {
     );
   }
 
-  const sessionTtlHours = Number.parseInt(process.env.SESSION_TTL_HOURS ?? '8', 10);
+  const sessionTtlRaw = process.env.SESSION_TTL_HOURS ?? '8';
+  if (!/^\d+$/.test(sessionTtlRaw)) {
+    throw new Error('SESSION_TTL_HOURS must be a positive integer');
+  }
+  const sessionTtlHours = Number.parseInt(sessionTtlRaw, 10);
   if (!Number.isFinite(sessionTtlHours) || sessionTtlHours <= 0) {
     throw new Error('SESSION_TTL_HOURS must be a positive integer');
   }

--- a/src/lib/config/auth-config.ts
+++ b/src/lib/config/auth-config.ts
@@ -15,15 +15,25 @@ export function loadAuthConfig(): AuthConfig {
     );
   }
 
+  const sessionTtlHours = Number.parseInt(process.env.SESSION_TTL_HOURS ?? '8', 10);
+  if (!Number.isFinite(sessionTtlHours) || sessionTtlHours <= 0) {
+    throw new Error('SESSION_TTL_HOURS must be a positive integer');
+  }
+
+  const roleMapping = {
+    admin: (process.env.OIDC_ROLE_ADMIN ?? 'homelab-admins').trim(),
+    operator: (process.env.OIDC_ROLE_OPERATOR ?? 'homelab-operators').trim(),
+    viewer: (process.env.OIDC_ROLE_VIEWER ?? 'homelab-viewers').trim(),
+  };
+  if (!roleMapping.admin || !roleMapping.operator || !roleMapping.viewer) {
+    throw new Error('OIDC_ROLE_ADMIN, OIDC_ROLE_OPERATOR, and OIDC_ROLE_VIEWER must be non-empty');
+  }
+
   return {
     issuerUrl,
     clientId,
     redirectUri,
-    sessionTtlHours: Number(process.env.SESSION_TTL_HOURS) || 8,
-    roleMapping: {
-      admin: process.env.OIDC_ROLE_ADMIN ?? 'homelab-admins',
-      operator: process.env.OIDC_ROLE_OPERATOR ?? 'homelab-operators',
-      viewer: process.env.OIDC_ROLE_VIEWER ?? 'homelab-viewers',
-    },
+    sessionTtlHours,
+    roleMapping,
   };
 }

--- a/src/lib/config/auth-config.ts
+++ b/src/lib/config/auth-config.ts
@@ -1,0 +1,29 @@
+import type { AuthConfig } from '@/lib/auth/types';
+
+export function isAuthDisabled(): boolean {
+  return process.env.DISABLE_AUTH === 'true';
+}
+
+export function loadAuthConfig(): AuthConfig {
+  const issuerUrl = process.env.OIDC_ISSUER_URL;
+  const clientId = process.env.OIDC_CLIENT_ID;
+  const redirectUri = process.env.OIDC_REDIRECT_URI;
+
+  if (!issuerUrl || !clientId || !redirectUri) {
+    throw new Error(
+      'OIDC configuration incomplete. Required: OIDC_ISSUER_URL, OIDC_CLIENT_ID, OIDC_REDIRECT_URI'
+    );
+  }
+
+  return {
+    issuerUrl,
+    clientId,
+    redirectUri,
+    sessionTtlHours: Number(process.env.SESSION_TTL_HOURS) || 8,
+    roleMapping: {
+      admin: process.env.OIDC_ROLE_ADMIN ?? 'homelab-admins',
+      operator: process.env.OIDC_ROLE_OPERATOR ?? 'homelab-operators',
+      viewer: process.env.OIDC_ROLE_VIEWER ?? 'homelab-viewers',
+    },
+  };
+}

--- a/src/lib/config/auth-config.ts
+++ b/src/lib/config/auth-config.ts
@@ -1,7 +1,7 @@
 import type { AuthConfig } from '@/lib/auth/types';
 
 export function isAuthDisabled(): boolean {
-  return process.env.DISABLE_AUTH === 'true';
+  return process.env.AUTH_ENABLED !== 'true';
 }
 
 export function loadAuthConfig(): AuthConfig {

--- a/src/lib/config/feature-flags.ts
+++ b/src/lib/config/feature-flags.ts
@@ -1,0 +1,15 @@
+/**
+ * Check if Docker stack management feature is enabled.
+ * Gated behind DOCKER_MANAGEMENT_FEATURE_FLAG=true env var.
+ */
+export function isDockerManagementEnabled(): boolean {
+  return process.env.DOCKER_MANAGEMENT_FEATURE_FLAG === 'true';
+}
+
+/**
+ * Check if authentication is enabled (server-side only).
+ * Auth state reaches the client through the getSession() server function.
+ */
+export function isAuthEnabled(): boolean {
+  return process.env.DISABLE_AUTH !== 'true';
+}

--- a/src/lib/config/feature-flags.ts
+++ b/src/lib/config/feature-flags.ts
@@ -11,5 +11,5 @@ export function isDockerManagementEnabled(): boolean {
  * Auth state reaches the client through the getSession() server function.
  */
 export function isAuthEnabled(): boolean {
-  return process.env.DISABLE_AUTH !== 'true';
+  return process.env.AUTH_ENABLED === 'true';
 }

--- a/src/lib/database/repositories/__tests__/git-token-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/git-token-repository.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { GitTokenRepository } from '../git-token-repository';
+import type { GitTokenRow } from '../git-token-repository';
+
+function createMockPool(rows: Record<string, unknown>[] = []) {
+  const queryResults: Record<string, unknown>[][] = [];
+  return {
+    pool: {
+      query: async (_sql: string, _params?: unknown[]) => {
+        const result = queryResults.length > 0 ? queryResults.shift()! : rows;
+        return { rows: result };
+      },
+    } as any,
+    pushResult(r: Record<string, unknown>[]) {
+      queryResults.push(r);
+    },
+  };
+}
+
+const now = new Date('2024-01-01T00:00:00Z');
+
+const baseTokenDbRow = {
+  id: '1',
+  user_id: '10',
+  label: 'my-token',
+  last_used_at: null as Date | null,
+  created_at: now,
+};
+
+const expectedTokenRow: GitTokenRow = {
+  id: 1,
+  userId: 10,
+  label: 'my-token',
+  lastUsedAt: null,
+  createdAt: now,
+};
+
+describe('GitTokenRepository', () => {
+  let repo: GitTokenRepository;
+  let mock: ReturnType<typeof createMockPool>;
+
+  beforeEach(() => {
+    mock = createMockPool();
+    repo = new GitTokenRepository(mock.pool);
+  });
+
+  describe('create', () => {
+    it('inserts a git token and returns the new row', async () => {
+      mock.pushResult([baseTokenDbRow]);
+      const result = await repo.create({
+        userId: 10,
+        encryptedToken: 'enc:abc123',
+        label: 'my-token',
+      });
+      expect(result.id).toBe(1);
+      expect(result.userId).toBe(10);
+      expect(result.label).toBe('my-token');
+      expect(result.lastUsedAt).toBeNull();
+      expect(result.createdAt).toEqual(now);
+    });
+
+    it('coerces string id and user_id to numbers', async () => {
+      mock.pushResult([{ ...baseTokenDbRow, id: '42', user_id: '99' }]);
+      const result = await repo.create({
+        userId: 99,
+        encryptedToken: 'enc:xyz',
+        label: 'coerce-test',
+      });
+      expect(result.id).toBe(42);
+      expect(result.userId).toBe(99);
+    });
+  });
+
+  describe('findByUserId', () => {
+    it('returns all tokens for a user', async () => {
+      const rows = [
+        { ...baseTokenDbRow, id: '1', label: 'token-a' },
+        { ...baseTokenDbRow, id: '2', label: 'token-b' },
+      ];
+      mock.pushResult(rows);
+      const result = await repo.findByUserId(10);
+      expect(result).toHaveLength(2);
+      expect(result[0].label).toBe('token-a');
+      expect(result[1].label).toBe('token-b');
+    });
+
+    it('returns empty array when user has no tokens', async () => {
+      mock.pushResult([]);
+      const result = await repo.findByUserId(999);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findAll', () => {
+    it('returns all tokens joined with user info', async () => {
+      const rows = [
+        {
+          ...baseTokenDbRow,
+          id: '1',
+          user_id: '10',
+          user_name: 'Alice',
+          user_email: 'alice@example.com',
+        },
+        {
+          ...baseTokenDbRow,
+          id: '2',
+          user_id: '20',
+          label: 'bob-token',
+          user_name: null,
+          user_email: 'bob@example.com',
+        },
+      ];
+      mock.pushResult(rows);
+      const result = await repo.findAll();
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(1);
+      expect(result[0].userName).toBe('Alice');
+      expect(result[0].userEmail).toBe('alice@example.com');
+      expect(result[1].id).toBe(2);
+      expect(result[1].userName).toBeNull();
+      expect(result[1].userEmail).toBe('bob@example.com');
+    });
+
+    it('returns empty array when no tokens exist', async () => {
+      mock.pushResult([]);
+      const result = await repo.findAll();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('findAllEncrypted', () => {
+    it('returns id, userId, and encryptedToken for all tokens', async () => {
+      mock.pushResult([
+        { id: '1', user_id: '10', encrypted_token: 'enc:token1' },
+        { id: '2', user_id: '20', encrypted_token: 'enc:token2' },
+      ]);
+      const result = await repo.findAllEncrypted();
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ id: 1, userId: 10, encryptedToken: 'enc:token1' });
+      expect(result[1]).toEqual({ id: 2, userId: 20, encryptedToken: 'enc:token2' });
+    });
+
+    it('returns empty array when no tokens exist', async () => {
+      mock.pushResult([]);
+      const result = await repo.findAllEncrypted();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('removes a specific token by id', async () => {
+      await repo.deleteById(5);
+      // No error means success (void return)
+    });
+  });
+
+  describe('deleteByUserId', () => {
+    it('removes all tokens for a user', async () => {
+      await repo.deleteByUserId(10);
+      // No error means success (void return)
+    });
+  });
+
+  describe('updateLastUsed', () => {
+    it('updates last_used_at for the given token id', async () => {
+      await repo.updateLastUsed(3);
+      // No error means success (void return)
+    });
+  });
+
+  describe('row mapping', () => {
+    it('preserves non-null last_used_at', async () => {
+      const usedAt = new Date('2024-06-15T12:00:00Z');
+      mock.pushResult([{ ...baseTokenDbRow, last_used_at: usedAt }]);
+      const result = await repo.findByUserId(10);
+      expect(result[0].lastUsedAt).toEqual(usedAt);
+    });
+
+    it('create returns row with null last_used_at by default', async () => {
+      mock.pushResult([baseTokenDbRow]);
+      const result = await repo.create({ userId: 10, encryptedToken: 'enc:x', label: 'lbl' });
+      expect(result).toEqual(expectedTokenRow);
+    });
+  });
+});

--- a/src/lib/database/repositories/__tests__/session-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/session-repository.test.ts
@@ -199,4 +199,58 @@ describe('SessionRepository', () => {
       await expect(repo.deleteExpired()).resolves.toBeUndefined();
     });
   });
+
+  describe('findAllWithUser', () => {
+    it('returns sessions joined with user info', async () => {
+      const joinRows = [
+        {
+          id: 'session-1',
+          user_id: 1,
+          encrypted_oidc: 'enc-data',
+          ip_address: '127.0.0.1',
+          user_agent: 'Mozilla/5.0',
+          expires_at: new Date('2099-01-01'),
+          created_at: new Date('2024-01-01'),
+          user_name: 'Alice',
+          user_email: 'alice@example.com',
+        },
+      ];
+      mock.pushResult(joinRows as unknown as Record<string, unknown>[]);
+      const result = await repo.findAllWithUser();
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('session-1');
+      expect(result[0].userId).toBe(1);
+      expect(result[0].encryptedOidc).toBe('enc-data');
+      expect(result[0].userName).toBe('Alice');
+      expect(result[0].userEmail).toBe('alice@example.com');
+    });
+
+    it('returns empty array when no active sessions exist', async () => {
+      mock.pushResult([]);
+      const result = await repo.findAllWithUser();
+      expect(result).toEqual([]);
+    });
+
+    it('handles null user_name', async () => {
+      const joinRows = [
+        {
+          id: 'session-2',
+          user_id: 2,
+          encrypted_oidc: null,
+          ip_address: null,
+          user_agent: null,
+          expires_at: new Date('2099-01-01'),
+          created_at: new Date('2024-01-01'),
+          user_name: null,
+          user_email: 'bob@example.com',
+        },
+      ];
+      mock.pushResult(joinRows as unknown as Record<string, unknown>[]);
+      const result = await repo.findAllWithUser();
+
+      expect(result[0].userName).toBeNull();
+      expect(result[0].userEmail).toBe('bob@example.com');
+    });
+  });
 });

--- a/src/lib/database/repositories/__tests__/session-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/session-repository.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { SessionRepository } from '../session-repository';
+import type { SessionRow, CreateSessionInput } from '../session-repository';
+import type { AuthUser } from '@/lib/auth/types';
+
+function createMockPool(rows: Record<string, unknown>[] = []) {
+  const queryResults: Record<string, unknown>[][] = [];
+  return {
+    pool: {
+      query: async (_sql: string, _params?: unknown[]) => {
+        const result = queryResults.length > 0 ? queryResults.shift()! : rows;
+        return { rows: result };
+      },
+    } as any,
+    /** Push a result set that will be returned by the next query call */
+    pushResult(r: Record<string, unknown>[]) {
+      queryResults.push(r);
+    },
+  };
+}
+
+const baseSessionRow: SessionRow = {
+  id: 'hashed-session-id',
+  userId: 1,
+  encryptedOidc: 'encrypted-token-data',
+  ipAddress: '127.0.0.1',
+  userAgent: 'Mozilla/5.0',
+  expiresAt: new Date('2099-01-01T00:00:00Z'),
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+};
+
+const baseAuthUser: AuthUser = {
+  id: 1,
+  email: 'alice@example.com',
+  name: 'Alice',
+  role: 'viewer',
+};
+
+/** Raw DB row shape returned by the JOIN query */
+const baseJoinRow = {
+  id: baseSessionRow.id,
+  user_id: baseSessionRow.userId,
+  encrypted_oidc: baseSessionRow.encryptedOidc,
+  ip_address: baseSessionRow.ipAddress,
+  user_agent: baseSessionRow.userAgent,
+  expires_at: baseSessionRow.expiresAt,
+  created_at: baseSessionRow.createdAt,
+  u_id: baseAuthUser.id,
+  email: baseAuthUser.email,
+  name: baseAuthUser.name,
+  role: baseAuthUser.role,
+};
+
+describe('SessionRepository', () => {
+  let repo: SessionRepository;
+  let mock: ReturnType<typeof createMockPool>;
+
+  beforeEach(() => {
+    mock = createMockPool();
+    repo = new SessionRepository(mock.pool);
+  });
+
+  describe('create', () => {
+    it('inserts session with hashed ID, user_id, encrypted_oidc, ip, user_agent, expires_at', async () => {
+      const capturedParams: unknown[][] = [];
+      const capturingPool = {
+        query: async (_sql: string, params?: unknown[]) => {
+          if (params) capturedParams.push(params);
+          return { rows: [] };
+        },
+      } as any;
+      const capturingRepo = new SessionRepository(capturingPool);
+
+      const input: CreateSessionInput = {
+        id: 'hashed-session-id',
+        userId: 1,
+        encryptedOidc: 'encrypted-token-data',
+        ipAddress: '127.0.0.1',
+        userAgent: 'Mozilla/5.0',
+        expiresAt: new Date('2099-01-01T00:00:00Z'),
+      };
+
+      await capturingRepo.create(input);
+
+      expect(capturedParams).toHaveLength(1);
+      const [id, userId, encryptedOidc, ipAddress, userAgent, expiresAt] = capturedParams[0] as unknown[];
+      expect(id).toBe('hashed-session-id');
+      expect(userId).toBe(1);
+      expect(encryptedOidc).toBe('encrypted-token-data');
+      expect(ipAddress).toBe('127.0.0.1');
+      expect(userAgent).toBe('Mozilla/5.0');
+      expect(expiresAt).toEqual(new Date('2099-01-01T00:00:00Z'));
+    });
+
+    it('accepts null encryptedOidc, ipAddress, and userAgent', async () => {
+      mock.pushResult([]);
+      const input: CreateSessionInput = {
+        id: 'hashed-session-id',
+        userId: 1,
+        encryptedOidc: null,
+        ipAddress: null,
+        userAgent: null,
+        expiresAt: new Date('2099-01-01T00:00:00Z'),
+      };
+      await expect(repo.create(input)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('findById', () => {
+    it('returns session joined with user when session exists', async () => {
+      mock.pushResult([baseJoinRow as unknown as Record<string, unknown>]);
+      const result = await repo.findById('hashed-session-id');
+
+      expect(result).not.toBeNull();
+      expect(result!.session.id).toBe('hashed-session-id');
+      expect(result!.session.userId).toBe(1);
+      expect(result!.session.encryptedOidc).toBe('encrypted-token-data');
+      expect(result!.session.ipAddress).toBe('127.0.0.1');
+      expect(result!.session.userAgent).toBe('Mozilla/5.0');
+      expect(result!.session.expiresAt).toEqual(new Date('2099-01-01T00:00:00Z'));
+      expect(result!.session.createdAt).toEqual(new Date('2024-01-01T00:00:00Z'));
+      expect(result!.user.id).toBe(1);
+      expect(result!.user.email).toBe('alice@example.com');
+      expect(result!.user.name).toBe('Alice');
+      expect(result!.user.role).toBe('viewer');
+    });
+
+    it('returns null for non-existent session', async () => {
+      mock.pushResult([]);
+      const result = await repo.findById('nonexistent-id');
+      expect(result).toBeNull();
+    });
+
+    it('returns null for expired session (query filters by expires_at > now())', async () => {
+      // The DB query already excludes expired sessions via WHERE expires_at > now()
+      // Simulate this by returning no rows (as the DB would do for expired sessions)
+      mock.pushResult([]);
+      const result = await repo.findById('expired-session-id');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findByUserId', () => {
+    it('returns all sessions for a user', async () => {
+      const sessionRows = [
+        {
+          id: 'session-1',
+          user_id: 1,
+          encrypted_oidc: 'enc-1',
+          ip_address: '127.0.0.1',
+          user_agent: 'Agent/1',
+          expires_at: new Date('2099-01-01T00:00:00Z'),
+          created_at: new Date('2024-01-01T00:00:00Z'),
+        },
+        {
+          id: 'session-2',
+          user_id: 1,
+          encrypted_oidc: null,
+          ip_address: '192.168.1.1',
+          user_agent: 'Agent/2',
+          expires_at: new Date('2099-06-01T00:00:00Z'),
+          created_at: new Date('2024-06-01T00:00:00Z'),
+        },
+      ];
+      mock.pushResult(sessionRows as unknown as Record<string, unknown>[]);
+      const result = await repo.findByUserId(1);
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('session-1');
+      expect(result[0].userId).toBe(1);
+      expect(result[1].id).toBe('session-2');
+      expect(result[1].encryptedOidc).toBeNull();
+    });
+
+    it('returns empty array when no sessions exist for user', async () => {
+      mock.pushResult([]);
+      const result = await repo.findByUserId(999);
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('deleteById', () => {
+    it('removes a single session by id', async () => {
+      mock.pushResult([]);
+      await expect(repo.deleteById('hashed-session-id')).resolves.toBeUndefined();
+    });
+  });
+
+  describe('deleteByUserId', () => {
+    it('removes all sessions for a user', async () => {
+      mock.pushResult([]);
+      await expect(repo.deleteByUserId(1)).resolves.toBeUndefined();
+    });
+  });
+
+  describe('deleteExpired', () => {
+    it('removes sessions past expires_at', async () => {
+      mock.pushResult([]);
+      await expect(repo.deleteExpired()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/lib/database/repositories/__tests__/user-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/user-repository.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { UserRepository } from '../user-repository';
+import type { UserRow } from '../user-repository';
+
+function createMockPool(rows: Record<string, unknown>[] = []) {
+  const queryResults: Record<string, unknown>[][] = [];
+  return {
+    pool: {
+      query: async (_sql: string, _params?: unknown[]) => {
+        const result = queryResults.length > 0 ? queryResults.shift()! : rows;
+        return { rows: result };
+      },
+    } as any,
+    /** Push a result set that will be returned by the next query call */
+    pushResult(r: Record<string, unknown>[]) {
+      queryResults.push(r);
+    },
+  };
+}
+
+const baseUserRow: UserRow = {
+  id: 1,
+  oidc_subject: 'sub|abc123',
+  email: 'alice@example.com',
+  name: 'Alice',
+  role: 'viewer',
+  oidc_groups: ['viewers'],
+  last_login: new Date('2024-01-01T00:00:00Z'),
+  created_at: new Date('2024-01-01T00:00:00Z'),
+  updated_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+describe('UserRepository', () => {
+  let repo: UserRepository;
+  let mock: ReturnType<typeof createMockPool>;
+
+  beforeEach(() => {
+    mock = createMockPool();
+    repo = new UserRepository(mock.pool);
+  });
+
+  describe('upsertFromOidc', () => {
+    it('creates new user when oidc_subject does not exist', async () => {
+      mock.pushResult([baseUserRow as unknown as Record<string, unknown>]);
+      const result = await repo.upsertFromOidc({
+        oidcSubject: 'sub|abc123',
+        email: 'alice@example.com',
+        name: 'Alice',
+        role: 'viewer',
+        groups: ['viewers'],
+      });
+      expect(result.id).toBe(1);
+      expect(result.oidc_subject).toBe('sub|abc123');
+      expect(result.email).toBe('alice@example.com');
+      expect(result.name).toBe('Alice');
+      expect(result.role).toBe('viewer');
+      expect(result.oidc_groups).toEqual(['viewers']);
+    });
+
+    it('updates existing user email, name, role, groups, and last_login', async () => {
+      const updatedRow: UserRow = {
+        ...baseUserRow,
+        email: 'alice-new@example.com',
+        name: 'Alice Updated',
+        role: 'admin',
+        oidc_groups: ['admins', 'operators'],
+        last_login: new Date('2024-06-01T00:00:00Z'),
+        updated_at: new Date('2024-06-01T00:00:00Z'),
+      };
+      mock.pushResult([updatedRow as unknown as Record<string, unknown>]);
+      const result = await repo.upsertFromOidc({
+        oidcSubject: 'sub|abc123',
+        email: 'alice-new@example.com',
+        name: 'Alice Updated',
+        role: 'admin',
+        groups: ['admins', 'operators'],
+      });
+      expect(result.email).toBe('alice-new@example.com');
+      expect(result.name).toBe('Alice Updated');
+      expect(result.role).toBe('admin');
+      expect(result.oidc_groups).toEqual(['admins', 'operators']);
+      expect(result.last_login).toEqual(new Date('2024-06-01T00:00:00Z'));
+    });
+  });
+
+  describe('findById', () => {
+    it('returns user when exists', async () => {
+      mock.pushResult([baseUserRow as unknown as Record<string, unknown>]);
+      const result = await repo.findById(1);
+      expect(result).not.toBeNull();
+      expect(result!.id).toBe(1);
+      expect(result!.email).toBe('alice@example.com');
+    });
+
+    it('returns null when not found', async () => {
+      mock.pushResult([]);
+      const result = await repo.findById(999);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findBySubject', () => {
+    it('returns user by OIDC subject claim', async () => {
+      mock.pushResult([baseUserRow as unknown as Record<string, unknown>]);
+      const result = await repo.findBySubject('sub|abc123');
+      expect(result).not.toBeNull();
+      expect(result!.oidc_subject).toBe('sub|abc123');
+      expect(result!.email).toBe('alice@example.com');
+    });
+
+    it('returns null when subject not found', async () => {
+      mock.pushResult([]);
+      const result = await repo.findBySubject('sub|notexist');
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('findAll', () => {
+    it('returns all users ordered by name', async () => {
+      const rows: UserRow[] = [
+        { ...baseUserRow, id: 2, name: 'Alice', email: 'alice@example.com' },
+        { ...baseUserRow, id: 3, name: 'Bob', email: 'bob@example.com' },
+      ];
+      mock.pushResult(rows as unknown as Record<string, unknown>[]);
+      const result = await repo.findAll();
+      expect(result).toHaveLength(2);
+      expect(result[0].name).toBe('Alice');
+      expect(result[1].name).toBe('Bob');
+    });
+
+    it('returns empty array when no users exist', async () => {
+      mock.pushResult([]);
+      const result = await repo.findAll();
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/lib/database/repositories/__tests__/user-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/user-repository.test.ts
@@ -18,7 +18,8 @@ function createMockPool(rows: Record<string, unknown>[] = []) {
   };
 }
 
-const baseUserRow: UserRow = {
+/** DB-shaped row (snake_case) as returned by PostgreSQL */
+const baseDbRow: Record<string, unknown> = {
   id: 1,
   oidc_subject: 'sub|abc123',
   email: 'alice@example.com',
@@ -28,6 +29,19 @@ const baseUserRow: UserRow = {
   last_login: new Date('2024-01-01T00:00:00Z'),
   created_at: new Date('2024-01-01T00:00:00Z'),
   updated_at: new Date('2024-01-01T00:00:00Z'),
+};
+
+/** Expected camelCase UserRow after conversion */
+const baseUserRow: UserRow = {
+  id: 1,
+  oidcSubject: 'sub|abc123',
+  email: 'alice@example.com',
+  name: 'Alice',
+  role: 'viewer',
+  oidcGroups: ['viewers'],
+  lastLogin: new Date('2024-01-01T00:00:00Z'),
+  createdAt: new Date('2024-01-01T00:00:00Z'),
+  updatedAt: new Date('2024-01-01T00:00:00Z'),
 };
 
 describe('UserRepository', () => {
@@ -41,7 +55,7 @@ describe('UserRepository', () => {
 
   describe('upsertFromOidc', () => {
     it('creates new user when oidc_subject does not exist', async () => {
-      mock.pushResult([baseUserRow as unknown as Record<string, unknown>]);
+      mock.pushResult([baseDbRow]);
       const result = await repo.upsertFromOidc({
         oidcSubject: 'sub|abc123',
         email: 'alice@example.com',
@@ -50,16 +64,16 @@ describe('UserRepository', () => {
         groups: ['viewers'],
       });
       expect(result.id).toBe(1);
-      expect(result.oidc_subject).toBe('sub|abc123');
+      expect(result.oidcSubject).toBe('sub|abc123');
       expect(result.email).toBe('alice@example.com');
       expect(result.name).toBe('Alice');
       expect(result.role).toBe('viewer');
-      expect(result.oidc_groups).toEqual(['viewers']);
+      expect(result.oidcGroups).toEqual(['viewers']);
     });
 
-    it('updates existing user email, name, role, groups, and last_login', async () => {
-      const updatedRow: UserRow = {
-        ...baseUserRow,
+    it('updates existing user email, name, role, groups, and lastLogin', async () => {
+      const updatedDbRow: Record<string, unknown> = {
+        ...baseDbRow,
         email: 'alice-new@example.com',
         name: 'Alice Updated',
         role: 'admin',
@@ -67,7 +81,7 @@ describe('UserRepository', () => {
         last_login: new Date('2024-06-01T00:00:00Z'),
         updated_at: new Date('2024-06-01T00:00:00Z'),
       };
-      mock.pushResult([updatedRow as unknown as Record<string, unknown>]);
+      mock.pushResult([updatedDbRow]);
       const result = await repo.upsertFromOidc({
         oidcSubject: 'sub|abc123',
         email: 'alice-new@example.com',
@@ -78,14 +92,14 @@ describe('UserRepository', () => {
       expect(result.email).toBe('alice-new@example.com');
       expect(result.name).toBe('Alice Updated');
       expect(result.role).toBe('admin');
-      expect(result.oidc_groups).toEqual(['admins', 'operators']);
-      expect(result.last_login).toEqual(new Date('2024-06-01T00:00:00Z'));
+      expect(result.oidcGroups).toEqual(['admins', 'operators']);
+      expect(result.lastLogin).toEqual(new Date('2024-06-01T00:00:00Z'));
     });
   });
 
   describe('findById', () => {
     it('returns user when exists', async () => {
-      mock.pushResult([baseUserRow as unknown as Record<string, unknown>]);
+      mock.pushResult([baseDbRow]);
       const result = await repo.findById(1);
       expect(result).not.toBeNull();
       expect(result!.id).toBe(1);
@@ -101,10 +115,10 @@ describe('UserRepository', () => {
 
   describe('findBySubject', () => {
     it('returns user by OIDC subject claim', async () => {
-      mock.pushResult([baseUserRow as unknown as Record<string, unknown>]);
+      mock.pushResult([baseDbRow]);
       const result = await repo.findBySubject('sub|abc123');
       expect(result).not.toBeNull();
-      expect(result!.oidc_subject).toBe('sub|abc123');
+      expect(result!.oidcSubject).toBe('sub|abc123');
       expect(result!.email).toBe('alice@example.com');
     });
 
@@ -117,11 +131,11 @@ describe('UserRepository', () => {
 
   describe('findAll', () => {
     it('returns all users ordered by name', async () => {
-      const rows: UserRow[] = [
-        { ...baseUserRow, id: 2, name: 'Alice', email: 'alice@example.com' },
-        { ...baseUserRow, id: 3, name: 'Bob', email: 'bob@example.com' },
+      const rows: Record<string, unknown>[] = [
+        { ...baseDbRow, id: 2, name: 'Alice', email: 'alice@example.com' },
+        { ...baseDbRow, id: 3, name: 'Bob', email: 'bob@example.com' },
       ];
-      mock.pushResult(rows as unknown as Record<string, unknown>[]);
+      mock.pushResult(rows);
       const result = await repo.findAll();
       expect(result).toHaveLength(2);
       expect(result[0].name).toBe('Alice');
@@ -132,6 +146,14 @@ describe('UserRepository', () => {
       mock.pushResult([]);
       const result = await repo.findAll();
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('rowToUser conversion', () => {
+    it('maps snake_case DB columns to camelCase UserRow fields', async () => {
+      mock.pushResult([baseDbRow]);
+      const result = await repo.findById(1);
+      expect(result).toEqual(baseUserRow);
     });
   });
 });

--- a/src/lib/database/repositories/__tests__/user-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/user-repository.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
-import { UserRepository } from '../user-repository';
-import type { UserRow } from '../user-repository';
+import { UserRepository } from '@/lib/database/repositories/user-repository';
+import type { UserRow } from '@/lib/database/repositories/user-repository';
 
 function createMockPool(rows: Record<string, unknown>[] = []) {
   const queryResults: Record<string, unknown>[][] = [];

--- a/src/lib/database/repositories/git-token-repository.ts
+++ b/src/lib/database/repositories/git-token-repository.ts
@@ -1,0 +1,116 @@
+import type { Pool } from 'pg';
+
+export interface GitTokenRow {
+  id: number;
+  userId: number;
+  label: string;
+  lastUsedAt: Date | null;
+  createdAt: Date;
+}
+
+export interface GitTokenWithUser extends GitTokenRow {
+  userName: string | null;
+  userEmail: string;
+}
+
+export interface GitTokenWithEncrypted {
+  id: number;
+  userId: number;
+  encryptedToken: string;
+}
+
+export interface CreateGitTokenInput {
+  userId: number;
+  encryptedToken: string;
+  label: string;
+}
+
+function rowToGitToken(row: {
+  id: unknown;
+  user_id: unknown;
+  label: unknown;
+  last_used_at: unknown;
+  created_at: unknown;
+}): GitTokenRow {
+  return {
+    id: Number(row.id),
+    userId: Number(row.user_id),
+    label: row.label as string,
+    lastUsedAt: (row.last_used_at as Date | null) ?? null,
+    createdAt: row.created_at as Date,
+  };
+}
+
+export class GitTokenRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(input: CreateGitTokenInput): Promise<GitTokenRow> {
+    const result = await this.pool.query(
+      `INSERT INTO git_tokens (user_id, encrypted_token, label)
+       VALUES ($1, $2, $3)
+       RETURNING id, user_id, label, last_used_at, created_at`,
+      [input.userId, input.encryptedToken, input.label]
+    );
+    return rowToGitToken(result.rows[0] as Parameters<typeof rowToGitToken>[0]);
+  }
+
+  async findByUserId(userId: number): Promise<GitTokenRow[]> {
+    const result = await this.pool.query(
+      `SELECT id, user_id, label, last_used_at, created_at
+       FROM git_tokens
+       WHERE user_id = $1
+       ORDER BY created_at DESC`,
+      [userId]
+    );
+    return (result.rows as Parameters<typeof rowToGitToken>[0][]).map(rowToGitToken);
+  }
+
+  async findAll(): Promise<GitTokenWithUser[]> {
+    const result = await this.pool.query(
+      `SELECT gt.id, gt.user_id, gt.label, gt.last_used_at, gt.created_at,
+              u.name AS user_name, u.email AS user_email
+       FROM git_tokens gt
+       JOIN users u ON gt.user_id = u.id
+       ORDER BY gt.created_at DESC`
+    );
+    return (result.rows as {
+      id: unknown;
+      user_id: unknown;
+      label: unknown;
+      last_used_at: unknown;
+      created_at: unknown;
+      user_name: unknown;
+      user_email: unknown;
+    }[]).map(row => ({
+      ...rowToGitToken(row),
+      userName: (row.user_name as string | null) ?? null,
+      userEmail: row.user_email as string,
+    }));
+  }
+
+  async findAllEncrypted(): Promise<GitTokenWithEncrypted[]> {
+    const result = await this.pool.query(
+      `SELECT id, user_id, encrypted_token FROM git_tokens`
+    );
+    return (result.rows as { id: unknown; user_id: unknown; encrypted_token: unknown }[]).map(row => ({
+      id: Number(row.id),
+      userId: Number(row.user_id),
+      encryptedToken: row.encrypted_token as string,
+    }));
+  }
+
+  async deleteById(id: number): Promise<void> {
+    await this.pool.query('DELETE FROM git_tokens WHERE id = $1', [id]);
+  }
+
+  async deleteByUserId(userId: number): Promise<void> {
+    await this.pool.query('DELETE FROM git_tokens WHERE user_id = $1', [userId]);
+  }
+
+  async updateLastUsed(id: number): Promise<void> {
+    await this.pool.query(
+      'UPDATE git_tokens SET last_used_at = now() WHERE id = $1',
+      [id]
+    );
+  }
+}

--- a/src/lib/database/repositories/session-repository.ts
+++ b/src/lib/database/repositories/session-repository.ts
@@ -1,0 +1,102 @@
+import type { Pool } from 'pg';
+import type { AuthUser } from '@/lib/auth/types';
+
+export interface CreateSessionInput {
+  id: string;
+  userId: number;
+  encryptedOidc: string | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  expiresAt: Date;
+}
+
+export interface SessionRow {
+  id: string;
+  userId: number;
+  encryptedOidc: string | null;
+  ipAddress: string | null;
+  userAgent: string | null;
+  expiresAt: Date;
+  createdAt: Date;
+}
+
+function rowToSession(row: {
+  id: string;
+  user_id: number;
+  encrypted_oidc: string | null;
+  ip_address: string | null;
+  user_agent: string | null;
+  expires_at: Date;
+  created_at: Date;
+}): SessionRow {
+  return {
+    id: row.id,
+    userId: row.user_id,
+    encryptedOidc: row.encrypted_oidc,
+    ipAddress: row.ip_address,
+    userAgent: row.user_agent,
+    expiresAt: row.expires_at,
+    createdAt: row.created_at,
+  };
+}
+
+export class SessionRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async create(input: CreateSessionInput): Promise<void> {
+    await this.pool.query(
+      `INSERT INTO sessions (id, user_id, encrypted_oidc, ip_address, user_agent, expires_at)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [input.id, input.userId, input.encryptedOidc, input.ipAddress, input.userAgent, input.expiresAt]
+    );
+  }
+
+  async findById(hashedId: string): Promise<{ session: SessionRow; user: AuthUser } | null> {
+    const result = await this.pool.query(
+      `SELECT s.id, s.user_id, s.encrypted_oidc, s.ip_address, s.user_agent, s.expires_at, s.created_at,
+              u.id as u_id, u.email, u.name, u.role
+       FROM sessions s
+       JOIN users u ON s.user_id = u.id
+       WHERE s.id = $1 AND s.expires_at > now()`,
+      [hashedId]
+    );
+    if (result.rows.length === 0) return null;
+    const row = result.rows[0] as {
+      id: string;
+      user_id: number;
+      encrypted_oidc: string | null;
+      ip_address: string | null;
+      user_agent: string | null;
+      expires_at: Date;
+      created_at: Date;
+      u_id: number;
+      email: string;
+      name: string | null;
+      role: AuthUser['role'];
+    };
+    return {
+      session: rowToSession(row),
+      user: { id: row.u_id, email: row.email, name: row.name, role: row.role },
+    };
+  }
+
+  async findByUserId(userId: number): Promise<SessionRow[]> {
+    const result = await this.pool.query(
+      'SELECT * FROM sessions WHERE user_id = $1 ORDER BY created_at DESC',
+      [userId]
+    );
+    return (result.rows as Parameters<typeof rowToSession>[0][]).map(rowToSession);
+  }
+
+  async deleteById(id: string): Promise<void> {
+    await this.pool.query('DELETE FROM sessions WHERE id = $1', [id]);
+  }
+
+  async deleteByUserId(userId: number): Promise<void> {
+    await this.pool.query('DELETE FROM sessions WHERE user_id = $1', [userId]);
+  }
+
+  async deleteExpired(): Promise<void> {
+    await this.pool.query('DELETE FROM sessions WHERE expires_at <= now()');
+  }
+}

--- a/src/lib/database/repositories/session-repository.ts
+++ b/src/lib/database/repositories/session-repository.ts
@@ -96,6 +96,22 @@ export class SessionRepository {
     await this.pool.query('DELETE FROM sessions WHERE user_id = $1', [userId]);
   }
 
+  async findAllWithUser(): Promise<(SessionRow & { userName: string | null; userEmail: string })[]> {
+    const result = await this.pool.query(
+      `SELECT s.id, s.user_id, s.encrypted_oidc, s.ip_address, s.user_agent, s.expires_at, s.created_at,
+              u.name AS user_name, u.email AS user_email
+       FROM sessions s
+       JOIN users u ON s.user_id = u.id
+       WHERE s.expires_at > now()
+       ORDER BY s.created_at DESC`
+    );
+    return (result.rows as (Parameters<typeof rowToSession>[0] & { user_name: string | null; user_email: string })[]).map(row => ({
+      ...rowToSession(row),
+      userName: row.user_name ?? null,
+      userEmail: row.user_email,
+    }));
+  }
+
   async deleteExpired(): Promise<void> {
     await this.pool.query('DELETE FROM sessions WHERE expires_at <= now()');
   }

--- a/src/lib/database/repositories/user-repository.ts
+++ b/src/lib/database/repositories/user-repository.ts
@@ -1,0 +1,72 @@
+import type { Pool } from 'pg';
+import type { Role } from '@/lib/auth/types';
+
+export interface UserRow {
+  id: number;
+  oidc_subject: string;
+  email: string;
+  name: string | null;
+  role: Role;
+  oidc_groups: string[];
+  last_login: Date;
+  created_at: Date;
+  updated_at: Date;
+}
+
+export interface UpsertUserInput {
+  oidcSubject: string;
+  email: string;
+  name: string | null;
+  role: Role;
+  groups: string[];
+}
+
+function rowToUser(row: UserRow): UserRow {
+  return {
+    id: row.id,
+    oidc_subject: row.oidc_subject,
+    email: row.email,
+    name: row.name,
+    role: row.role,
+    oidc_groups: row.oidc_groups,
+    last_login: row.last_login,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+export class UserRepository {
+  constructor(private readonly pool: Pool) {}
+
+  async upsertFromOidc(input: UpsertUserInput): Promise<UserRow> {
+    const result = await this.pool.query(
+      `INSERT INTO users (oidc_subject, email, name, role, oidc_groups, last_login)
+       VALUES ($1, $2, $3, $4, $5, now())
+       ON CONFLICT (oidc_subject) DO UPDATE SET
+         email = EXCLUDED.email,
+         name = EXCLUDED.name,
+         role = EXCLUDED.role,
+         oidc_groups = EXCLUDED.oidc_groups,
+         last_login = now(),
+         updated_at = now()
+       RETURNING *`,
+      [input.oidcSubject, input.email, input.name, input.role, JSON.stringify(input.groups)]
+    );
+    return rowToUser(result.rows[0] as UserRow);
+  }
+
+  async findById(id: number): Promise<UserRow | null> {
+    const result = await this.pool.query('SELECT * FROM users WHERE id = $1', [id]);
+    return result.rows.length > 0 ? rowToUser(result.rows[0] as UserRow) : null;
+  }
+
+  async findBySubject(oidcSubject: string): Promise<UserRow | null> {
+    const result = await this.pool.query('SELECT * FROM users WHERE oidc_subject = $1', [oidcSubject]);
+    return result.rows.length > 0 ? rowToUser(result.rows[0] as UserRow) : null;
+  }
+
+  async findAll(): Promise<UserRow[]> {
+    const result = await this.pool.query('SELECT * FROM users ORDER BY name ASC, email ASC');
+    return (result.rows as UserRow[]).map(rowToUser);
+  }
+}

--- a/src/lib/database/repositories/user-repository.ts
+++ b/src/lib/database/repositories/user-repository.ts
@@ -3,14 +3,14 @@ import type { Role } from '@/lib/auth/types';
 
 export interface UserRow {
   id: number;
-  oidc_subject: string;
+  oidcSubject: string;
   email: string;
   name: string | null;
   role: Role;
-  oidc_groups: string[];
-  last_login: Date;
-  created_at: Date;
-  updated_at: Date;
+  oidcGroups: string[];
+  lastLogin: Date;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface UpsertUserInput {
@@ -21,17 +21,17 @@ export interface UpsertUserInput {
   groups: string[];
 }
 
-function rowToUser(row: UserRow): UserRow {
+function rowToUser(row: Record<string, unknown>): UserRow {
   return {
-    id: row.id,
-    oidc_subject: row.oidc_subject,
-    email: row.email,
-    name: row.name,
-    role: row.role,
-    oidc_groups: row.oidc_groups,
-    last_login: row.last_login,
-    created_at: row.created_at,
-    updated_at: row.updated_at,
+    id: row.id as number,
+    oidcSubject: row.oidc_subject as string,
+    email: row.email as string,
+    name: (row.name as string) ?? null,
+    role: row.role as Role,
+    oidcGroups: row.oidc_groups as string[],
+    lastLogin: row.last_login as Date,
+    createdAt: row.created_at as Date,
+    updatedAt: row.updated_at as Date,
   };
 }
 
@@ -52,21 +52,21 @@ export class UserRepository {
        RETURNING *`,
       [input.oidcSubject, input.email, input.name, input.role, JSON.stringify(input.groups)]
     );
-    return rowToUser(result.rows[0] as UserRow);
+    return rowToUser(result.rows[0] as Record<string, unknown>);
   }
 
   async findById(id: number): Promise<UserRow | null> {
     const result = await this.pool.query('SELECT * FROM users WHERE id = $1', [id]);
-    return result.rows.length > 0 ? rowToUser(result.rows[0] as UserRow) : null;
+    return result.rows.length > 0 ? rowToUser(result.rows[0] as Record<string, unknown>) : null;
   }
 
   async findBySubject(oidcSubject: string): Promise<UserRow | null> {
     const result = await this.pool.query('SELECT * FROM users WHERE oidc_subject = $1', [oidcSubject]);
-    return result.rows.length > 0 ? rowToUser(result.rows[0] as UserRow) : null;
+    return result.rows.length > 0 ? rowToUser(result.rows[0] as Record<string, unknown>) : null;
   }
 
   async findAll(): Promise<UserRow[]> {
     const result = await this.pool.query('SELECT * FROM users ORDER BY name ASC, email ASC');
-    return (result.rows as UserRow[]).map(rowToUser);
+    return (result.rows as Record<string, unknown>[]).map(rowToUser);
   }
 }

--- a/src/lib/sse/create-broadcast-sse-handler.ts
+++ b/src/lib/sse/create-broadcast-sse-handler.ts
@@ -39,6 +39,12 @@ export function createBroadcastSseHandler<Event>(
   options: BroadcastSseHandlerOptions<Event>,
 ) {
   return async ({ request }: { request: Request }): Promise<Response> => {
+    const { authenticateSSE } = await import('@/lib/auth/sse-auth');
+    const user = await authenticateSSE(request);
+    if (!user) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
     const encoder = new TextEncoder();
     let closed = false;
 

--- a/src/lib/sse/create-stats-sse-handler.ts
+++ b/src/lib/sse/create-stats-sse-handler.ts
@@ -7,6 +7,12 @@ import type { StatsSource } from '@/lib/database/subscription-service';
  */
 export function createStatsSseHandler(source: StatsSource) {
   return async ({ request }: { request: Request }) => {
+    const { authenticateSSE } = await import('@/lib/auth/sse-auth');
+    const user = await authenticateSSE(request);
+    if (!user) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
     await import('@/lib/server-init');
     const { statsPollService } = await import(
       '@/lib/database/subscription-service'

--- a/src/middleware/__tests__/auth-middleware.test.ts
+++ b/src/middleware/__tests__/auth-middleware.test.ts
@@ -79,7 +79,7 @@ describe('authMiddleware', () => {
   });
 
   test('injects SYNTHETIC_ADMIN when auth is disabled', async () => {
-    process.env.DISABLE_AUTH = 'true';
+    delete process.env.AUTH_ENABLED;
 
     const { authMiddleware } = await import('@/middleware/auth-middleware');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -105,6 +105,7 @@ describe('authMiddleware', () => {
     // Happy-DOM (used in bun test preload) strips "cookie" from Request headers
     // (browser forbidden-header behavior). We test via the serverHandler with a
     // mock request object that has no cookie header.
+    process.env.AUTH_ENABLED = 'true';
     const { authMiddleware } = await import('@/middleware/auth-middleware');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const serverHandler = (authMiddleware as any).options.server as (args: unknown) => Promise<unknown>;
@@ -120,6 +121,7 @@ describe('authMiddleware', () => {
   });
 
   test('throws AuthError 401 with status 401 for missing session', async () => {
+    process.env.AUTH_ENABLED = 'true';
     const { authMiddleware } = await import('@/middleware/auth-middleware');
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const serverHandler = (authMiddleware as any).options.server as (args: unknown) => Promise<unknown>;

--- a/src/middleware/__tests__/auth-middleware.test.ts
+++ b/src/middleware/__tests__/auth-middleware.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test, beforeEach, afterEach, mock } from 'bun:test';
+import {
+  parseCookie,
+  AuthError,
+  resetAuthMiddlewareState,
+} from '@/middleware/auth-middleware';
+import type { AuthUser } from '@/lib/auth/types';
+
+function makeUser(overrides?: Partial<AuthUser>): AuthUser {
+  return {
+    id: 1,
+    email: 'test@example.com',
+    name: 'Test User',
+    role: 'admin',
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseCookie unit tests
+// ---------------------------------------------------------------------------
+describe('parseCookie', () => {
+  test('returns the value for a matching cookie', () => {
+    expect(parseCookie('session=abc123', 'session')).toBe('abc123');
+  });
+
+  test('returns null when header is null', () => {
+    expect(parseCookie(null, 'session')).toBeNull();
+  });
+
+  test('returns null when cookie name not present', () => {
+    expect(parseCookie('other=xyz', 'session')).toBeNull();
+  });
+
+  test('handles multiple cookies and returns the right one', () => {
+    expect(parseCookie('foo=bar; session=tok123; baz=qux', 'session')).toBe('tok123');
+  });
+
+  test('URL-decodes the cookie value', () => {
+    const encoded = encodeURIComponent('value with spaces');
+    expect(parseCookie(`session=${encoded}`, 'session')).toBe('value with spaces');
+  });
+
+  test('returns null for empty header string', () => {
+    expect(parseCookie('', 'session')).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AuthError
+// ---------------------------------------------------------------------------
+describe('AuthError', () => {
+  test('has the correct status and message', () => {
+    const err = new AuthError(401, 'No session');
+    expect(err.status).toBe(401);
+    expect(err.message).toBe('No session');
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  test('name is AuthError', () => {
+    const err = new AuthError(401, 'test');
+    expect(err.name).toBe('AuthError');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// authMiddleware server handler
+// ---------------------------------------------------------------------------
+describe('authMiddleware', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    resetAuthMiddlewareState();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    resetAuthMiddlewareState();
+  });
+
+  test('injects SYNTHETIC_ADMIN when auth is disabled', async () => {
+    process.env.DISABLE_AUTH = 'true';
+
+    const { authMiddleware } = await import('@/middleware/auth-middleware');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const serverHandler = (authMiddleware as any).options.server as (args: unknown) => Promise<unknown>;
+
+    let capturedContext: Record<string, unknown> = {};
+    const nextFn = mock(({ context }: { context: Record<string, unknown> }) => {
+      capturedContext = context;
+      return Promise.resolve('next-result');
+    });
+
+    await serverHandler({ next: nextFn, context: {} });
+
+    expect(nextFn).toHaveBeenCalledTimes(1);
+    expect(capturedContext.user).toMatchObject({
+      id: 0,
+      email: 'admin@local',
+      role: 'admin',
+    });
+  });
+
+  test('throws AuthError 401 when no session cookie', async () => {
+    // Happy-DOM (used in bun test preload) strips "cookie" from Request headers
+    // (browser forbidden-header behavior). We test via the serverHandler with a
+    // mock request object that has no cookie header.
+    const { authMiddleware } = await import('@/middleware/auth-middleware');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const serverHandler = (authMiddleware as any).options.server as (args: unknown) => Promise<unknown>;
+
+    const nextFn = mock(() => Promise.resolve());
+    // Use a plain mock request with no cookie header
+    const mockRequest = { headers: { get: (_name: string) => null } };
+
+    await expect(
+      serverHandler({ next: nextFn, context: { request: mockRequest } }),
+    ).rejects.toThrow('No session');
+    expect(nextFn).not.toHaveBeenCalled();
+  });
+
+  test('throws AuthError 401 with status 401 for missing session', async () => {
+    const { authMiddleware } = await import('@/middleware/auth-middleware');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const serverHandler = (authMiddleware as any).options.server as (args: unknown) => Promise<unknown>;
+
+    const mockRequest = { headers: { get: (_name: string) => null } };
+
+    try {
+      await serverHandler({ next: mock(() => Promise.resolve()), context: { request: mockRequest } });
+      expect(true).toBe(false); // should not reach here
+    } catch (err) {
+      expect(err).toBeInstanceOf(AuthError);
+      expect((err as AuthError).status).toBe(401);
+    }
+  });
+
+  test('throws AuthError 401 when session token is invalid', async () => {
+    // Test the middleware logic directly using exported helpers.
+    // We test parseCookie with raw cookie strings (not via Request.headers.get,
+    // which Happy-DOM strips) to verify the invalid-session code path.
+    const mockValidateSession = mock((_t: string) => Promise.resolve(null as AuthUser | null));
+    const mockSessionManager = { validateSession: mockValidateSession };
+
+    async function runMiddlewareLogic(
+      cookieHeader: string | null,
+      sessionManager: { validateSession: (t: string) => Promise<AuthUser | null> },
+    ): Promise<AuthUser> {
+      const sessionToken = parseCookie(cookieHeader, 'session');
+      if (!sessionToken) throw new AuthError(401, 'No session');
+      const user = await sessionManager.validateSession(sessionToken);
+      if (!user) throw new AuthError(401, 'Invalid or expired session');
+      return user;
+    }
+
+    await expect(
+      runMiddlewareLogic('session=invalid-token-xyz', mockSessionManager),
+    ).rejects.toThrow('Invalid or expired session');
+
+    await expect(
+      runMiddlewareLogic('session=invalid-token-xyz', mockSessionManager),
+    ).rejects.toMatchObject({ status: 401 });
+
+    expect(mockValidateSession).toHaveBeenCalledWith('invalid-token-xyz');
+  });
+
+  test('injects correct AuthUser into context on valid session', async () => {
+    const user = makeUser({ id: 5, email: 'alice@example.com', role: 'operator' });
+    const mockValidateSession = mock((_t: string) => Promise.resolve(user as AuthUser | null));
+    const mockSessionManager = { validateSession: mockValidateSession };
+
+    async function runMiddlewareLogic(
+      cookieHeader: string | null,
+      sessionManager: { validateSession: (t: string) => Promise<AuthUser | null> },
+    ): Promise<AuthUser> {
+      const sessionToken = parseCookie(cookieHeader, 'session');
+      if (!sessionToken) throw new AuthError(401, 'No session');
+      const result = await sessionManager.validateSession(sessionToken);
+      if (!result) throw new AuthError(401, 'Invalid or expired session');
+      return result;
+    }
+
+    const result = await runMiddlewareLogic('session=valid-token-abc', mockSessionManager);
+
+    expect(result).toEqual(user);
+    expect(mockValidateSession).toHaveBeenCalledWith('valid-token-abc');
+  });
+
+  test('middleware options have server handler defined', async () => {
+    const { authMiddleware } = await import('@/middleware/auth-middleware');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((authMiddleware as any).options).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((authMiddleware as any).options.server).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(typeof (authMiddleware as any).options.server).toBe('function');
+  });
+});

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -6,7 +6,7 @@ let cachedSessionManager: import('@/lib/auth/session-manager').SessionManager | 
 
 /**
  * Auth middleware — validates session cookies and injects AuthUser into server function context.
- * When auth is disabled (DISABLE_AUTH=true), injects a synthetic admin user.
+ * When auth is disabled (AUTH_ENABLED not set to "true"), injects a synthetic admin user.
  * Dynamically imports server-only modules to avoid leaking into the client bundle.
  */
 export const authMiddleware = createMiddleware().server(

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -52,7 +52,12 @@ export function parseCookie(header: string | null, name: string): string | null 
   if (!header) return null;
   const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
   const match = header.match(new RegExp(`(?:^|;\\s*)${escapedName}=([^;]*)`));
-  return match ? decodeURIComponent(match[1]) : null;
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
 }
 
 export class AuthError extends Error {

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -1,0 +1,72 @@
+import { createMiddleware } from '@tanstack/react-start';
+import type { AuthUser } from '@/lib/auth/types';
+import { SYNTHETIC_ADMIN } from '@/lib/auth/types';
+
+let cachedSessionManager: import('@/lib/auth/session-manager').SessionManager | null = null;
+
+/**
+ * Auth middleware — validates session cookies and injects AuthUser into server function context.
+ * When auth is disabled (DISABLE_AUTH=true), injects a synthetic admin user.
+ * Dynamically imports server-only modules to avoid leaking into the client bundle.
+ */
+export const authMiddleware = createMiddleware().server(
+  async ({ next, context }) => {
+    const { isAuthDisabled } = await import('@/lib/config/auth-config');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ctx = context as any;
+
+    if (isAuthDisabled()) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return next({ context: { ...ctx, user: SYNTHETIC_ADMIN as AuthUser } });
+    }
+
+    // Extract the session token from the cookie before building the session manager
+    // to avoid unnecessary DB/OpenBao connections on unauthenticated requests.
+    const request = (ctx.request as Request | undefined);
+    const cookieHeader = request?.headers.get('cookie') ?? null;
+    const sessionToken = parseCookie(cookieHeader, 'session');
+
+    if (!sessionToken) {
+      throw new AuthError(401, 'No session');
+    }
+
+    if (!cachedSessionManager) {
+      const { buildSessionManager } = await import('@/lib/auth/session-manager');
+      cachedSessionManager = await buildSessionManager();
+    }
+
+    const user = await cachedSessionManager.validateSession(sessionToken);
+    if (!user) {
+      throw new AuthError(401, 'Invalid or expired session');
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+    return next({ context: { ...ctx, user } });
+  },
+);
+
+/**
+ * Parses a single cookie value from a Cookie header string.
+ */
+export function parseCookie(header: string | null, name: string): string | null {
+  if (!header) return null;
+  const match = header.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+export class AuthError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'AuthError';
+  }
+}
+
+/**
+ * Reset cached session manager (for testing only).
+ */
+export function resetAuthMiddlewareState(): void {
+  cachedSessionManager = null;
+}

--- a/src/middleware/auth-middleware.ts
+++ b/src/middleware/auth-middleware.ts
@@ -50,7 +50,8 @@ export const authMiddleware = createMiddleware().server(
  */
 export function parseCookie(header: string | null, name: string): string | null {
   if (!header) return null;
-  const match = header.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = header.match(new RegExp(`(?:^|;\\s*)${escapedName}=([^;]*)`));
   return match ? decodeURIComponent(match[1]) : null;
 }
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -30,6 +30,8 @@ import { Route as ApiDockerLogsContainerIdRouteImport } from './routes/api/docke
 import { Route as ApiAuthLoginRouteImport } from './routes/api/auth/login'
 import { Route as ApiAuthCallbackRouteImport } from './routes/api/auth/callback'
 import { Route as ApiAuthLogoutRouteImport } from './routes/api/auth/logout'
+import { Route as LoginRouteImport } from './routes/login'
+import { Route as DeniedRouteImport } from './routes/denied'
 
 const ZfsRoute = ZfsRouteImport.update({
   id: '/zfs',
@@ -137,6 +139,16 @@ const ApiAuthLogoutRoute = ApiAuthLogoutRouteImport.update({
   path: '/api/auth/logout',
   getParentRoute: () => rootRouteImport,
 } as any)
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DeniedRoute = DeniedRouteImport.update({
+  id: '/denied',
+  path: '/denied',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -160,6 +172,8 @@ export interface FileRoutesByFullPath {
   '/api/auth/login': typeof ApiAuthLoginRoute
   '/api/auth/callback': typeof ApiAuthCallbackRoute
   '/api/auth/logout': typeof ApiAuthLogoutRoute
+  '/login': typeof LoginRoute
+  '/denied': typeof DeniedRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -182,6 +196,8 @@ export interface FileRoutesByTo {
   '/api/auth/login': typeof ApiAuthLoginRoute
   '/api/auth/callback': typeof ApiAuthCallbackRoute
   '/api/auth/logout': typeof ApiAuthLogoutRoute
+  '/login': typeof LoginRoute
+  '/denied': typeof DeniedRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -206,6 +222,8 @@ export interface FileRoutesById {
   '/api/auth/login': typeof ApiAuthLoginRoute
   '/api/auth/callback': typeof ApiAuthCallbackRoute
   '/api/auth/logout': typeof ApiAuthLogoutRoute
+  '/login': typeof LoginRoute
+  '/denied': typeof DeniedRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -231,6 +249,8 @@ export interface FileRouteTypes {
     | '/api/auth/login'
     | '/api/auth/callback'
     | '/api/auth/logout'
+    | '/login'
+    | '/denied'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -253,6 +273,8 @@ export interface FileRouteTypes {
     | '/api/auth/login'
     | '/api/auth/callback'
     | '/api/auth/logout'
+    | '/login'
+    | '/denied'
   id:
     | '__root__'
     | '/'
@@ -276,6 +298,8 @@ export interface FileRouteTypes {
     | '/api/auth/login'
     | '/api/auth/callback'
     | '/api/auth/logout'
+    | '/login'
+    | '/denied'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -296,6 +320,8 @@ export interface RootRouteChildren {
   ApiAuthLoginRoute: typeof ApiAuthLoginRoute
   ApiAuthCallbackRoute: typeof ApiAuthCallbackRoute
   ApiAuthLogoutRoute: typeof ApiAuthLogoutRoute
+  LoginRoute: typeof LoginRoute
+  DeniedRoute: typeof DeniedRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -447,6 +473,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAuthLogoutRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/denied': {
+      id: '/denied'
+      path: '/denied'
+      fullPath: '/denied'
+      preLoaderRoute: typeof DeniedRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -494,6 +534,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAuthLoginRoute: ApiAuthLoginRoute,
   ApiAuthCallbackRoute: ApiAuthCallbackRoute,
   ApiAuthLogoutRoute: ApiAuthLogoutRoute,
+  LoginRoute: LoginRoute,
+  DeniedRoute: DeniedRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -27,6 +27,9 @@ import { Route as ApiDockerInventoryRouteImport } from './routes/api/docker-inve
 import { Route as StacksHostHostNameRouteImport } from './routes/stacks/host.$hostName'
 import { Route as ApiGitSplatRouteImport } from './routes/api/git.$'
 import { Route as ApiDockerLogsContainerIdRouteImport } from './routes/api/docker-logs.$containerId'
+import { Route as ApiAuthLoginRouteImport } from './routes/api/auth/login'
+import { Route as ApiAuthCallbackRouteImport } from './routes/api/auth/callback'
+import { Route as ApiAuthLogoutRouteImport } from './routes/api/auth/logout'
 
 const ZfsRoute = ZfsRouteImport.update({
   id: '/zfs',
@@ -119,6 +122,21 @@ const ApiDockerLogsContainerIdRoute =
     path: '/api/docker-logs/$containerId',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiAuthLoginRoute = ApiAuthLoginRouteImport.update({
+  id: '/api/auth/login',
+  path: '/api/auth/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAuthCallbackRoute = ApiAuthCallbackRouteImport.update({
+  id: '/api/auth/callback',
+  path: '/api/auth/callback',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiAuthLogoutRoute = ApiAuthLogoutRouteImport.update({
+  id: '/api/auth/logout',
+  path: '/api/auth/logout',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -139,6 +157,9 @@ export interface FileRoutesByFullPath {
   '/api/docker-logs/$containerId': typeof ApiDockerLogsContainerIdRoute
   '/api/git/$': typeof ApiGitSplatRoute
   '/stacks/host/$hostName': typeof StacksHostHostNameRoute
+  '/api/auth/login': typeof ApiAuthLoginRoute
+  '/api/auth/callback': typeof ApiAuthCallbackRoute
+  '/api/auth/logout': typeof ApiAuthLogoutRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -158,6 +179,9 @@ export interface FileRoutesByTo {
   '/api/docker-logs/$containerId': typeof ApiDockerLogsContainerIdRoute
   '/api/git/$': typeof ApiGitSplatRoute
   '/stacks/host/$hostName': typeof StacksHostHostNameRoute
+  '/api/auth/login': typeof ApiAuthLoginRoute
+  '/api/auth/callback': typeof ApiAuthCallbackRoute
+  '/api/auth/logout': typeof ApiAuthLogoutRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -179,6 +203,9 @@ export interface FileRoutesById {
   '/api/docker-logs/$containerId': typeof ApiDockerLogsContainerIdRoute
   '/api/git/$': typeof ApiGitSplatRoute
   '/stacks/host/$hostName': typeof StacksHostHostNameRoute
+  '/api/auth/login': typeof ApiAuthLoginRoute
+  '/api/auth/callback': typeof ApiAuthCallbackRoute
+  '/api/auth/logout': typeof ApiAuthLogoutRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -201,6 +228,9 @@ export interface FileRouteTypes {
     | '/api/docker-logs/$containerId'
     | '/api/git/$'
     | '/stacks/host/$hostName'
+    | '/api/auth/login'
+    | '/api/auth/callback'
+    | '/api/auth/logout'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -220,6 +250,9 @@ export interface FileRouteTypes {
     | '/api/docker-logs/$containerId'
     | '/api/git/$'
     | '/stacks/host/$hostName'
+    | '/api/auth/login'
+    | '/api/auth/callback'
+    | '/api/auth/logout'
   id:
     | '__root__'
     | '/'
@@ -240,6 +273,9 @@ export interface FileRouteTypes {
     | '/api/docker-logs/$containerId'
     | '/api/git/$'
     | '/stacks/host/$hostName'
+    | '/api/auth/login'
+    | '/api/auth/callback'
+    | '/api/auth/logout'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -257,6 +293,9 @@ export interface RootRouteChildren {
   ApiZfsStatsRoute: typeof ApiZfsStatsRoute
   ApiDockerLogsContainerIdRoute: typeof ApiDockerLogsContainerIdRoute
   ApiGitSplatRoute: typeof ApiGitSplatRoute
+  ApiAuthLoginRoute: typeof ApiAuthLoginRoute
+  ApiAuthCallbackRoute: typeof ApiAuthCallbackRoute
+  ApiAuthLogoutRoute: typeof ApiAuthLogoutRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -387,6 +426,27 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiDockerLogsContainerIdRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/auth/login': {
+      id: '/api/auth/login'
+      path: '/api/auth/login'
+      fullPath: '/api/auth/login'
+      preLoaderRoute: typeof ApiAuthLoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/auth/callback': {
+      id: '/api/auth/callback'
+      path: '/api/auth/callback'
+      fullPath: '/api/auth/callback'
+      preLoaderRoute: typeof ApiAuthCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/auth/logout': {
+      id: '/api/auth/logout'
+      path: '/api/auth/logout'
+      fullPath: '/api/auth/logout'
+      preLoaderRoute: typeof ApiAuthLogoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
@@ -431,6 +491,9 @@ const rootRouteChildren: RootRouteChildren = {
   ApiZfsStatsRoute: ApiZfsStatsRoute,
   ApiDockerLogsContainerIdRoute: ApiDockerLogsContainerIdRoute,
   ApiGitSplatRoute: ApiGitSplatRoute,
+  ApiAuthLoginRoute: ApiAuthLoginRoute,
+  ApiAuthCallbackRoute: ApiAuthCallbackRoute,
+  ApiAuthLogoutRoute: ApiAuthLogoutRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,4 @@
-import { HeadContent, Outlet, Scripts, createRootRoute } from '@tanstack/react-router'
+import { HeadContent, Outlet, Scripts, createRootRoute, useRouterState } from '@tanstack/react-router'
 import { lazy } from 'react'
 import AppShell from '@/components/AppShell'
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary'
@@ -52,13 +52,20 @@ export const Route = createRootRoute({
 })
 
 function RootLayout() {
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  const isAuthPage = pathname === '/login' || pathname === '/denied';
+
+  if (isAuthPage) {
+    return <Outlet />;
+  }
+
   return (
     <AppShell>
       <ErrorBoundary name="root">
         <Outlet />
       </ErrorBoundary>
     </AppShell>
-  )
+  );
 }
 
 function RootDocument({ children }: { children: React.ReactNode }) {

--- a/src/routes/api/auth/__tests__/callback.test.ts
+++ b/src/routes/api/auth/__tests__/callback.test.ts
@@ -4,12 +4,8 @@ import type { CallbackHandlerDeps } from '../callback';
 import type { OidcTokens, Role } from '@/lib/auth/types';
 import type { UserRow } from '@/lib/database/repositories/user-repository';
 
-// ----- Shared test constants -----
-
 const validState = 'state-abc123';
 const validNonce = 'nonce-xyz789';
-
-// ----- Helpers -----
 
 function makeTokens(overrides?: Partial<OidcTokens>): OidcTokens {
   return {
@@ -77,8 +73,6 @@ function makeDeps(overrides?: Partial<CallbackHandlerDeps>): CallbackHandlerDeps
 function validCookieHeader(): string {
   return `oidc_state=${encodedStateParam(validState, validNonce)}`;
 }
-
-// ----- Tests -----
 
 describe('handleCallback', () => {
   describe('request validation', () => {
@@ -432,8 +426,6 @@ describe('handleCallback', () => {
     });
   });
 });
-
-// ----- Route GET handler -----
 
 // Access the route's server handler directly to test the wiring layer.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/routes/api/auth/__tests__/callback.test.ts
+++ b/src/routes/api/auth/__tests__/callback.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, mock } from 'bun:test';
-import { handleCallback, buildSessionCookie, CLEAR_STATE_COOKIE } from '../callback';
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { handleCallback, buildSessionCookie, CLEAR_STATE_COOKIE, Route } from '../callback';
 import type { CallbackHandlerDeps } from '../callback';
 import type { OidcTokens, Role } from '@/lib/auth/types';
 import type { UserRow } from '@/lib/database/repositories/user-repository';
@@ -430,5 +430,67 @@ describe('handleCallback', () => {
       expect(ipAddress).toBe('10.0.0.1');
       expect(userAgent).toBe('TestAgent/1.0');
     });
+  });
+});
+
+// ----- Route GET handler -----
+
+// Access the route's server handler directly to test the wiring layer.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const routeGetHandler = (Route as any).options?.server?.handlers?.GET as
+  ((args: { request: Request }) => Promise<Response>) | undefined;
+
+function makeRouteRequest(url: string): Request {
+  return new Request(url);
+}
+
+describe('Route GET handler', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  it('redirects to / when auth is disabled', async () => {
+    delete process.env.AUTH_ENABLED;
+    const response = await routeGetHandler!({ request: makeRouteRequest('http://localhost/api/auth/callback') });
+    expect(response.status).toBe(302);
+    expect(response.headers.get('Location')).toBe('/');
+  });
+
+  it('returns 400 when code is missing from query params', async () => {
+    process.env.AUTH_ENABLED = 'true';
+    process.env.OIDC_ISSUER_URL = 'https://pocketid.example.com';
+    process.env.OIDC_CLIENT_ID = 'homelab-manager';
+    process.env.OIDC_REDIRECT_URI = 'http://localhost:3000/api/auth/callback';
+    const response = await routeGetHandler!({ request: makeRouteRequest('http://localhost/api/auth/callback?state=xyz') });
+    expect(response.status).toBe(400);
+  });
+
+  it('returns 400 when state is missing from query params', async () => {
+    process.env.AUTH_ENABLED = 'true';
+    process.env.OIDC_ISSUER_URL = 'https://pocketid.example.com';
+    process.env.OIDC_CLIENT_ID = 'homelab-manager';
+    process.env.OIDC_REDIRECT_URI = 'http://localhost:3000/api/auth/callback';
+    const response = await routeGetHandler!({ request: makeRouteRequest('http://localhost/api/auth/callback?code=abc') });
+    expect(response.status).toBe(400);
+  });
+
+  it('redirects to /login?error=callback_failed when an unhandled error occurs', async () => {
+    // AUTH_ENABLED=true, code+state present, but OIDC vars missing → loadAuthConfig throws → caught
+    process.env.AUTH_ENABLED = 'true';
+    delete process.env.OIDC_ISSUER_URL;
+    delete process.env.OIDC_CLIENT_ID;
+    delete process.env.OIDC_REDIRECT_URI;
+    // Suppress expected console.error from the catch block so bun doesn't treat it as an unhandled error
+    const originalConsoleError = console.error;
+    console.error = () => {};
+    try {
+      const response = await routeGetHandler!({ request: makeRouteRequest('http://localhost/api/auth/callback?code=abc&state=xyz') });
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toBe('/login?error=callback_failed');
+    } finally {
+      console.error = originalConsoleError;
+    }
   });
 });

--- a/src/routes/api/auth/__tests__/callback.test.ts
+++ b/src/routes/api/auth/__tests__/callback.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, mock } from 'bun:test';
+import { handleCallback, buildSessionCookie, CLEAR_STATE_COOKIE } from '../callback';
+import type { CallbackHandlerDeps } from '../callback';
+import type { OidcTokens, Role } from '@/lib/auth/types';
+import type { UserRow } from '@/lib/database/repositories/user-repository';
+
+// ----- Helpers -----
+
+function makeTokens(overrides?: Partial<OidcTokens>): OidcTokens {
+  return {
+    accessToken: 'access-token-abc',
+    refreshToken: 'refresh-token-xyz',
+    idToken: 'eyJhbGciOiJSUzI1NiJ9.test.sig',
+    ...overrides,
+  };
+}
+
+function makeUser(overrides?: Partial<UserRow>): UserRow {
+  return {
+    id: 42,
+    oidc_subject: 'sub-123',
+    email: 'alice@example.com',
+    name: 'Alice',
+    role: 'viewer',
+    oidc_groups: ['homelab-viewers'],
+    last_login: new Date(),
+    created_at: new Date(),
+    updated_at: new Date(),
+    ...overrides,
+  };
+}
+
+function makeIdTokenClaims(overrides?: Record<string, unknown>): Record<string, unknown> {
+  return {
+    sub: 'sub-123',
+    email: 'alice@example.com',
+    name: 'Alice',
+    groups: [],
+    ...overrides,
+  };
+}
+
+function encodedStateParam(state: string, nonce: string): string {
+  return encodeURIComponent(JSON.stringify({ state, nonce }));
+}
+
+function makeDeps(overrides?: Partial<CallbackHandlerDeps>): CallbackHandlerDeps {
+  return {
+    oidcClient: {
+      exchangeCode: mock(async () => makeTokens()),
+      getUserGroups: mock(async () => ['homelab-viewers']),
+    },
+    extractIdTokenClaims: mock(() => makeIdTokenClaims()),
+    mapGroupsToRole: mock(() => 'viewer' as Role | null),
+    userRepo: {
+      upsertFromOidc: mock(async () => makeUser()),
+    },
+    sessionManager: {
+      createSession: mock(async () => 'raw-session-token-abc'),
+    },
+    roleMapping: {
+      admin: 'homelab-admins',
+      operator: 'homelab-operators',
+      viewer: 'homelab-viewers',
+    },
+    isSecure: false,
+    ...overrides,
+  };
+}
+
+// ----- Tests -----
+
+describe('handleCallback', () => {
+  const validState = 'state-abc123';
+  const validNonce = 'nonce-xyz789';
+
+  function validCookieHeader(): string {
+    return `oidc_state=${encodedStateParam(validState, validNonce)}`;
+  }
+
+  describe('request validation', () => {
+    it('returns 400 when state cookie is missing', async () => {
+      const deps = makeDeps();
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        '',
+        null,
+        null,
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('Missing state cookie');
+    });
+
+    it('returns 400 when state cookie is not valid JSON', async () => {
+      const deps = makeDeps();
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        'oidc_state=%7Bnot-valid-json%7D',
+        null,
+        null,
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('Invalid state cookie');
+    });
+
+    it('returns 400 when state parameter does not match cookie', async () => {
+      const deps = makeDeps();
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        'different-state',
+        validCookieHeader(),
+        null,
+        null,
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('State mismatch');
+    });
+
+    it('extracts state cookie correctly when multiple cookies are present', async () => {
+      const deps = makeDeps();
+      const cookieHeader = `other=value; oidc_state=${encodedStateParam(validState, validNonce)}; another=abc`;
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        cookieHeader,
+        null,
+        null,
+      );
+      // Valid state — should not be a 400
+      expect(response.status).not.toBe(400);
+    });
+  });
+
+  describe('role mapping', () => {
+    it('redirects to /denied when no role maps to user groups', async () => {
+      const deps = makeDeps({
+        mapGroupsToRole: mock(() => null),
+      });
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toBe('/denied');
+    });
+
+    it('sets oidc_state clear cookie when redirecting to /denied', async () => {
+      const deps = makeDeps({
+        mapGroupsToRole: mock(() => null),
+      });
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+      // Verify the response was constructed with the clear-state cookie constant
+      expect(CLEAR_STATE_COOKIE).toContain('oidc_state=');
+      expect(CLEAR_STATE_COOKIE).toContain('Max-Age=0');
+      expect(CLEAR_STATE_COOKIE).toContain('Path=/api/auth');
+      // Response status confirms the redirect happened
+      expect(response.status).toBe(302);
+    });
+  });
+
+  describe('successful login', () => {
+    it('redirects to / on success', async () => {
+      const deps = makeDeps();
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toBe('/');
+    });
+
+    it('does not call sessionManager when role is null', async () => {
+      const deps = makeDeps({ mapGroupsToRole: mock(() => null) });
+      await handleCallback(deps, 'auth-code', validState, validCookieHeader(), null, null);
+      expect(deps.sessionManager.createSession).not.toHaveBeenCalled();
+    });
+
+    it('calls sessionManager.createSession on successful auth', async () => {
+      const deps = makeDeps();
+      await handleCallback(deps, 'auth-code', validState, validCookieHeader(), null, null);
+      expect(deps.sessionManager.createSession).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('buildSessionCookie helper', () => {
+    it('includes HttpOnly, SameSite=Lax, and Path=/ for non-secure', () => {
+      const cookie = buildSessionCookie('my-raw-token', false);
+      expect(cookie).toContain('HttpOnly');
+      expect(cookie).toContain('SameSite=Lax');
+      expect(cookie).toContain('Path=/');
+      expect(cookie).not.toContain('Secure');
+    });
+
+    it('includes Secure flag when isSecure=true', () => {
+      const cookie = buildSessionCookie('my-raw-token', true);
+      expect(cookie).toContain('Secure');
+    });
+
+    it('encodes the raw token in the cookie value', () => {
+      const token = 'raw/token+value';
+      const cookie = buildSessionCookie(token, false);
+      expect(cookie).toContain(`session=${encodeURIComponent(token)}`);
+    });
+
+    it('starts with session= prefix', () => {
+      const cookie = buildSessionCookie('abc', false);
+      expect(cookie).toMatch(/^session=/);
+    });
+  });
+
+  describe('CLEAR_STATE_COOKIE constant', () => {
+    it('clears the oidc_state cookie with Max-Age=0', () => {
+      expect(CLEAR_STATE_COOKIE).toContain('oidc_state=');
+      expect(CLEAR_STATE_COOKIE).toContain('Max-Age=0');
+      expect(CLEAR_STATE_COOKIE).toContain('Path=/api/auth');
+      expect(CLEAR_STATE_COOKIE).toContain('HttpOnly');
+    });
+  });
+
+  describe('group merging', () => {
+    it('merges groups from userinfo and id_token, deduplicating', async () => {
+      const deps = makeDeps({
+        oidcClient: {
+          exchangeCode: mock(async () => makeTokens()),
+          getUserGroups: mock(async () => ['group-a', 'group-b']),
+        },
+        extractIdTokenClaims: mock(() =>
+          makeIdTokenClaims({ groups: ['group-b', 'group-c'] }),
+        ),
+        mapGroupsToRole: mock((groups: string[]) => {
+          // Verify we see the merged, deduplicated groups
+          if (
+            groups.includes('group-a') &&
+            groups.includes('group-b') &&
+            groups.includes('group-c') &&
+            groups.filter((g) => g === 'group-b').length === 1
+          ) {
+            return 'viewer';
+          }
+          return null;
+        }),
+      });
+
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+
+      // mapGroupsToRole should have been called with merged groups
+      expect(deps.mapGroupsToRole).toHaveBeenCalledTimes(1);
+      const calledGroups = (deps.mapGroupsToRole as ReturnType<typeof mock>).mock
+        .calls[0][0] as string[];
+      expect(calledGroups).toContain('group-a');
+      expect(calledGroups).toContain('group-b');
+      expect(calledGroups).toContain('group-c');
+      expect(calledGroups.filter((g) => g === 'group-b')).toHaveLength(1);
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toBe('/');
+    });
+
+    it('handles empty id_token groups gracefully', async () => {
+      const deps = makeDeps({
+        oidcClient: {
+          exchangeCode: mock(async () => makeTokens()),
+          getUserGroups: mock(async () => ['homelab-viewers']),
+        },
+        extractIdTokenClaims: mock(() => makeIdTokenClaims({ groups: undefined })),
+      });
+
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+
+      expect(response.status).toBe(302);
+    });
+  });
+
+  describe('user upsert', () => {
+    it('passes correct user info extracted from id_token claims to upsertFromOidc', async () => {
+      const claims = makeIdTokenClaims({
+        sub: 'user-subject-456',
+        email: 'bob@example.com',
+        name: 'Bob Smith',
+        groups: [],
+      });
+      const deps = makeDeps({
+        extractIdTokenClaims: mock(() => claims),
+        mapGroupsToRole: mock(() => 'admin' as Role | null),
+      });
+
+      await handleCallback(deps, 'auth-code', validState, validCookieHeader(), null, null);
+
+      expect(deps.userRepo.upsertFromOidc).toHaveBeenCalledTimes(1);
+      const callArg = (deps.userRepo.upsertFromOidc as ReturnType<typeof mock>).mock
+        .calls[0][0] as Record<string, unknown>;
+      expect(callArg.oidcSubject).toBe('user-subject-456');
+      expect(callArg.email).toBe('bob@example.com');
+      expect(callArg.name).toBe('Bob Smith');
+      expect(callArg.role).toBe('admin');
+    });
+
+    it('passes ipAddress and userAgent to createSession', async () => {
+      const deps = makeDeps();
+      await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        '10.0.0.1',
+        'TestAgent/1.0',
+      );
+
+      expect(deps.sessionManager.createSession).toHaveBeenCalledTimes(1);
+      const [, , ipAddress, userAgent] = (
+        deps.sessionManager.createSession as ReturnType<typeof mock>
+      ).mock.calls[0] as [number, OidcTokens, string | null, string | null];
+      expect(ipAddress).toBe('10.0.0.1');
+      expect(userAgent).toBe('TestAgent/1.0');
+    });
+  });
+});

--- a/src/routes/api/auth/__tests__/callback.test.ts
+++ b/src/routes/api/auth/__tests__/callback.test.ts
@@ -4,6 +4,11 @@ import type { CallbackHandlerDeps } from '../callback';
 import type { OidcTokens, Role } from '@/lib/auth/types';
 import type { UserRow } from '@/lib/database/repositories/user-repository';
 
+// ----- Shared test constants -----
+
+const validState = 'state-abc123';
+const validNonce = 'nonce-xyz789';
+
 // ----- Helpers -----
 
 function makeTokens(overrides?: Partial<OidcTokens>): OidcTokens {
@@ -18,14 +23,14 @@ function makeTokens(overrides?: Partial<OidcTokens>): OidcTokens {
 function makeUser(overrides?: Partial<UserRow>): UserRow {
   return {
     id: 42,
-    oidc_subject: 'sub-123',
+    oidcSubject: 'sub-123',
     email: 'alice@example.com',
     name: 'Alice',
     role: 'viewer',
-    oidc_groups: ['homelab-viewers'],
-    last_login: new Date(),
-    created_at: new Date(),
-    updated_at: new Date(),
+    oidcGroups: ['homelab-viewers'],
+    lastLogin: new Date(),
+    createdAt: new Date(),
+    updatedAt: new Date(),
     ...overrides,
   };
 }
@@ -36,6 +41,7 @@ function makeIdTokenClaims(overrides?: Record<string, unknown>): Record<string, 
     email: 'alice@example.com',
     name: 'Alice',
     groups: [],
+    nonce: validNonce,
     ...overrides,
   };
 }
@@ -68,16 +74,13 @@ function makeDeps(overrides?: Partial<CallbackHandlerDeps>): CallbackHandlerDeps
   };
 }
 
+function validCookieHeader(): string {
+  return `oidc_state=${encodedStateParam(validState, validNonce)}`;
+}
+
 // ----- Tests -----
 
 describe('handleCallback', () => {
-  const validState = 'state-abc123';
-  const validNonce = 'nonce-xyz789';
-
-  function validCookieHeader(): string {
-    return `oidc_state=${encodedStateParam(validState, validNonce)}`;
-  }
-
   describe('request validation', () => {
     it('returns 400 when state cookie is missing', async () => {
       const deps = makeDeps();
@@ -134,6 +137,86 @@ describe('handleCallback', () => {
       );
       // Valid state — should not be a 400
       expect(response.status).not.toBe(400);
+    });
+
+    it('returns 400 when id_token nonce does not match stored nonce', async () => {
+      const deps = makeDeps({
+        extractIdTokenClaims: mock(() => makeIdTokenClaims({ nonce: 'wrong-nonce' })),
+      });
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('Nonce mismatch');
+    });
+
+    it('returns 400 when id_token is missing sub claim', async () => {
+      const deps = makeDeps({
+        extractIdTokenClaims: mock(() => makeIdTokenClaims({ sub: undefined })),
+      });
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('ID token missing required "sub" claim');
+    });
+
+    it('returns 400 when id_token has empty sub claim', async () => {
+      const deps = makeDeps({
+        extractIdTokenClaims: mock(() => makeIdTokenClaims({ sub: '' })),
+      });
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('ID token missing required "sub" claim');
+    });
+
+    it('returns 400 when id_token is missing email claim', async () => {
+      const deps = makeDeps({
+        extractIdTokenClaims: mock(() => makeIdTokenClaims({ email: undefined })),
+      });
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('ID token missing required "email" claim');
+    });
+
+    it('returns 400 when id_token has empty email claim', async () => {
+      const deps = makeDeps({
+        extractIdTokenClaims: mock(() => makeIdTokenClaims({ email: '' })),
+      });
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+      expect(response.status).toBe(400);
+      expect(await response.text()).toBe('ID token missing required "email" claim');
     });
   });
 

--- a/src/routes/api/auth/callback.ts
+++ b/src/routes/api/auth/callback.ts
@@ -81,6 +81,22 @@ export async function handleCallback(
   // Get groups from userinfo AND id_token claims (merge, deduplicate)
   const userinfoGroups = await deps.oidcClient.getUserGroups(tokens.accessToken);
   const idTokenClaims = deps.extractIdTokenClaims(tokens.idToken);
+
+  // Issue 1: Validate nonce claim matches stored nonce
+  if (idTokenClaims.nonce !== storedState.nonce) {
+    return new Response('Nonce mismatch', { status: 400 });
+  }
+
+  // Issue 4: Validate required sub and email claims
+  const subject = idTokenClaims.sub;
+  if (typeof subject !== 'string' || !subject) {
+    return new Response('ID token missing required "sub" claim', { status: 400 });
+  }
+  const email = idTokenClaims.email;
+  if (typeof email !== 'string' || !email) {
+    return new Response('ID token missing required "email" claim', { status: 400 });
+  }
+
   const idTokenGroups = Array.isArray(idTokenClaims.groups)
     ? (idTokenClaims.groups as string[])
     : [];
@@ -100,9 +116,7 @@ export async function handleCallback(
   }
 
   // Extract user info from id_token
-  const email = (idTokenClaims.email as string) ?? '';
   const name = (idTokenClaims.name as string) ?? null;
-  const subject = idTokenClaims.sub as string;
 
   // Upsert user
   const user = await deps.userRepo.upsertFromOidc({
@@ -140,6 +154,7 @@ export const Route = createFileRoute('/api/auth/callback')({
   server: {
     handlers: {
       GET: async ({ request }) => {
+        try {
         const { isAuthDisabled, loadAuthConfig } = await import('@/lib/config/auth-config');
         if (isAuthDisabled()) {
           return new Response(null, { status: 302, headers: { Location: '/' } });
@@ -181,7 +196,8 @@ export const Route = createFileRoute('/api/auth/callback')({
           request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
         const userAgent = request.headers.get('user-agent') ?? null;
 
-        const isSecure = !config.redirectUri.startsWith('http://localhost');
+        // Issue 2: Correct Secure flag logic — set when using HTTPS
+        const isSecure = config.redirectUri.startsWith('https://');
 
         return handleCallback(
           {
@@ -199,6 +215,13 @@ export const Route = createFileRoute('/api/auth/callback')({
           ipAddress,
           userAgent,
         );
+        } catch (err) {
+          console.error('[auth/callback] Unhandled error during callback:', err);
+          return new Response(null, {
+            status: 302,
+            headers: { Location: '/login?error=callback_failed' },
+          });
+        }
       },
     },
   },

--- a/src/routes/api/auth/callback.ts
+++ b/src/routes/api/auth/callback.ts
@@ -110,7 +110,7 @@ export async function handleCallback(
       status: 302,
       headers: {
         Location: '/denied',
-        'Set-Cookie': 'oidc_state=; HttpOnly; SameSite=Lax; Path=/api/auth; Max-Age=0',
+        'Set-Cookie': CLEAR_STATE_COOKIE,
       },
     });
   }

--- a/src/routes/api/auth/callback.ts
+++ b/src/routes/api/auth/callback.ts
@@ -2,8 +2,6 @@ import { createFileRoute } from '@tanstack/react-router';
 import type { OidcTokens, Role, RoleMappingConfig } from '@/lib/auth/types';
 import type { UserRow } from '@/lib/database/repositories/user-repository';
 
-// ----- Dependency interfaces -----
-
 export interface CallbackOidcClient {
   exchangeCode(code: string): Promise<OidcTokens>;
   getUserGroups(accessToken: string): Promise<string[]>;
@@ -38,8 +36,6 @@ export interface CallbackHandlerDeps {
   isSecure: boolean;
 }
 
-// ----- Cookie helpers (pure, testable) -----
-
 export function buildSessionCookie(rawToken: string, isSecure: boolean): string {
   const securePart = isSecure ? ' Secure;' : '';
   return `session=${encodeURIComponent(rawToken)}; HttpOnly;${securePart} SameSite=Lax; Path=/`;
@@ -47,8 +43,6 @@ export function buildSessionCookie(rawToken: string, isSecure: boolean): string 
 
 export const CLEAR_STATE_COOKIE =
   'oidc_state=; HttpOnly; SameSite=Lax; Path=/api/auth; Max-Age=0';
-
-// ----- Testable handler -----
 
 export async function handleCallback(
   deps: CallbackHandlerDeps,
@@ -147,8 +141,6 @@ export async function handleCallback(
     ],
   });
 }
-
-// ----- Route -----
 
 export const Route = createFileRoute('/api/auth/callback')({
   server: {

--- a/src/routes/api/auth/callback.ts
+++ b/src/routes/api/auth/callback.ts
@@ -1,0 +1,205 @@
+import { createFileRoute } from '@tanstack/react-router';
+import type { OidcTokens, Role, RoleMappingConfig } from '@/lib/auth/types';
+import type { UserRow } from '@/lib/database/repositories/user-repository';
+
+// ----- Dependency interfaces -----
+
+export interface CallbackOidcClient {
+  exchangeCode(code: string): Promise<OidcTokens>;
+  getUserGroups(accessToken: string): Promise<string[]>;
+}
+
+export interface CallbackUserRepo {
+  upsertFromOidc(input: {
+    oidcSubject: string;
+    email: string;
+    name: string | null;
+    role: string;
+    groups: string[];
+  }): Promise<UserRow>;
+}
+
+export interface CallbackSessionManager {
+  createSession(
+    userId: number,
+    tokens: OidcTokens,
+    ipAddress: string | null,
+    userAgent: string | null,
+  ): Promise<string>;
+}
+
+export interface CallbackHandlerDeps {
+  oidcClient: CallbackOidcClient;
+  extractIdTokenClaims: (idToken: string) => Record<string, unknown>;
+  mapGroupsToRole: (groups: string[], mapping: RoleMappingConfig) => Role | null;
+  userRepo: CallbackUserRepo;
+  sessionManager: CallbackSessionManager;
+  roleMapping: RoleMappingConfig;
+  isSecure: boolean;
+}
+
+// ----- Cookie helpers (pure, testable) -----
+
+export function buildSessionCookie(rawToken: string, isSecure: boolean): string {
+  const securePart = isSecure ? ' Secure;' : '';
+  return `session=${encodeURIComponent(rawToken)}; HttpOnly;${securePart} SameSite=Lax; Path=/`;
+}
+
+export const CLEAR_STATE_COOKIE =
+  'oidc_state=; HttpOnly; SameSite=Lax; Path=/api/auth; Max-Age=0';
+
+// ----- Testable handler -----
+
+export async function handleCallback(
+  deps: CallbackHandlerDeps,
+  code: string,
+  state: string,
+  cookieHeader: string,
+  ipAddress: string | null,
+  userAgent: string | null,
+): Promise<Response> {
+  // Validate state from cookie
+  const stateMatch = cookieHeader.match(/(?:^|;\s*)oidc_state=([^;]*)/);
+  if (!stateMatch) {
+    return new Response('Missing state cookie', { status: 400 });
+  }
+
+  let storedState: { state: string; nonce: string };
+  try {
+    storedState = JSON.parse(decodeURIComponent(stateMatch[1]));
+  } catch {
+    return new Response('Invalid state cookie', { status: 400 });
+  }
+
+  if (state !== storedState.state) {
+    return new Response('State mismatch', { status: 400 });
+  }
+
+  // Exchange code for tokens
+  const tokens = await deps.oidcClient.exchangeCode(code);
+
+  // Get groups from userinfo AND id_token claims (merge, deduplicate)
+  const userinfoGroups = await deps.oidcClient.getUserGroups(tokens.accessToken);
+  const idTokenClaims = deps.extractIdTokenClaims(tokens.idToken);
+  const idTokenGroups = Array.isArray(idTokenClaims.groups)
+    ? (idTokenClaims.groups as string[])
+    : [];
+  const allGroups = [...new Set([...userinfoGroups, ...idTokenGroups])];
+
+  // Map groups to role
+  const role = deps.mapGroupsToRole(allGroups, deps.roleMapping);
+
+  if (!role) {
+    return new Response(null, {
+      status: 302,
+      headers: {
+        Location: '/denied',
+        'Set-Cookie': 'oidc_state=; HttpOnly; SameSite=Lax; Path=/api/auth; Max-Age=0',
+      },
+    });
+  }
+
+  // Extract user info from id_token
+  const email = (idTokenClaims.email as string) ?? '';
+  const name = (idTokenClaims.name as string) ?? null;
+  const subject = idTokenClaims.sub as string;
+
+  // Upsert user
+  const user = await deps.userRepo.upsertFromOidc({
+    oidcSubject: subject,
+    email,
+    name,
+    role,
+    groups: allGroups,
+  });
+
+  // Create session
+  const rawSessionToken = await deps.sessionManager.createSession(
+    user.id,
+    tokens,
+    ipAddress,
+    userAgent,
+  );
+
+  // Set cookies: session cookie + clear oidc_state cookie
+  const sessionCookie = buildSessionCookie(rawSessionToken, deps.isSecure);
+
+  return new Response(null, {
+    status: 302,
+    headers: [
+      ['Location', '/'],
+      ['Set-Cookie', sessionCookie],
+      ['Set-Cookie', CLEAR_STATE_COOKIE],
+    ],
+  });
+}
+
+// ----- Route -----
+
+export const Route = createFileRoute('/api/auth/callback')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const { isAuthDisabled, loadAuthConfig } = await import('@/lib/config/auth-config');
+        if (isAuthDisabled()) {
+          return new Response(null, { status: 302, headers: { Location: '/' } });
+        }
+
+        const url = new URL(request.url);
+        const code = url.searchParams.get('code');
+        const state = url.searchParams.get('state');
+
+        if (!code || !state) {
+          return new Response('Missing code or state', { status: 400 });
+        }
+
+        const config = loadAuthConfig();
+        const { OidcClient } = await import('@/lib/auth/oidc-client');
+        const { getOidcClientSecret } = await import('@/lib/auth/oidc-secrets');
+        const { mapGroupsToRole } = await import('@/lib/auth/role-mapper');
+        const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+        const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+        const { UserRepository } = await import('@/lib/database/repositories/user-repository');
+        const { buildSessionManager } = await import('@/lib/auth/session-manager');
+
+        const clientSecret = await getOidcClientSecret();
+
+        const oidc = new OidcClient({
+          issuerUrl: config.issuerUrl,
+          clientId: config.clientId,
+          clientSecret,
+          redirectUri: config.redirectUri,
+        });
+
+        const dbConfig = loadDatabaseConfig();
+        const dbClient = await databaseConnectionManager.getClient(dbConfig);
+        const userRepo = new UserRepository(dbClient.getPool());
+        const sessionManager = await buildSessionManager();
+
+        const cookieHeader = request.headers.get('cookie') ?? '';
+        const ipAddress =
+          request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? null;
+        const userAgent = request.headers.get('user-agent') ?? null;
+
+        const isSecure = !config.redirectUri.startsWith('http://localhost');
+
+        return handleCallback(
+          {
+            oidcClient: oidc,
+            extractIdTokenClaims: OidcClient.extractIdTokenClaims,
+            mapGroupsToRole,
+            userRepo,
+            sessionManager,
+            roleMapping: config.roleMapping,
+            isSecure,
+          },
+          code,
+          state,
+          cookieHeader,
+          ipAddress,
+          userAgent,
+        );
+      },
+    },
+  },
+});

--- a/src/routes/api/auth/callback.ts
+++ b/src/routes/api/auth/callback.ts
@@ -116,7 +116,7 @@ export async function handleCallback(
   }
 
   // Extract user info from id_token
-  const name = (idTokenClaims.name as string) ?? null;
+  const name = typeof idTokenClaims.name === 'string' ? idTokenClaims.name : null;
 
   // Upsert user
   const user = await deps.userRepo.upsertFromOidc({

--- a/src/routes/api/auth/login.ts
+++ b/src/routes/api/auth/login.ts
@@ -1,0 +1,41 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { randomBytes } from 'crypto';
+
+export const Route = createFileRoute('/api/auth/login')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const { isAuthDisabled, loadAuthConfig } = await import('@/lib/config/auth-config');
+        if (isAuthDisabled()) {
+          return new Response(null, { status: 302, headers: { Location: '/' } });
+        }
+
+        const config = loadAuthConfig();
+        const { OidcClient } = await import('@/lib/auth/oidc-client');
+        const { getOidcClientSecret } = await import('@/lib/auth/oidc-secrets');
+        const clientSecret = await getOidcClientSecret();
+
+        const oidc = new OidcClient({
+          issuerUrl: config.issuerUrl,
+          clientId: config.clientId,
+          clientSecret,
+          redirectUri: config.redirectUri,
+        });
+
+        const state = randomBytes(32).toString('hex');
+        const nonce = randomBytes(32).toString('hex');
+        const url = await oidc.getAuthorizationUrl(state, nonce);
+
+        const stateCookie = `oidc_state=${encodeURIComponent(JSON.stringify({ state, nonce }))}; HttpOnly; SameSite=Lax; Path=/api/auth; Max-Age=600`;
+
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: url,
+            'Set-Cookie': stateCookie,
+          },
+        });
+      },
+    },
+  },
+});

--- a/src/routes/api/auth/login.ts
+++ b/src/routes/api/auth/login.ts
@@ -27,7 +27,9 @@ export const Route = createFileRoute('/api/auth/login')({
         const nonce = randomBytes(32).toString('hex');
         const url = await oidc.getAuthorizationUrl(state, nonce);
 
-        const stateCookie = `oidc_state=${encodeURIComponent(JSON.stringify({ state, nonce }))}; HttpOnly; SameSite=Lax; Path=/api/auth; Max-Age=600`;
+        const isSecure = config.redirectUri.startsWith('https://');
+        const secureFlag = isSecure ? '; Secure' : '';
+        const stateCookie = `oidc_state=${encodeURIComponent(JSON.stringify({ state, nonce }))}; HttpOnly; SameSite=Lax; Path=/api/auth; Max-Age=600${secureFlag}`;
 
         return new Response(null, {
           status: 302,

--- a/src/routes/api/auth/login.ts
+++ b/src/routes/api/auth/login.ts
@@ -5,6 +5,7 @@ export const Route = createFileRoute('/api/auth/login')({
   server: {
     handlers: {
       GET: async () => {
+        try {
         const { isAuthDisabled, loadAuthConfig } = await import('@/lib/config/auth-config');
         if (isAuthDisabled()) {
           return new Response(null, { status: 302, headers: { Location: '/' } });
@@ -35,6 +36,13 @@ export const Route = createFileRoute('/api/auth/login')({
             'Set-Cookie': stateCookie,
           },
         });
+        } catch (err) {
+          console.error('[auth/login] Unhandled error during login:', err);
+          return new Response(null, {
+            status: 302,
+            headers: { Location: '/login?error=login_failed' },
+          });
+        }
       },
     },
   },

--- a/src/routes/api/auth/logout.ts
+++ b/src/routes/api/auth/logout.ts
@@ -6,14 +6,17 @@ export const Route = createFileRoute('/api/auth/logout')({
     handlers: {
       GET: async ({ request }) => {
         const { isAuthDisabled, loadAuthConfig } = await import('@/lib/config/auth-config');
+        let isSecure = false;
         if (!isAuthDisabled()) {
+          const config = loadAuthConfig();
+          isSecure = config.redirectUri.startsWith('https://');
+
           // Extract session, delete from DB
           const cookieHeader = request.headers.get('cookie') ?? '';
           const match = cookieHeader.match(/(?:^|;\s*)session=([^;]*)/);
           const token = match ? decodeURIComponent(match[1]) : null;
 
           if (token) {
-            // Issue 8: Wrap revocation in try-catch so logout always clears the cookie
             try {
               const hashedId = createHash('sha256').update(token).digest('hex');
               const { buildSessionManager } = await import('@/lib/auth/session-manager');
@@ -25,9 +28,6 @@ export const Route = createFileRoute('/api/auth/logout')({
           }
         }
 
-        // Issue 9: Apply same Secure flag logic to the clear cookie
-        const config = loadAuthConfig();
-        const isSecure = config.redirectUri.startsWith('https://');
         const securePart = isSecure ? ' Secure;' : '';
 
         // Clear session cookie, redirect to login page

--- a/src/routes/api/auth/logout.ts
+++ b/src/routes/api/auth/logout.ts
@@ -1,0 +1,35 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { createHash } from 'crypto';
+
+export const Route = createFileRoute('/api/auth/logout')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        const { isAuthDisabled } = await import('@/lib/config/auth-config');
+        if (!isAuthDisabled()) {
+          // Extract session, delete from DB
+          const cookieHeader = request.headers.get('cookie') ?? '';
+          const match = cookieHeader.match(/(?:^|;\s*)session=([^;]*)/);
+          const token = match ? decodeURIComponent(match[1]) : null;
+
+          if (token) {
+            const hashedId = createHash('sha256').update(token).digest('hex');
+            const { buildSessionManager } = await import('@/lib/auth/session-manager');
+            const sessionManager = await buildSessionManager();
+            await sessionManager.revokeSession(hashedId);
+          }
+        }
+
+        // Clear session cookie, redirect to login page
+        const clearCookie = 'session=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0';
+        return new Response(null, {
+          status: 302,
+          headers: {
+            Location: '/login',
+            'Set-Cookie': clearCookie,
+          },
+        });
+      },
+    },
+  },
+});

--- a/src/routes/api/auth/logout.ts
+++ b/src/routes/api/auth/logout.ts
@@ -5,7 +5,7 @@ export const Route = createFileRoute('/api/auth/logout')({
   server: {
     handlers: {
       GET: async ({ request }) => {
-        const { isAuthDisabled } = await import('@/lib/config/auth-config');
+        const { isAuthDisabled, loadAuthConfig } = await import('@/lib/config/auth-config');
         if (!isAuthDisabled()) {
           // Extract session, delete from DB
           const cookieHeader = request.headers.get('cookie') ?? '';
@@ -13,15 +13,25 @@ export const Route = createFileRoute('/api/auth/logout')({
           const token = match ? decodeURIComponent(match[1]) : null;
 
           if (token) {
-            const hashedId = createHash('sha256').update(token).digest('hex');
-            const { buildSessionManager } = await import('@/lib/auth/session-manager');
-            const sessionManager = await buildSessionManager();
-            await sessionManager.revokeSession(hashedId);
+            // Issue 8: Wrap revocation in try-catch so logout always clears the cookie
+            try {
+              const hashedId = createHash('sha256').update(token).digest('hex');
+              const { buildSessionManager } = await import('@/lib/auth/session-manager');
+              const sessionManager = await buildSessionManager();
+              await sessionManager.revokeSession(hashedId);
+            } catch (err) {
+              console.error('[auth/logout] Failed to revoke session:', err);
+            }
           }
         }
 
+        // Issue 9: Apply same Secure flag logic to the clear cookie
+        const config = loadAuthConfig();
+        const isSecure = config.redirectUri.startsWith('https://');
+        const securePart = isSecure ? ' Secure;' : '';
+
         // Clear session cookie, redirect to login page
-        const clearCookie = 'session=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0';
+        const clearCookie = `session=; HttpOnly;${securePart} SameSite=Lax; Path=/; Max-Age=0`;
         return new Response(null, {
           status: 302,
           headers: {

--- a/src/routes/api/docker-logs.$containerId.ts
+++ b/src/routes/api/docker-logs.$containerId.ts
@@ -4,6 +4,12 @@ export const Route = createFileRoute('/api/docker-logs/$containerId')({
   server: {
     handlers: {
       GET: async ({ request, params }) => {
+        const { authenticateSSE } = await import('@/lib/auth/sse-auth');
+        const user = await authenticateSSE(request);
+        if (!user) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+
         const { containerId } = params;
         const url = new URL(request.url);
         const hostName = url.searchParams.get('host');

--- a/src/routes/api/git.$.ts
+++ b/src/routes/api/git.$.ts
@@ -1,5 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createHash, timingSafeEqual } from 'node:crypto';
+import type { AuthUser } from '@/lib/auth/types';
 
 function constantTimeEqual(a: string, b: string): boolean {
   const hashA = createHash('sha256').update(a).digest();
@@ -8,59 +9,135 @@ function constantTimeEqual(a: string, b: string): boolean {
 }
 
 /**
- * Authenticate git HTTP requests via Bearer token.
- * CRITICAL: Pushes can trigger auto-deploys, so this endpoint must be authenticated.
- * Uses GIT_SERVER_TOKEN env var. Returns null if authenticated, or an error Response.
+ * Extract the raw token from the Authorization header.
+ * Supports Bearer and Basic (password field) auth schemes.
+ * Returns null if the header is missing or uses an unsupported scheme.
  */
-function authenticateRequest(request: Request): Response | null {
-  const token = process.env.GIT_SERVER_TOKEN;
-  if (!token) {
-    return new Response('Git server token not configured', { status: 500 });
-  }
-
+function extractToken(request: Request): string | null {
   const authHeader = request.headers.get('Authorization');
-  if (!authHeader) {
-    return new Response('Unauthorized', {
-      status: 401,
-      headers: { 'WWW-Authenticate': 'Basic realm="git"' },
-    });
+  if (!authHeader) return null;
+
+  if (authHeader.startsWith('Bearer ')) {
+    return authHeader.slice('Bearer '.length);
   }
 
-  let providedToken: string;
-  if (authHeader.startsWith('Bearer ')) {
-    providedToken = authHeader.slice('Bearer '.length);
-  } else if (authHeader.startsWith('Basic ')) {
-    // Git sends Basic auth as base64(username:password); the token is the password
-    let decoded: string;
-    try {
-      decoded = atob(authHeader.slice('Basic '.length));
-    } catch {
-      return new Response('Malformed Basic auth encoding', {
-        status: 401,
-        headers: { 'WWW-Authenticate': 'Basic realm="Git", charset="UTF-8"' },
-      });
-    }
+  if (authHeader.startsWith('Basic ')) {
+    // Git sends Basic auth as base64(username:password) — the token is the password
+    const decoded = atob(authHeader.slice('Basic '.length));
     const colonIndex = decoded.indexOf(':');
-    providedToken = colonIndex >= 0 ? decoded.slice(colonIndex + 1) : decoded;
-  } else {
-    return new Response('Unauthorized', {
-      status: 401,
-      headers: { 'WWW-Authenticate': 'Basic realm="git"' },
-    });
-  }
-  if (!constantTimeEqual(providedToken, token)) {
-    return new Response('Forbidden', { status: 403 });
+    return colonIndex >= 0 ? decoded.slice(colonIndex + 1) : decoded;
   }
 
   return null;
+}
+
+/**
+ * Authenticate git HTTP requests using per-user git tokens.
+ * CRITICAL: Pushes can trigger auto-deploys, so this endpoint must be authenticated.
+ *
+ * Auth flow:
+ * 1. Extract token from Bearer or Basic auth
+ * 2. Load all git tokens from DB and decrypt via JWE keyring
+ * 3. Timing-safe compare against provided token
+ * 4. On match: resolve user, check role, update last_used_at
+ * 5. On no match: 403
+ *
+ * Returns the authenticated user on success, or a Response on failure.
+ */
+async function authenticateRequest(request: Request): Promise<AuthUser | Response> {
+  const providedToken = extractToken(request);
+
+  if (!providedToken) {
+    return new Response('Unauthorized', {
+      status: 401,
+      headers: { 'WWW-Authenticate': 'Basic realm="git"' },
+    });
+  }
+
+  const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+  const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+  const { GitTokenRepository } = await import(
+    '@/lib/database/repositories/git-token-repository'
+  );
+  const { UserRepository } = await import(
+    '@/lib/database/repositories/user-repository'
+  );
+  const { requireRole } = await import('@/lib/auth/require-role');
+  const { loadMasterKeyring } = await import('@/lib/crypto/master-key');
+  const { decryptValue } = await import('@/lib/crypto/encrypted-value');
+
+  const dbConfig = loadDatabaseConfig();
+  const dbClient = await databaseConnectionManager.getClient(dbConfig);
+  const pool = dbClient.getPool();
+
+  const gitTokenRepo = new GitTokenRepository(pool);
+  const userRepo = new UserRepository(pool);
+
+  const keyring = await loadMasterKeyring();
+  const encryptedTokens = await gitTokenRepo.findAllEncrypted();
+
+  let matchedTokenId: number | null = null;
+  let matchedUserId: number | null = null;
+
+  for (const tokenRecord of encryptedTokens) {
+    let decrypted: string;
+    try {
+      decrypted = await decryptValue(tokenRecord.encryptedToken, keyring);
+    } catch {
+      // Skip tokens that fail to decrypt (e.g., key rotation edge cases)
+      continue;
+    }
+
+    if (constantTimeEqual(providedToken, decrypted)) {
+      matchedTokenId = tokenRecord.id;
+      matchedUserId = tokenRecord.userId;
+      break;
+    }
+  }
+
+  if (matchedTokenId === null || matchedUserId === null) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const userRow = await userRepo.findById(matchedUserId);
+  if (!userRow) {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  const user: AuthUser = {
+    id: userRow.id,
+    email: userRow.email,
+    name: userRow.name,
+    role: userRow.role,
+  };
+
+  try {
+    requireRole('admin', 'operator')(user);
+  } catch {
+    return new Response('Forbidden', { status: 403 });
+  }
+
+  // Update last_used_at non-blocking — auth has already succeeded
+  gitTokenRepo.updateLastUsed(matchedTokenId).catch((err) => {
+    console.error(
+      `[GitAuth] Failed to update last_used_at for token ${matchedTokenId}:`,
+      err instanceof Error ? err.message : err,
+    );
+  });
+
+  return user;
 }
 
 export const Route = createFileRoute('/api/git/$')({
   server: {
     handlers: {
       GET: async ({ request }) => {
-        const authError = authenticateRequest(request);
-        if (authError) return authError;
+        if (process.env.DOCKER_MANAGEMENT_FEATURE_FLAG !== 'true') {
+          return new Response('Not Found', { status: 404 });
+        }
+
+        const authResult = await authenticateRequest(request);
+        if (authResult instanceof Response) return authResult;
 
         const { loadGitConfig } = await import('@/lib/config/git-config');
         const { parseGitPath, isGitInfoRefsRequest } = await import(
@@ -97,8 +174,12 @@ export const Route = createFileRoute('/api/git/$')({
       },
 
       POST: async ({ request }) => {
-        const authError = authenticateRequest(request);
-        if (authError) return authError;
+        if (process.env.DOCKER_MANAGEMENT_FEATURE_FLAG !== 'true') {
+          return new Response('Not Found', { status: 404 });
+        }
+
+        const authResult = await authenticateRequest(request);
+        if (authResult instanceof Response) return authResult;
 
         const { loadGitConfig } = await import('@/lib/config/git-config');
         const {

--- a/src/routes/api/git.$.ts
+++ b/src/routes/api/git.$.ts
@@ -22,10 +22,14 @@ function extractToken(request: Request): string | null {
   }
 
   if (authHeader.startsWith('Basic ')) {
-    // Git sends Basic auth as base64(username:password) — the token is the password
-    const decoded = atob(authHeader.slice('Basic '.length));
-    const colonIndex = decoded.indexOf(':');
-    return colonIndex >= 0 ? decoded.slice(colonIndex + 1) : decoded;
+    // Git sends Basic auth as base64(username:password), the token is the password
+    try {
+      const decoded = atob(authHeader.slice('Basic '.length));
+      const colonIndex = decoded.indexOf(':');
+      return colonIndex >= 0 ? decoded.slice(colonIndex + 1) : decoded;
+    } catch {
+      return null;
+    }
   }
 
   return null;

--- a/src/routes/api/git.$.ts
+++ b/src/routes/api/git.$.ts
@@ -78,13 +78,15 @@ async function authenticateRequest(request: Request): Promise<AuthUser | Respons
 
   let matchedTokenId: number | null = null;
   let matchedUserId: number | null = null;
+  let decryptFailures = 0;
 
   for (const tokenRecord of encryptedTokens) {
     let decrypted: string;
     try {
       decrypted = await decryptValue(tokenRecord.encryptedToken, keyring);
-    } catch {
-      // Skip tokens that fail to decrypt (e.g., key rotation edge cases)
+    } catch (error) {
+      decryptFailures++;
+      console.error(`[GitAuth] Failed to decrypt token ${tokenRecord.id}:`, error instanceof Error ? error.message : error);
       continue;
     }
 
@@ -93,6 +95,10 @@ async function authenticateRequest(request: Request): Promise<AuthUser | Respons
       matchedUserId = tokenRecord.userId;
       break;
     }
+  }
+
+  if (decryptFailures > 0 && decryptFailures === encryptedTokens.length) {
+    console.error(`[GitAuth] ALL ${decryptFailures} token(s) failed to decrypt — Transit may be unavailable`);
   }
 
   if (matchedTokenId === null || matchedUserId === null) {

--- a/src/routes/api/git.$.ts
+++ b/src/routes/api/git.$.ts
@@ -106,7 +106,11 @@ async function authenticateRequest(request: Request): Promise<AuthUser | Respons
   }
 
   if (matchedTokenId === null || matchedUserId === null) {
-    return new Response('Forbidden', { status: 403 });
+    // 401 lets git CLI re-prompt for credentials on token mismatch
+    return new Response('Unauthorized', {
+      status: 401,
+      headers: { 'WWW-Authenticate': 'Basic realm="git"' },
+    });
   }
 
   const userRow = await userRepo.findById(matchedUserId);

--- a/src/routes/denied.tsx
+++ b/src/routes/denied.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+import DeniedPage from '@/components/auth/DeniedPage';
+
+export const Route = createFileRoute('/denied')({
+  ssr: false,
+  component: DeniedPage,
+});

--- a/src/routes/login.tsx
+++ b/src/routes/login.tsx
@@ -1,0 +1,7 @@
+import { createFileRoute } from '@tanstack/react-router';
+import LoginPage from '@/components/auth/LoginPage';
+
+export const Route = createFileRoute('/login')({
+  ssr: false,
+  component: LoginPage,
+});

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -11,6 +11,8 @@ import {
 } from '@/hooks/useSettings'
 import PageTitle from '@/components/PageTitle'
 import { ManagedHostsCard } from '@/components/settings/ManagedHostsCardConnected'
+import { AuthManagementCard } from '@/components/settings/AuthManagementCard'
+import { useAuth } from '@/hooks/useAuth'
 import {
   CHART_WINDOW_MARKS,
   UPDATE_INTERVAL_MARKS,
@@ -46,6 +48,7 @@ function SettingsContent() {
   } = useGeneralSettings();
   const { docker, setMemoryDisplayMode, setChartWindowSeconds, setDockerDecimal } = useDockerSettings();
   const { zfs, setZfsDecimal } = useZfsSettings();
+  const { user } = useAuth();
   const hash = useLocation({ select: (l) => l.hash });
 
   useEffect(() => {
@@ -266,6 +269,8 @@ function SettingsContent() {
           <ManagedHostsCard />
         </div>
 
+        {user?.role === 'admin' && <AuthManagementCard />}
+
         <Card id="developer" variant="outlined" className="p-4 scroll-mt-20">
           <Typography variant="h6" className="mb-4">Developer</Typography>
           <div className="flex flex-col gap-4">
@@ -311,4 +316,3 @@ function SettingsContent() {
     </div>
   )
 }
-


### PR DESCRIPTION
## Summary

- Add OIDC authentication (targeting PocketID, compatible with any OIDC provider) with three fixed roles: Admin, Operator, Viewer
- Server-side PostgreSQL sessions with cookie-based auth; session OIDC tokens encrypted at rest via the existing JWE keyring (same `MASTER_KEY` used for stack secrets and agent keypairs)
- Per-user git tokens replacing shared `GIT_SERVER_TOKEN`, with deploy attribution to pushing user
- Admin UI for role mapping visibility, user management, session revocation, and git token management
- Auth is opt-in: no env vars needed to run without auth; set `AUTH_ENABLED=true` plus OIDC vars to enable

## Key Changes

- **Database**: Migration `023_auth_tables.sql` adds `users`, `sessions`, `git_tokens` tables
- **Auth middleware**: Injected into all server functions and SSE endpoints; bypassed when `AUTH_ENABLED` is not `"true"`
- **OIDC flow**: `/api/auth/login` → provider → `/api/auth/callback` with state/nonce validation
- **Role mapping**: OIDC groups → roles via env vars (`OIDC_ROLE_ADMIN`, etc.), highest privilege wins
- **Encryption**: Session OIDC tokens and git tokens encrypted at rest via `encryptValue` (JWE, existing keyring)
- **Login/Denied pages**: Render outside AppShell, conditional routing in `__root.tsx`
- **Admin card**: Added to settings page (gated to admin role) with users, sessions, git tokens tables

## Differences from original PR (#93)

- Rebased onto current main (28 commits ahead at time of rebase)
- Replaced OpenBao Transit with the existing JWE keyring (`MASTER_KEY`) for at-rest encryption; no new infrastructure dependency
- Migration renumbered to `023` (was `017` before intervening migrations landed)
- `AUTH_ENABLED=true` opt-in flag instead of `DISABLE_AUTH=true` opt-out; safe to merge before PocketID is configured
- Dropped `018_agent_token_transit.sql` (agent auth already uses Ed25519 keypairs from migration 022)

## Test Plan

- [ ] `bun run typecheck:all` passes
- [ ] `bun run test:all` passes
- [ ] Login flow works with PocketID (or any OIDC provider)
- [ ] Role mapping correctly assigns Admin/Operator/Viewer from OIDC groups
- [ ] Denied page shows when no group matches
- [ ] Session revocation forces re-auth
- [ ] App works normally with no `AUTH_ENABLED` set (auth off by default)
- [ ] SSE endpoints return 401 without valid session when `AUTH_ENABLED=true`
- [ ] Per-user git token auth works for push/pull
- [ ] Admin UI shows role mappings, users, sessions, git tokens
- [ ] Demo mode still works (`VITE_DEMO_MODE=true`)

## Env vars (all optional until `AUTH_ENABLED=true`)

```env
AUTH_ENABLED=true
OIDC_ISSUER_URL=https://pocketid.example.com
OIDC_CLIENT_ID=homelab-manager
OIDC_REDIRECT_URI=http://localhost:3000/api/auth/callback
SESSION_TTL_HOURS=8
OIDC_ROLE_ADMIN=homelab-admins
OIDC_ROLE_OPERATOR=homelab-operators
OIDC_ROLE_VIEWER=homelab-viewers
```

Closes #93

https://claude.ai/code/session_01XhF5uiJnbVYJraYC8G8yAH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OIDC login/logout flow with session creation and configurable session lifetime.
  * Role-based access control (admin, operator, viewer) enforcing UI and API permissions.
  * Admin settings: manage users, active sessions, and generate/revoke git tokens.
  * New login and access-denied pages with clear user guidance.
  * Git HTTP auth via per-user tokens (generation, last-used tracking).
  * SSE and API endpoints now require authentication where applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/jaredglaser/homelab-manager/pull/200)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->