### PR TITLE
fix(ci): remove invalid cache input from setup-bun in deploy-demo job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,8 +324,6 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile


### PR DESCRIPTION
## Summary

- Remove `with: cache: true` from the `oven-sh/setup-bun@v2` step in the Deploy Demo to GitHub Pages job

`oven-sh/setup-bun@v2` does not accept a `cache` input (valid inputs: `bun-version`, `bun-version-file`, `bun-download-url`, `no-cache`, `token`, etc.). The unexpected input caused the deploy-demo job to exit with an error, blocking GitHub Pages deployment.

## Test plan

- [ ] CI passes the Deploy Demo to GitHub Pages job without the unexpected-input error

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1zqBtYaJSDvqARB2JVYrR)_