### PR TITLE
fix(scripts): fix download-compose-schema to fetch from main branch

### DIFF
--- a/scripts/download-compose-schema.ts
+++ b/scripts/download-compose-schema.ts
@@ -10,25 +10,39 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 
-async function resolveRef(): Promise<string> {
-  if (process.env.COMPOSE_SPEC_REF) return process.env.COMPOSE_SPEC_REF;
-  const res = await fetch('https://api.github.com/repos/compose-spec/compose-spec/tags?per_page=1', {
-    headers: { Accept: 'application/vnd.github+json' },
-  });
-  if (!res.ok) throw new Error(`Failed to resolve latest tag: ${res.status} ${res.statusText}`);
-  const [{ name }] = await res.json() as { name: string }[];
-  return name;
-}
-
-const ref = await resolveRef();
-const SCHEMA_URL = `https://raw.githubusercontent.com/compose-spec/compose-spec/${ref}/schema/compose-spec.json`;
+const REQUEST_TIMEOUT_MS = 10_000;
 const OUTPUT_DIR = './src/lib/schemas';
 const OUTPUT_PATH = `${OUTPUT_DIR}/compose-spec.json`;
 
-async function downloadComposeSchema() {
-  console.info(`Fetching Compose schema (${ref}) from ${SCHEMA_URL}...`);
+async function fetchWithTimeout(input: string, init: RequestInit = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
 
-  const response = await fetch(SCHEMA_URL);
+async function resolveRef(): Promise<string> {
+  if (process.env.COMPOSE_SPEC_REF) return process.env.COMPOSE_SPEC_REF;
+  const res = await fetchWithTimeout('https://api.github.com/repos/compose-spec/compose-spec/tags?per_page=1', {
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) throw new Error(`Failed to resolve latest tag: ${res.status} ${res.statusText}`);
+  const tags = (await res.json()) as unknown;
+  if (!Array.isArray(tags) || tags.length === 0 || typeof tags[0]?.name !== 'string') {
+    throw new Error('Failed to resolve latest tag: unexpected tags payload');
+  }
+  return tags[0].name;
+}
+
+async function downloadComposeSchema() {
+  const ref = await resolveRef();
+  const schemaUrl = `https://raw.githubusercontent.com/compose-spec/compose-spec/${ref}/schema/compose-spec.json`;
+  console.info(`Fetching Compose schema (${ref}) from ${schemaUrl}...`);
+
+  const response = await fetchWithTimeout(schemaUrl);
   if (!response.ok) {
     throw new Error(`Failed to fetch schema: ${response.status} ${response.statusText}`);
   }

--- a/scripts/download-compose-schema.ts
+++ b/scripts/download-compose-schema.ts
@@ -10,14 +10,23 @@
 import { writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
 
-const COMPOSE_SPEC_REF = process.env.COMPOSE_SPEC_REF ?? 'v2.4.0';
-const SCHEMA_URL =
-  `https://raw.githubusercontent.com/compose-spec/compose-spec/${COMPOSE_SPEC_REF}/schema/compose-spec.json`;
+async function resolveRef(): Promise<string> {
+  if (process.env.COMPOSE_SPEC_REF) return process.env.COMPOSE_SPEC_REF;
+  const res = await fetch('https://api.github.com/repos/compose-spec/compose-spec/tags?per_page=1', {
+    headers: { Accept: 'application/vnd.github+json' },
+  });
+  if (!res.ok) throw new Error(`Failed to resolve latest tag: ${res.status} ${res.statusText}`);
+  const [{ name }] = await res.json() as { name: string }[];
+  return name;
+}
+
+const ref = await resolveRef();
+const SCHEMA_URL = `https://raw.githubusercontent.com/compose-spec/compose-spec/${ref}/schema/compose-spec.json`;
 const OUTPUT_DIR = './src/lib/schemas';
 const OUTPUT_PATH = `${OUTPUT_DIR}/compose-spec.json`;
 
 async function downloadComposeSchema() {
-  console.info(`Fetching Compose schema from ${SCHEMA_URL}...`);
+  console.info(`Fetching Compose schema (${ref}) from ${SCHEMA_URL}...`);
 
   const response = await fetch(SCHEMA_URL);
   if (!response.ok) {

--- a/scripts/download-compose-schema.ts
+++ b/scripts/download-compose-schema.ts
@@ -14,6 +14,13 @@ const REQUEST_TIMEOUT_MS = 10_000;
 const OUTPUT_DIR = './src/lib/schemas';
 const OUTPUT_PATH = `${OUTPUT_DIR}/compose-spec.json`;
 
+function makeHeaders(): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (process.env.GITHUB_TOKEN) headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+  return headers;
+}
+
+// Native fetch has no built-in timeout; without this wrapper, the script hangs indefinitely in CI if GitHub is slow or unresponsive.
 async function fetchWithTimeout(input: string, init: RequestInit = {}) {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
@@ -24,25 +31,12 @@ async function fetchWithTimeout(input: string, init: RequestInit = {}) {
   }
 }
 
-async function resolveRef(): Promise<string> {
-  if (process.env.COMPOSE_SPEC_REF) return process.env.COMPOSE_SPEC_REF;
-  const res = await fetchWithTimeout('https://api.github.com/repos/compose-spec/compose-spec/tags?per_page=1', {
-    headers: { Accept: 'application/vnd.github+json' },
-  });
-  if (!res.ok) throw new Error(`Failed to resolve latest tag: ${res.status} ${res.statusText}`);
-  const tags = (await res.json()) as unknown;
-  if (!Array.isArray(tags) || tags.length === 0 || typeof tags[0]?.name !== 'string') {
-    throw new Error('Failed to resolve latest tag: unexpected tags payload');
-  }
-  return tags[0].name;
-}
-
 async function downloadComposeSchema() {
-  const ref = await resolveRef();
+  const ref = process.env.COMPOSE_SPEC_REF ?? 'main';
   const schemaUrl = `https://raw.githubusercontent.com/compose-spec/compose-spec/${ref}/schema/compose-spec.json`;
   console.info(`Fetching Compose schema (${ref}) from ${schemaUrl}...`);
 
-  const response = await fetchWithTimeout(schemaUrl);
+  const response = await fetchWithTimeout(schemaUrl, { headers: makeHeaders() });
   if (!response.ok) {
     throw new Error(`Failed to fetch schema: ${response.status} ${response.statusText}`);
   }


### PR DESCRIPTION
## Summary

- The script was hardcoded to `v2.4.0`, which is not a valid tag in the compose-spec repo, causing `bun run schema:download` to always fail with 404
- Attempted to resolve the latest tag dynamically via GitHub API, but compose-spec has no tags or releases -- the API returns an empty array
- Now defaults to `main` (the only stable ref the repo exposes) instead of erroring
- `COMPOSE_SPEC_REF` env var overrides the ref when a specific commit or branch is needed
- `GITHUB_TOKEN` env var is used when set, to avoid GitHub rate limits in CI

## Test plan

- [ ] Run `bun run schema:download` and confirm it exits cleanly and writes the schema
- [ ] Run `COMPOSE_SPEC_REF=<commit-sha> bun run schema:download` and confirm it uses the pinned ref

---
_Generated by [Claude Code](https://claude.ai/code)_