### PR TITLE
style: replace hardcoded colors with design-system tokens

### DIFF
--- a/src/components/docker/ContainerStateChip.tsx
+++ b/src/components/docker/ContainerStateChip.tsx
@@ -21,7 +21,7 @@ function StateIndicator({ state }: { state: ContainerState }) {
   if (state === 'running') {
     return (
       <span
-        className="inline-block w-2 h-2 rounded-full bg-green-500"
+        className="inline-block w-2 h-2 rounded-full bg-(--indicator-active)"
         aria-label="running"
       />
     );
@@ -30,7 +30,7 @@ function StateIndicator({ state }: { state: ContainerState }) {
   if (state === 'restarting') {
     return (
       <span
-        className="inline-block w-2 h-2 rounded-full bg-yellow-400 animate-pulse"
+        className="inline-block w-2 h-2 rounded-full bg-(--mui-palette-warning-main) animate-pulse"
         aria-label="restarting"
       />
     );
@@ -39,7 +39,7 @@ function StateIndicator({ state }: { state: ContainerState }) {
   if (state === 'paused') {
     return (
       <span
-        className="inline-block w-2 h-2 rounded-full bg-yellow-400"
+        className="inline-block w-2 h-2 rounded-full bg-(--mui-palette-info-main)"
         aria-label="paused"
       />
     );
@@ -48,7 +48,7 @@ function StateIndicator({ state }: { state: ContainerState }) {
   if (state === 'exited' || state === 'dead') {
     return (
       <span
-        className="inline-block w-2 h-2 rounded-full bg-(--mui-palette-action-disabled)"
+        className="inline-block w-2 h-2 rounded-full bg-(--mui-palette-text-disabled)"
         aria-label={state}
       />
     );

--- a/src/components/docker/ContainerTable.tsx
+++ b/src/components/docker/ContainerTable.tsx
@@ -329,12 +329,12 @@ export default function ContainerTable({
 
   const rowClassName = useCallback((row: DockerTableRow) => {
     if (row.type === 'host') {
-      const base = row.isStale ? 'bg-amber-500/10!' : 'bg-(--mui-palette-background-level1)!';
+      const base = row.isStale ? 'bg-[var(--row-stale-tint)]!' : 'bg-(--mui-palette-background-level1)!';
       // scroll-mt clears the DataTable's sticky column header (~37px) when scrollIntoView is called
       return `${base} scroll-mt-10`;
     }
     if (row.isStale) {
-      return 'bg-amber-500/10! opacity-70!';
+      return 'bg-[var(--row-stale-tint)]! opacity-70!';
     }
     const { state } = row.inventory;
     if (state !== 'running' && state !== 'restarting') {

--- a/src/components/docker/HistoricalTimeline.tsx
+++ b/src/components/docker/HistoricalTimeline.tsx
@@ -129,10 +129,10 @@ export default memo(function HistoricalTimeline({
   const dateTimeFormat = general.use12HourTime ? 'MM/DD/YYYY hh:mm A' : 'MM/DD/YYYY HH:mm';
 
   return (
-    <div className="sticky bottom-0 z-10 border-t border-neutral-200 dark:border-neutral-700 bg-(--mui-palette-background-paper) px-4 py-3">
+    <div className="sticky bottom-0 z-10 border-t border-(--mui-palette-divider) bg-(--mui-palette-background-paper) px-4 py-3">
       <div className="flex items-center gap-3 mb-2 flex-wrap">
         <div className="flex items-center gap-2">
-          <Typography variant="caption" className="text-neutral-500">Range:</Typography>
+          <Typography variant="caption" className="text-(--mui-palette-text-secondary)">Range:</Typography>
           <ToggleButtonGroup
             value={activeRangeValue ? String(activeRangeValue.ms) : null}
             onChange={(_e, newValue) => {
@@ -151,7 +151,7 @@ export default memo(function HistoricalTimeline({
 
         <LocalizationProvider dateAdapter={AdapterDayjs}>
           <div className="flex items-center gap-2">
-            <Typography variant="caption" className="text-neutral-500">From:</Typography>
+            <Typography variant="caption" className="text-(--mui-palette-text-secondary)">From:</Typography>
             <DateTimePicker
               value={dayjs(timelineFrom)}
               onChange={handleFromChange}
@@ -162,7 +162,7 @@ export default memo(function HistoricalTimeline({
                 textField: { size: 'small' },
               }}
             />
-            <Typography variant="caption" className="text-neutral-500">To:</Typography>
+            <Typography variant="caption" className="text-(--mui-palette-text-secondary)">To:</Typography>
             <DateTimePicker
               value={dayjs(timelineTo)}
               onChange={handleToChange}
@@ -177,7 +177,7 @@ export default memo(function HistoricalTimeline({
         </LocalizationProvider>
 
         <div className="ml-auto flex items-center gap-2">
-          <Typography variant="caption" className="text-neutral-500">Metric:</Typography>
+          <Typography variant="caption" className="text-(--mui-palette-text-secondary)">Metric:</Typography>
           <ToggleButtonGroup
             value={timelineMetric}
             onChange={(_e, newValue) => {

--- a/src/components/docker/HostNameCell.tsx
+++ b/src/components/docker/HostNameCell.tsx
@@ -24,7 +24,7 @@ const HostNameCell = memo(function HostNameCell({
       )}
       <Server size={18} className="shrink-0" />
       {row.isStale && (
-        <WifiOff size={16} className="text-amber-600 dark:text-amber-400 shrink-0" />
+        <WifiOff size={16} className="text-(--indicator-late) shrink-0" />
       )}
       <span className="font-bold">{row.hostName}</span>
       {a.staleContainerCount > 0 && !row.isStale && (

--- a/src/components/proxmox/ClusterSummaryCards.tsx
+++ b/src/components/proxmox/ClusterSummaryCards.tsx
@@ -15,7 +15,7 @@ export default function ClusterSummaryCards({ overview }: ClusterSummaryCardsPro
   return (
     <div className="grid grid-cols-2 gap-4 mb-6 lg:grid-cols-4">
       <Card variant="outlined" className="p-4">
-        <Typography variant="caption" className="uppercase tracking-wide text-neutral-500">
+        <Typography variant="caption" className="uppercase tracking-wide text-(--mui-palette-text-secondary)">
           Cluster
         </Typography>
         <Typography variant="h5">{clusterName}</Typography>
@@ -25,7 +25,7 @@ export default function ClusterSummaryCards({ overview }: ClusterSummaryCardsPro
       </Card>
 
       <Card variant="outlined" className="p-4">
-        <Typography variant="caption" className="uppercase tracking-wide text-neutral-500">
+        <Typography variant="caption" className="uppercase tracking-wide text-(--mui-palette-text-secondary)">
           CPU
         </Typography>
         <Typography variant="h5">{cpuPercent.toFixed(1)}%</Typography>
@@ -35,7 +35,7 @@ export default function ClusterSummaryCards({ overview }: ClusterSummaryCardsPro
       </Card>
 
       <Card variant="outlined" className="p-4">
-        <Typography variant="caption" className="uppercase tracking-wide text-neutral-500">
+        <Typography variant="caption" className="uppercase tracking-wide text-(--mui-palette-text-secondary)">
           Memory
         </Typography>
         <Typography variant="h5">{memPercent.toFixed(1)}%</Typography>
@@ -45,7 +45,7 @@ export default function ClusterSummaryCards({ overview }: ClusterSummaryCardsPro
       </Card>
 
       <Card variant="outlined" className="p-4">
-        <Typography variant="caption" className="uppercase tracking-wide text-neutral-500">
+        <Typography variant="caption" className="uppercase tracking-wide text-(--mui-palette-text-secondary)">
           Guests
         </Typography>
         <Typography variant="h5">

--- a/src/components/proxmox/GuestCell.tsx
+++ b/src/components/proxmox/GuestCell.tsx
@@ -8,7 +8,7 @@ interface GuestCellProps {
 export const GuestCell = memo(function GuestCell({ vmid, name }: GuestCellProps) {
   return (
     <div className="flex items-center gap-2 truncate">
-      <span className="text-neutral-500 tabular-nums">{vmid}</span>
+      <span className="text-(--mui-palette-text-secondary) tabular-nums">{vmid}</span>
       <span className="truncate">{name}</span>
     </div>
   );

--- a/src/components/proxmox/GuestSection.tsx
+++ b/src/components/proxmox/GuestSection.tsx
@@ -18,7 +18,7 @@ interface GuestSectionProps {
   useAbbreviatedUnits: boolean;
 }
 
-const BORDER = 'border-t border-neutral-200 dark:border-neutral-700';
+const BORDER = 'border-t border-(--mui-palette-divider)';
 
 const metricGroups: MetricGroup[] = [
   { label: 'CPU / Memory', columnIds: ['cpu', 'memory'] },

--- a/src/components/proxmox/ProxmoxHostView.tsx
+++ b/src/components/proxmox/ProxmoxHostView.tsx
@@ -94,7 +94,7 @@ export default function ProxmoxHostView({ overview }: Readonly<ProxmoxHostViewPr
               onClick={() => toggleProxmoxHostExpanded(node.node)}
               onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleProxmoxHostExpanded(node.node); } }}
               className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors duration-150 ${
-                nodeIdx > 0 ? 'border-t border-neutral-200 dark:border-neutral-700' : ''
+                nodeIdx > 0 ? 'border-t border-(--mui-palette-divider)' : ''
               } ${hostExpanded ? 'bg-(--mui-palette-action-hover)' : 'bg-(--mui-palette-background-level2)'}`}
             >
               <ChevronRight
@@ -113,7 +113,7 @@ export default function ProxmoxHostView({ overview }: Readonly<ProxmoxHostViewPr
                 <span>CPU: {cpuPercent}%</span>
                 <span>Mem: {memPercent}%</span>
                 <span>Disk: {diskPercent}%</span>
-                <span className="text-neutral-500">
+                <span className="text-(--mui-palette-text-secondary)">
                   {node.status === 'online' ? formatUptime(node.uptime) : EMPTY_METRIC}
                 </span>
               </div>

--- a/src/components/proxmox/StorageCell.tsx
+++ b/src/components/proxmox/StorageCell.tsx
@@ -9,7 +9,7 @@ export const StorageCell = memo(function StorageCell({ name, type }: StorageCell
   return (
     <div className="flex items-center gap-2 truncate">
       <span className="truncate">{name}</span>
-      <span className="text-xs text-neutral-500">({type})</span>
+      <span className="text-xs text-(--mui-palette-text-secondary)">({type})</span>
     </div>
   );
 });

--- a/src/components/proxmox/StorageSection.tsx
+++ b/src/components/proxmox/StorageSection.tsx
@@ -17,7 +17,7 @@ interface StorageSectionProps {
   useAbbreviatedUnits: boolean;
 }
 
-const BORDER = 'border-t border-neutral-200 dark:border-neutral-700';
+const BORDER = 'border-t border-(--mui-palette-divider)';
 
 const metricGroups: MetricGroup[] = [
   { label: 'Used / Available', columnIds: ['used', 'available'] },

--- a/src/components/shared-table/DataTable.tsx
+++ b/src/components/shared-table/DataTable.tsx
@@ -265,7 +265,7 @@ export function DataTable<TRow>({
     return (
       <div ref={containerRef} className="flex flex-col flex-1 min-h-0">
         {toolbar}
-        <div className="flex items-center justify-center flex-1 text-neutral-500 dark:text-neutral-400 py-12">
+        <div className="flex items-center justify-center flex-1 text-(--mui-palette-text-secondary) py-12">
           No data
         </div>
       </div>
@@ -281,7 +281,7 @@ export function DataTable<TRow>({
         {/* Sticky header: inside scroll container so it tracks horizontal scroll */}
         {showHeader && (
           <div
-            className="grid border-b border-neutral-200 dark:border-neutral-700 bg-(--mui-palette-background-default) sticky top-0 z-10"
+            className="grid border-b border-(--mui-palette-divider) bg-(--mui-palette-background-default) sticky top-0 z-10"
             style={{ gridTemplateColumns: gridTemplate }}
           >
             {table.getHeaderGroups().map((headerGroup) =>
@@ -289,7 +289,7 @@ export function DataTable<TRow>({
                 <div
                   key={header.id}
                   className={`px-3 py-2 font-semibold text-sm whitespace-nowrap select-none ${
-                    header.column.getCanSort() ? 'cursor-pointer hover:bg-neutral-100 dark:hover:bg-neutral-800' : ''
+                    header.column.getCanSort() ? 'cursor-pointer hover:bg-(--mui-palette-action-hover)' : ''
                   }`}
                   onClick={header.column.getToggleSortingHandler()}
                   role={header.column.getCanSort() ? 'button' : undefined}
@@ -353,7 +353,7 @@ export function DataTable<TRow>({
                     const panel = renderDetailPanel(row.original);
                     if (panel == null || !isExpanded) return null;
                     return (
-                      <div className="border-t border-neutral-200 dark:border-neutral-700">
+                      <div className="border-t border-(--mui-palette-divider)">
                         {panel}
                       </div>
                     );
@@ -382,7 +382,7 @@ export function DataTable<TRow>({
                     if (panel == null) return null;
                     return (
                       <Collapse in={isExpanded} unmountOnExit timeout={300}>
-                        <div className="border-t border-neutral-200 dark:border-neutral-700">
+                        <div className="border-t border-(--mui-palette-divider)">
                           {panel}
                         </div>
                       </Collapse>
@@ -415,7 +415,7 @@ function DataTableRow<TRow>({ row, gridTemplate, rowClassName, rowAttributes, ha
     <div
       role={canExpand ? 'button' : undefined}
       tabIndex={canExpand ? 0 : undefined}
-      className={`group grid border-t border-neutral-200 dark:border-neutral-700 hover:bg-blue-500/5 hover:shadow-[inset_0_0_0_1px_rgba(59,130,246,0.3)] transition-[background-color,box-shadow] duration-150 ${canExpand ? 'cursor-pointer' : ''} ${customClass}`}
+      className={`group grid border-t border-(--mui-palette-divider) hover:bg-(--row-hover-tint) hover:shadow-[inset_0_0_0_1px_var(--row-hover-ring)] transition-[background-color,box-shadow] duration-150 ${canExpand ? 'cursor-pointer' : ''} ${customClass}`}
       style={{ gridTemplateColumns: gridTemplate }}
       onClick={canExpand ? () => row.toggleExpanded() : undefined}
       onKeyDown={canExpand ? (e) => { if (e.target !== e.currentTarget) return; if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); row.toggleExpanded(); } } : undefined}

--- a/src/components/shared-table/MetricCell.tsx
+++ b/src/components/shared-table/MetricCell.tsx
@@ -71,7 +71,7 @@ export const MetricCell = memo(function MetricCell({
         {value}
       </span>
 
-      <span className={`${unitWidth} min-w-0 text-left text-xs font-mono text-neutral-500 dark:text-neutral-400 transition-opacity duration-200 ${staleClass}`}>
+      <span className={`${unitWidth} min-w-0 text-left text-xs font-mono text-(--mui-palette-text-secondary) transition-opacity duration-200 ${staleClass}`}>
         {displayUnit}
       </span>
     </div>

--- a/src/components/shared-table/columns.tsx
+++ b/src/components/shared-table/columns.tsx
@@ -149,7 +149,7 @@ export function progressColumn<TRow>(opts: {
               color={color}
             />
           </div>
-          <span className="shrink-0 min-w-[5ch] text-right text-xs tabular-nums text-neutral-600 dark:text-neutral-300">
+          <span className="shrink-0 min-w-[5ch] text-right text-xs tabular-nums text-(--mui-palette-text-secondary)">
             {label}
           </span>
         </div>

--- a/src/routes/proxmox.tsx
+++ b/src/routes/proxmox.tsx
@@ -150,7 +150,7 @@ function ProxmoxContent({ onOverviewChange }: Readonly<ProxmoxContentProps>) {
           <Typography variant="body1" className="mb-2">
             Proxmox is not configured.
           </Typography>
-          <Typography variant="body2" className="text-neutral-500">
+          <Typography variant="body2" className="text-(--mui-palette-text-secondary)">
             Set the following environment variables to connect to your Proxmox cluster:
           </Typography>
           <pre className="mt-3 p-4 bg-(--mui-palette-background-level1) rounded-lg text-sm font-mono">

--- a/src/routes/settings.tsx
+++ b/src/routes/settings.tsx
@@ -84,7 +84,7 @@ function SettingsContent() {
                 <FormLabel>Update Interval</FormLabel>
                 <Typography variant="body2" className="font-mono">{formatUpdateInterval(general.updateIntervalMs)}</Typography>
               </div>
-              <Typography variant="caption" className="text-neutral-500 mb-3 block">
+              <Typography variant="caption" className="text-(--mui-palette-text-secondary) mb-3 block">
                 Controls how frequently stats are collected and displayed (requires worker restart)
               </Typography>
               <Slider
@@ -114,7 +114,7 @@ function SettingsContent() {
 
             <FormControl>
               <FormLabel>Light Mode Palette</FormLabel>
-              <Typography variant="caption" className="text-neutral-500 mb-2 block">
+              <Typography variant="caption" className="text-(--mui-palette-text-secondary) mb-2 block">
                 Background color palette used in light mode
               </Typography>
               <Select
@@ -157,7 +157,7 @@ function SettingsContent() {
                   {formatChartWindow(docker.chartWindowSeconds)}
                 </Typography>
               </div>
-              <Typography variant="caption" className="text-neutral-500 mb-3 block">
+              <Typography variant="caption" className="text-(--mui-palette-text-secondary) mb-3 block">
                 Time range shown in the expanded container metric charts
               </Typography>
               <Slider
@@ -211,7 +211,7 @@ function SettingsContent() {
                 <FormLabel>Raw Data</FormLabel>
                 <Typography variant="body2" className="font-mono">{formatHours(retention.rawDataHours)}</Typography>
               </div>
-              <Typography variant="caption" className="text-neutral-500 mb-3 block">
+              <Typography variant="caption" className="text-(--mui-palette-text-secondary) mb-3 block">
                 Second-level data is downsampled to minute averages after this period
               </Typography>
               <Slider
@@ -229,7 +229,7 @@ function SettingsContent() {
                 <FormLabel>Minute Aggregates</FormLabel>
                 <Typography variant="body2" className="font-mono">{formatDays(retention.minuteAggDays)}</Typography>
               </div>
-              <Typography variant="caption" className="text-neutral-500 mb-3 block">
+              <Typography variant="caption" className="text-(--mui-palette-text-secondary) mb-3 block">
                 Minute averages are downsampled to hourly averages after this period
               </Typography>
               <Slider
@@ -247,7 +247,7 @@ function SettingsContent() {
                 <FormLabel>Hour Aggregates</FormLabel>
                 <Typography variant="body2" className="font-mono">{formatDays(retention.hourAggDays)}</Typography>
               </div>
-              <Typography variant="caption" className="text-neutral-500 mb-3 block">
+              <Typography variant="caption" className="text-(--mui-palette-text-secondary) mb-3 block">
                 Hourly averages are downsampled to daily averages after this period. Daily data is kept forever.
               </Typography>
               <Slider
@@ -272,7 +272,7 @@ function SettingsContent() {
             <div className="flex justify-between items-center">
               <div>
                 <FormLabel>Docker Debug Logging</FormLabel>
-                <Typography variant="caption" className="text-neutral-500 block">
+                <Typography variant="caption" className="text-(--mui-palette-text-secondary) block">
                   Log connection lifecycle, stream events, and collection timing
                 </Typography>
               </div>
@@ -284,7 +284,7 @@ function SettingsContent() {
             <div className="flex justify-between items-center">
               <div>
                 <FormLabel>Database Flush Logging</FormLabel>
-                <Typography variant="caption" className="text-neutral-500 block">
+                <Typography variant="caption" className="text-(--mui-palette-text-secondary) block">
                   Log batch flush counts and database write timing
                 </Typography>
               </div>
@@ -296,7 +296,7 @@ function SettingsContent() {
             <div className="flex justify-between items-center">
               <div>
                 <FormLabel>SSE Pipeline Logging</FormLabel>
-                <Typography variant="caption" className="text-neutral-500 block">
+                <Typography variant="caption" className="text-(--mui-palette-text-secondary) block">
                   Log NOTIFY reception, cache updates, and SSE event emission
                 </Typography>
               </div>


### PR DESCRIPTION
## Summary

- State indicator dots in `ContainerStateChip` now use semantic CSS vars instead of hardcoded Tailwind colors. Paused is now correctly blue (info.main), not amber; restarting uses warning.main; running uses `--indicator-active`; exited/dead use `--mui-palette-text-disabled`.
- All `border-neutral-200 dark:border-neutral-700` instances replaced with `border-(--mui-palette-divider)` across DataTable, HistoricalTimeline, GuestSection, StorageSection, and ProxmoxHostView.
- DataTable row hover switched from hardcoded `rgba(59,130,246,...)` to `var(--row-hover-tint)` / `var(--row-hover-ring)` so the ring adapts correctly in light mode.
- Sortable column header hover uses `--mui-palette-action-hover` (was `neutral-100/800`).
- Stale row tints use `var(--row-stale-tint)` (was `bg-amber-500/10`).
- Stale `WifiOff` icon in HostNameCell uses `text-(--indicator-late)` (was `text-amber-600 dark:text-amber-400`).
- Secondary/caption text across MetricCell, columns, Proxmox, and settings routes uses `text-(--mui-palette-text-secondary)` (was `text-neutral-500/400/600`).

15 files changed, 40 insertions, 40 deletions. All mechanical class substitutions, no logic changes.

## Test plan

- [ ] Docker table: container state chips show correct colors (green running, orange restarting, blue paused, muted exited)
- [ ] Docker table: stale host row shows amber tint, WifiOff icon in amber
- [ ] Docker table: row hover shows correct tint and ring in both dark and light mode
- [ ] Sortable column headers: hover shows neutral action-hover tint
- [ ] Proxmox: node separator borders visible in both light and dark mode
- [ ] MetricCell: unit labels readable in secondary text color
- [ ] CI passes

https://claude.ai/code/session_012FYtJcZmyGNqUjp4S3rKhh