### PR TITLE
fix(demo): export controlStack mock to unblock demo build

### DIFF
--- a/src/lib/mock/functions/stacks.functions.tsx
+++ b/src/lib/mock/functions/stacks.functions.tsx
@@ -429,3 +429,17 @@ export async function ensureVariablesExist(_opts: {
 }): Promise<void> {
   // No-op in demo mode
 }
+
+export async function controlStack(_opts: {
+  data:
+    | { host: string; stack: string; action: 'start' | 'stop' | 'restart'; scope: 'stack' }
+    | {
+        host: string;
+        stack: string;
+        action: 'start' | 'stop' | 'restart';
+        scope: 'service';
+        service: string;
+      };
+}): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+}


### PR DESCRIPTION
## Summary

- Add a `controlStack` mock to `src/lib/mock/functions/stacks.functions.tsx` so the demo build resolves the import added by the new Containers tab

`StackContainersPanel.tsx` imports `controlStack` from `@/data/stacks/functions`. In demo mode, Vite aliases that module to the mock at `src/lib/mock/functions/stacks.functions.tsx`, which was missing the export. `build:demo` failed with `[MISSING_EXPORT] "controlStack" is not exported`, blocking the Deploy Demo to GitHub Pages job on main.

The mock is a no-op that mirrors the real input shape (discriminated union on `scope`).

## Test plan

- [x] `bun run build:demo` succeeds locally
- [ ] CI Deploy Demo to GitHub Pages job passes

---
_Generated by [Claude Code](https://claude.ai/code/session_01X1zqBtYaJSDvqARB2JVYrR)_