### PR TITLE
docs: fix inaccuracies, document auth, align docs with code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,7 +82,7 @@ bun run test:coverage:all     # Run tests in both with coverage enforcement
 - **Framework:** TanStack Start (SPA mode, SSR disabled) + React 19
 - **Runtime:** Bun (pinned in `.bun-version`; package manager, test runner, runtime)
 - **Language:** TypeScript (strict mode, `noUnusedLocals`, `noUnusedParameters`)
-- **UI:** MUI Material UI v7 (components) + TailwindCSS v4 (styling, via `@tailwindcss/vite` plugin - no config file)
+- **UI:** MUI Material UI v9 (components) + TailwindCSS v4 (styling, via `@tailwindcss/vite` plugin - no config file)
 - **State:** Jotai (settings atoms) + TanStack Query
 - **Streaming:** SSE via TanStack Router server routes
 - **Charts:** Apache ECharts
@@ -153,6 +153,10 @@ Separate Bun package that runs as a sidecar container alongside Docker hosts. Pr
 
 The agent is intentionally NOT a workspace member of the homelab-manager `package.json`: its `agent/bun.lock` is the only lockfile the docker build (`context: ./agent`) sees, and workspace membership would mask drift by routing local `bun install` to the homelab-manager lockfile. Web/worker import only types from the agent via the TS path alias `@homelab-manager/agent/*` (resolved at compile time, no runtime dependency). Run `bun run setup` for a full install.
 
+### Authentication (`src/lib/auth/`)
+
+Optional OIDC login, gated by `AUTH_ENABLED=true`. When enabled, `/api/auth/login`, `/api/auth/callback`, and `/api/auth/logout` handle the OIDC handshake; sessions are issued as signed cookies with TTL from `SESSION_TTL_HOURS`. OIDC group claims map to three roles (`admin`, `operator`, `viewer`) via `OIDC_ROLE_ADMIN`/`OPERATOR`/`VIEWER` env vars. `require-role.ts` guards server functions; `sse-auth.ts` authenticates SSE endpoints. `agent-token-migration.ts` migrates legacy agent tokens on startup. UI routes: `src/routes/login.tsx`, `src/routes/denied.tsx`. Designed to pair with Pocket ID but works with any OIDC provider. When `AUTH_ENABLED=false` (default), all routes are open: keep the dashboard on a trusted network.
+
 ### Deploy Pipeline (`src/lib/deploy/`)
 
 Trigger-agnostic orchestration: `DeployRequest` → validate → resolve secrets → dispatch to agent → record result. Uses `GitTriggerBuilder` (post-receive) or `UITriggerBuilder` (UI actions). Concurrency enforced via PostgreSQL partial unique index. Stuck deploys recovered on startup and via `DeployWatchdog` (default 10-min threshold) so a crashed process can't leave `in_progress` rows stranded.
@@ -170,15 +174,15 @@ Hypertables: `docker_stats`, `zfs_stats`, `proxmox_stats`, `docker_container_eve
 Encrypted columns (`stack_secrets.ciphertext_jwe`, `agent_keypairs.private_jwk_jwe`) use a versioned keyring so a new master key can be enrolled without breaking existing ciphertext.
 
 **Env var patterns:**
-- `MASTER_KEY` / `MASTER_KEY_FILE` — single-key legacy pattern, treated as KID `v1`.
-- `MASTER_KEY_<KID>` / `MASTER_KEY_FILE_<KID>` — additional keys, e.g. `MASTER_KEY_v2=<base64>`.
+- `MASTER_KEY` / `MASTER_KEY_FILE`: single-key legacy pattern, treated as KID `v1`.
+- `MASTER_KEY_<KID>` / `MASTER_KEY_FILE_<KID>`: additional keys, e.g. `MASTER_KEY_v2=<base64>`.
 
 The lexicographically last KID is used for new encryptions; all loaded keys are available for decryption.
 
 **Rotation procedure:**
 1. Generate a new key: `openssl rand -base64 32`
 2. Add it alongside the old key: set `MASTER_KEY_v2=<new-base64>` (keep `MASTER_KEY`/`MASTER_KEY_v1` in place).
-3. Restart the app — new secrets encrypt under `v2`, old secrets still decrypt via `v1`.
+3. Restart the app: new secrets encrypt under `v2`, old secrets still decrypt via `v1`.
 4. Run the migration CLI to re-encrypt existing rows:
 
    ```bash

--- a/README.md
+++ b/README.md
@@ -47,17 +47,18 @@ Homelab Manager is a **one-stop-shop dashboard** for monitoring and managing Doc
 
 ## Quick Start
 
+The fastest path is the pre-built Docker images. Download the compose file and a `.env`, then bring it up:
+
 ```bash
-# Clone and start the full stack
-git clone https://github.com/jaredglaser/homelab-manager.git
-cd homelab-manager
-cp .env.example .env          # Edit with your host details
-docker compose up -d          # Start TimescaleDB, web, and worker
+mkdir homelab-manager && cd homelab-manager
+curl -O https://raw.githubusercontent.com/jaredglaser/homelab-manager/main/self-hosting/docker-compose.yml
+# Create a .env with POSTGRES_* and MASTER_KEY (see self-hosting guide)
+docker compose up -d
 ```
 
-Open http://localhost:3000
+Open http://localhost:3000.
 
-For development setup, see the [Development Guide](docs/development.md).
+Full instructions: [Self-Hosting Guide](self-hosting/README.md). For local development setup (source checkout, HMR, sample data), see the [Development Guide](docs/development.md).
 
 ## Roadmap
 
@@ -72,7 +73,7 @@ For development setup, see the [Development Guide](docs/development.md).
 - [x] Agent-updater sidecar for automatic container updates
 - [x] Pre-built Docker image on a container registry
 - [x] Live demo deployed to GitHub Pages
-- [ ] Authentication (OIDC with Pocket ID support)
+- [~] Authentication (OIDC with Pocket ID support): code landed in `src/lib/auth/` and gated by `AUTH_ENABLED`; integration docs pending
 - [ ] Return to TanStack Start streaming server functions (pending upstream abort signal fix)
 
 ## AI Disclosure

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -332,7 +332,7 @@ stacks:
 At-rest encryption uses a symmetric `MASTER_KEY` (base64, 256-bit) resolved at startup from the `MASTER_KEY` env var or `MASTER_KEY_FILE`.
 
 - **Stack secrets** (`stack_secrets` table): name/value pairs stored as JWE-encrypted blobs. The deploy pipeline resolves `${SECRET:name}` references in compose files before dispatching to agents (`src/lib/crypto/encrypted-value.ts`)
-- **Agent keypairs** (`agent_keypairs` table): per-host Ed25519 keypairs. The private JWK is stored JWE-encrypted; the public JWK is sent to the agent at enrollment and written to `AGENT_TRUSTED_PUBKEY_FILE`. Each deploy request carries a short-lived JWT signed by the private key (`src/lib/crypto/agent-jwt.ts`)
+- **Agent keypairs** (`agent_keypairs` table): per-host Ed25519 keypairs. The private JWK is stored JWE-encrypted; the public JWK is injected into the agent container as the `AGENT_TRUSTED_PUBKEY` env var when the dashboard provisions the agent (`src/lib/services/agent-provisioning-service.ts`). The dev compose flow writes the JWK to `data/dev-agent-pubkey.json` and the agent loads it via `AGENT_TRUSTED_PUBKEY_FILE`. Each deploy request carries a short-lived JWT signed by the private key (`src/lib/crypto/agent-jwt.ts`)
 - `src/lib/crypto/master-key.ts` handles key resolution and exports the AES-GCM key object used by the JWE helpers
 
 ### Stacks UI

--- a/docs/development.md
+++ b/docs/development.md
@@ -206,9 +206,10 @@ Tests use [Bun's built-in test runner](https://bun.sh/docs/cli/test), organized 
 
 ```bash
 # homelab-manager only
-bun test --isolate          # Run homelab-manager tests (enforces coverage thresholds)
+bun test --isolate          # Run homelab-manager tests (no coverage enforcement)
 bun test --isolate --watch  # Watch mode (no coverage enforcement)
-bun run test:coverage       # Coverage report only
+bun run test                # Tests + coverage enforcement (95% functions / 98% lines)
+bun run test:coverage       # Coverage report only (no enforcement)
 
 # Agent only
 bun run test:agent          # Run agent tests
@@ -223,7 +224,7 @@ bun run test:coverage:all   # Run tests in both with coverage thresholds
 
 - Minimum **95% function coverage**
 - Minimum **98% line coverage**
-- Automatically enforced by `bun test` and CI
+- Enforced by `bun run test` (which pipes `--coverage` to `scripts/check-coverage.js`) and CI. Bare `bun test --isolate` does NOT enforce the thresholds.
 
 Test files use `*.test.ts` naming in `__tests__/` directories co-located with source (e.g., `src/lib/__tests__/stream-utils.test.ts`).
 

--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -193,6 +193,15 @@ src/
 │   │   └── agent-stack-compose.ts   # Generate agent docker-compose.yml for host deployment
 │   ├── hosts/
 │   │   └── host-utils.ts            # Host utility functions
+│   ├── auth/
+│   │   ├── oidc-client.ts            # OIDC discovery + authorization-code flow client
+│   │   ├── oidc-secrets.ts           # OIDC client secret resolution
+│   │   ├── session-manager.ts       # Signed-cookie session issue/verify (TTL from SESSION_TTL_HOURS)
+│   │   ├── role-mapper.ts            # OIDC group claim -> admin/operator/viewer role
+│   │   ├── require-role.ts           # Server-function guard by role
+│   │   ├── sse-auth.ts               # SSE endpoint authentication helper
+│   │   ├── agent-token-migration.ts # One-shot migration of legacy agent tokens at startup
+│   │   └── types.ts                  # Auth domain types (Session, Role, OIDCClaims)
 │   ├── settings/
 │   │   └── settings-broadcast-service.ts  # PostgreSQL LISTEN + SSE broadcast for settings changes
 │   ├── sse/
@@ -257,7 +266,13 @@ src/
     │   ├── proxmox-stats.ts         # Proxmox SSE endpoint
     │   ├── settings.ts              # Settings SSE endpoint (cross-browser sync)
     │   ├── stack-status.ts          # Stack status SSE endpoint
+    │   ├── auth/
+    │   │   ├── login.ts             # OIDC login redirect (initiates auth code flow)
+    │   │   ├── callback.ts          # OIDC callback (issues session cookie)
+    │   │   └── logout.ts            # Clears session cookie
     │   └── git.$.ts                 # Git HTTP smart protocol (catch-all route)
+    ├── login.tsx                    # Login landing page (/login)
+    ├── denied.tsx                   # Access-denied page (/denied)
     ├── index.tsx                    # Home/redirect page (/)
     ├── docker.tsx                   # Docker page (/docker)
     ├── docker.$containerId.tsx      # Docker container detail (/docker/:containerId)
@@ -273,7 +288,7 @@ src/
 src/theme.ts                         # MUI Material theme config
 public/icons/                        # SVG icons from homarr-labs/dashboard-icons
 migrations/                          # SQL migrations (settings + TimescaleDB wide tables + stack status + deploys)
-scripts/                             # check-coverage.js, download-icons.ts, download-compose-schema.ts
+scripts/                             # check-coverage.js, download-icons.ts, download-compose-schema.ts, migrate-master-key.ts, test-perf.sh
 
 agent/                               # Agent sidecar container (separate Bun package)
 ├── src/
@@ -293,6 +308,11 @@ agent/                               # Agent sidecar container (separate Bun pac
 ├── Dockerfile
 ├── package.json
 └── tsconfig.json
+
+server/                              # WebSocket / non-SSR API routes outside TanStack Router
+└── routes/
+    └── api/
+        └── docker-exec/[containerId].ts  # WebSocket-style exec passthrough to agent for container terminal
 
 agent-updater/                       # Agent updater sidecar (separate Bun package)
 ├── src/

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -14,6 +14,8 @@
 | **Crypto** | [jose](https://github.com/panva/jose) | JWE at-rest encryption for stack secrets and per-agent private keys; Ed25519 JWT signing for agent auth |
 | **Code Editor** | [Monaco Editor](https://microsoft.github.io/monaco-editor/) + [monaco-yaml](https://github.com/remcohaszing/monaco-yaml) | In-app YAML editor for Docker Compose files with schema validation |
 | **Database** | [TimescaleDB](https://www.timescale.com/) | PostgreSQL with automatic compression and indefinite retention for time-series data |
+| **DB Driver** | [node-postgres (`pg`)](https://node-postgres.com/) | PostgreSQL client used by the web server and worker for queries, LISTEN/NOTIFY, and connection pooling |
+| **Server Runtime** | [Nitro](https://nitro.build/) | Server engine under TanStack Start (pinned to a nightly build via `nitro-nightly`) |
 | **Validation** | [Zod](https://zod.dev) | Schema validation |
 | **Charts** | [Apache ECharts](https://echarts.apache.org/) | Interactive charts - sparklines, dual-series, and historical metric charts |
 | **Terminal** | [xterm.js](https://xtermjs.org/) | Container log viewer with live SSE streaming |

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -85,7 +85,7 @@ All configuration is done via environment variables in your `.env` file.
 | `POSTGRES_DB` | Database name |
 | `POSTGRES_USER` | Database user |
 | `POSTGRES_PASSWORD` | Database password |
-| `MASTER_KEY` | Base64-encoded 256-bit key for at-rest encryption of stack secrets and agent keypairs. Generate with `openssl rand -base64 32`. Use `MASTER_KEY_FILE` (path to a file containing the base64 string) as an alternative for secrets-managed deployments. For key rotation, add `MASTER_KEY_<KID>` (e.g. `MASTER_KEY_v2`) alongside the old key and re-encrypt with `bun run migrate-secrets --from v1 --to v2`. |
+| `MASTER_KEY` or `MASTER_KEY_FILE` | Base64-encoded 256-bit key for at-rest encryption of stack secrets and agent keypairs. Set exactly one: `MASTER_KEY` inline, or `MASTER_KEY_FILE` pointing at a file containing the base64 string. Generate with `openssl rand -base64 32`. For key rotation, add `MASTER_KEY_<KID>` (e.g. `MASTER_KEY_v2`) alongside the old key and re-encrypt with `bun run migrate-secrets --from v1 --to v2`. |
 
 ### Web Server
 

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -85,7 +85,7 @@ All configuration is done via environment variables in your `.env` file.
 | `POSTGRES_DB` | Database name |
 | `POSTGRES_USER` | Database user |
 | `POSTGRES_PASSWORD` | Database password |
-| `MASTER_KEY` | Base64-encoded 256-bit key for at-rest encryption of stack secrets and agent keypairs. Generate with `openssl rand -base64 32`. |
+| `MASTER_KEY` | Base64-encoded 256-bit key for at-rest encryption of stack secrets and agent keypairs. Generate with `openssl rand -base64 32`. Use `MASTER_KEY_FILE` (path to a file containing the base64 string) as an alternative for secrets-managed deployments. For key rotation, add `MASTER_KEY_<KID>` (e.g. `MASTER_KEY_v2`) alongside the old key and re-encrypt with `bun run migrate-secrets --from v1 --to v2`. |
 
 ### Web Server
 
@@ -144,6 +144,31 @@ Stack management lets you deploy and manage Docker Compose stacks on your hosts 
 | `POSTGRES_SSL` | `false` | Enable TLS for the PostgreSQL connection |
 | `POSTGRES_SSL_REJECT_UNAUTHORIZED` | `true` | Verify the server's TLS certificate. Set to `false` only for self-signed certificates. This disables chain validation and exposes the connection to MITM attacks. |
 | `POSTGRES_POOL_SIZE` | `10` | Database connection pool size |
+
+### Authentication (optional, OIDC)
+
+Off by default. Set `AUTH_ENABLED=true` to require login via an OIDC provider (designed and tested with [Pocket ID](https://github.com/stonith404/pocket-id), but works with any OIDC issuer). With auth disabled, the dashboard still relies on network isolation (see the warning above).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTH_ENABLED` | `false` | Require OIDC login for all routes and SSE streams |
+| `OIDC_ISSUER_URL` | - | OIDC discovery URL (e.g. `https://pocketid.example.com`) |
+| `OIDC_CLIENT_ID` | - | OIDC client ID registered with your provider |
+| `OIDC_CLIENT_SECRET` | - | OIDC client secret |
+| `OIDC_REDIRECT_URI` | - | Public callback URL, e.g. `https://homelab.example.com/api/auth/callback` |
+| `SESSION_TTL_HOURS` | `8` | Session cookie lifetime |
+| `OIDC_ROLE_ADMIN` | `homelab-admins` | OIDC group claim that maps to the `admin` role |
+| `OIDC_ROLE_OPERATOR` | `homelab-operators` | OIDC group claim that maps to the `operator` role |
+| `OIDC_ROLE_VIEWER` | `homelab-viewers` | OIDC group claim that maps to the `viewer` role |
+
+If you prefer to keep auth at the proxy layer instead (tinyauth + Pocket ID), leave `AUTH_ENABLED=false`. See the [Authentication layer](#reverse-proxy) note above.
+
+### Deploy Watchdog (optional)
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DEPLOY_WATCHDOG_INTERVAL_MS` | `120000` | How often to scan for stuck deploys |
+| `DEPLOY_WATCHDOG_TIMEOUT_MINUTES` | `10` | Deploys still `in_progress` past this threshold are failed |
 
 ### Worker Behavior
 


### PR DESCRIPTION
## Summary

Repo-wide documentation review. Each finding was verified against the actual codebase before editing. Seven files updated; no source code changes.

## Changes by file

### `README.md`
- **Quick Start was broken.** It told users to `docker compose up -d` from a fresh clone, but the repo root has no `docker-compose.yml` (only `docker-compose.local.yml` for dev, which needs `--env-file`). New users would fail immediately. Rewrote the Quick Start to point at `self-hosting/docker-compose.yml` (the actually-published path), with a pointer to the development guide for source builds.
- **Roadmap was out of date on auth.** Auth was checked as not started, but `src/lib/auth/` exists with OIDC client, session manager, role mapper, SSE auth, login/callback/logout routes, migration `023_auth_tables.sql`, and `AUTH_ENABLED`/`OIDC_*` env vars in `.env.example`. Marked it in-progress and pointed at the code location.

### `CLAUDE.md`
- **Rule 15 self-violation: em dashes.** Lines 173, 174, and 181 used `—` despite rule 15 banning them. Replaced with colons.
- **MUI version was wrong.** Said "MUI Material UI v7"; `package.json` pins `@mui/material: 9.0.0`. Updated to v9.
- **No mention of the auth subsystem.** Added an `### Authentication (src/lib/auth/)` section to the Architecture block describing `AUTH_ENABLED`, the OIDC handshake routes, session cookies / `SESSION_TTL_HOURS`, role mapping, `require-role.ts`, `sse-auth.ts`, the agent-token migration, and the `login.tsx`/`denied.tsx` routes.

### `docs/architecture.md`
- **Agent pubkey mechanism was inaccurate.** Said the public JWK is "sent to the agent at enrollment and written to `AGENT_TRUSTED_PUBKEY_FILE`". Actual behavior (verified in `agent/src/index.ts` and `src/lib/services/agent-provisioning-service.ts`): the dashboard injects `AGENT_TRUSTED_PUBKEY=<jwk>` as an env var into the agent container at provisioning time. The `*_FILE` variant is only used by the dev compose flow (`HOMELAB_DEV_SEED` writes `data/dev-agent-pubkey.json`, mounted into the agent). Rewrote the bullet to describe both paths accurately.

### `docs/development.md`
- **Misleading coverage claim.** The doc said `bun test --isolate` "enforces coverage thresholds". It does not — coverage is enforced by `bun run test`, which pipes `--coverage` to `scripts/check-coverage.js`. Updated the command table to show `bun run test` as the enforcing variant and added a note under Coverage Requirements clarifying that bare `bun test --isolate` does not enforce thresholds.

### `docs/project-structure.md`
- **Missing `src/lib/auth/`.** The tree omitted the whole auth directory. Added entries for `oidc-client.ts`, `oidc-secrets.ts`, `session-manager.ts`, `role-mapper.ts`, `require-role.ts`, `sse-auth.ts`, `agent-token-migration.ts`, `types.ts`.
- **Missing auth routes / pages.** Added `src/routes/api/auth/{login,callback,logout}.ts` and the `login.tsx` / `denied.tsx` top-level routes.
- **Missing `server/` directory.** `server/routes/api/docker-exec/[containerId].ts` exists (WebSocket exec passthrough for the container terminal) but was not in the tree. Added a top-level `server/` entry.
- **`scripts/` listing was incomplete.** Added `migrate-master-key.ts` and `test-perf.sh` alongside the three previously listed scripts.

### `docs/tech-stack.md`
- **Missing `pg` (node-postgres).** It's the DB driver used throughout the web/worker for queries and LISTEN/NOTIFY; was documented in CLAUDE.md but absent from the tech stack table.
- **Missing Nitro.** `package.json` pins `nitro-nightly` as a direct dependency; worth a row since it's the server engine under TanStack Start.

### `self-hosting/README.md`
- **`MASTER_KEY` row didn't mention `MASTER_KEY_FILE` or rotation.** Both are documented in CLAUDE.md and `.env.example` but were absent from the operator-facing config table. Extended the row to cover the file variant and pointed at `bun run migrate-secrets` for rotation.
- **No auth section.** `.env.example` documents `AUTH_ENABLED`, `OIDC_*`, `SESSION_TTL_HOURS`, and `OIDC_ROLE_*`, but operators reading `self-hosting/README.md` had no way to discover them. Added an "Authentication (optional, OIDC)" section with the full env var table, plus a cross-reference to the proxy-layer tinyauth + Pocket ID approach already mentioned above.
- **No deploy watchdog section.** `DEPLOY_WATCHDOG_INTERVAL_MS` and `DEPLOY_WATCHDOG_TIMEOUT_MINUTES` are in `.env.example` but were absent here. Added a small table.

## Findings reviewed but intentionally not changed

- **Sample-stack walkthrough duplicated between `docs/development.md` Step 3 and `docs/git-stacks-repo.md`.** Some duplication, but the contexts are different (one is "first-time dev setup with seed data", the other is "stacks repo reference"). Left both; consolidating would lose context in one of them.
- **Self-hosting / development AGENT_TRUSTED_PUBKEY wording.** Self-hosting says "sends the public JWK to the agent" and development.md describes the dev volume-mount path. Both are accurate as written; only `architecture.md` was wrong and has been fixed.
- **CLAUDE.md commands block omitting `migrate-secrets`, `schema:download`, etc.** The block already states it isn't exhaustive and `migrate-secrets` is mentioned in the Key Rotation procedure where it's relevant. Not worth bloating the quick-reference.

## Verification

All claims in the diff were checked against the codebase:
- `package.json` for MUI/`pg`/Nitro versions and the actual `test` vs `test:coverage` script bodies.
- `agent/src/index.ts` + `src/lib/services/agent-provisioning-service.ts` for the AGENT_TRUSTED_PUBKEY mechanism.
- `src/lib/auth/`, `src/routes/api/auth/`, `src/routes/login.tsx`, `src/routes/denied.tsx`, `server/routes/api/docker-exec/` directory listings for project-structure additions.
- `.env.example` for the env var names and defaults added to self-hosting docs.
- Grep for em dashes (`—`) and rule-15 banned vocabulary across all edits; only the rule definition itself in CLAUDE.md still contains em dashes (as examples of what's banned).

## Test plan

- [ ] Render README.md on GitHub and confirm the Quick Start block reads cleanly.
- [ ] Confirm `docs/project-structure.md` tree still parses as readable (no broken indentation).
- [ ] Spot-check the new "Authentication (optional, OIDC)" section against `.env.example` to confirm env var names and defaults match.
- [ ] Confirm `bun run test` vs `bun test --isolate` distinction in `docs/development.md` matches `package.json`.

https://claude.ai/code/session_01RKpcyP8uV7EJaZ9DbanJ4M

---
_Generated by [Claude Code](https://claude.ai/code/session_01RKpcyP8uV7EJaZ9DbanJ4M)_