### PR TITLE
fix(sse): handle broadcast error events in useEventSource consumers

### DIFF
--- a/src/hooks/__tests__/useDockerInventory.test.ts
+++ b/src/hooks/__tests__/useDockerInventory.test.ts
@@ -362,4 +362,18 @@ describe('useDockerInventory', () => {
     expect(result.current.inventory.has('server1/abc123')).toBe(true);
     expect(result.current.inventory.has('server2/abc123')).toBe(true);
   });
+
+  it('surfaces inventory_error events and clears the error on next data', () => {
+    const { result } = renderHook(() => useDockerInventory());
+    const es = MockEventSource.instances[0];
+
+    act(() => { es.onopen?.(); });
+    act(() => { es.fireEvent('inventory_error'); });
+
+    expect(result.current.error?.message).toBe('Inventory stream unavailable');
+
+    act(() => { sendEvent(es, { type: 'init', containers: [] }); });
+
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/src/hooks/__tests__/useEventSource.test.ts
+++ b/src/hooks/__tests__/useEventSource.test.ts
@@ -253,6 +253,32 @@ describe('useEventSource', () => {
     expect(onServiceError).toHaveBeenCalledTimes(1);
   });
 
+  it('calls onServiceError for a custom errorEventName', () => {
+    const onServiceError = mock(() => {});
+    renderHook(() =>
+      useEventSource({ url: '/api/settings', onData: () => {}, onServiceError, errorEventName: 'settings_error' })
+    );
+
+    const es = MockEventSource.instances[0];
+    act(() => { es.onopen?.(); });
+    act(() => { es.fireEvent('settings_error'); });
+
+    expect(onServiceError).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not listen for stats_error when a custom errorEventName is set', () => {
+    const onServiceError = mock(() => {});
+    renderHook(() =>
+      useEventSource({ url: '/api/settings', onData: () => {}, onServiceError, errorEventName: 'settings_error' })
+    );
+
+    const es = MockEventSource.instances[0];
+    act(() => { es.onopen?.(); });
+    act(() => { es.fireEvent('stats_error'); });
+
+    expect(onServiceError).not.toHaveBeenCalled();
+  });
+
   it('processes multiple messages sequentially', () => {
     const received: unknown[] = [];
     const onData = mock((data: unknown) => { received.push(data); });

--- a/src/hooks/__tests__/useSettingsSync.test.ts
+++ b/src/hooks/__tests__/useSettingsSync.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { renderHook, act } from '@testing-library/react';
+import { useAtomValue } from 'jotai';
+import { MockEventSource } from '@/lib/test/mock-event-source';
+import { useSettingsSync } from '../useSettingsSync';
+import { rawSettingsAtom } from '../settingsAtom';
+
+const originalEventSource = globalThis.EventSource;
+
+beforeEach(() => {
+  MockEventSource.reset();
+  (globalThis as unknown as Record<string, unknown>).EventSource = MockEventSource;
+});
+
+afterEach(() => {
+  (globalThis as unknown as Record<string, unknown>).EventSource = originalEventSource;
+});
+
+function useHarness() {
+  useSettingsSync();
+  return useAtomValue(rawSettingsAtom);
+}
+
+describe('useSettingsSync', () => {
+  it('subscribes to /api/settings EventSource', () => {
+    renderHook(() => useHarness());
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe('/api/settings');
+  });
+
+  it('replaces all settings on init and merges single keys on change', () => {
+    const { result } = renderHook(() => useHarness());
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.onopen?.();
+      es.onmessage?.({ data: JSON.stringify({ type: 'init', settings: { a: '1', b: '2' } }) });
+    });
+    expect(result.current).toEqual({ a: '1', b: '2' });
+
+    act(() => {
+      es.onmessage?.({ data: JSON.stringify({ type: 'change', key: 'b', value: '3' }) });
+    });
+    expect(result.current).toEqual({ a: '1', b: '3' });
+  });
+
+  it('logs settings_error events from the server', () => {
+    const origError = console.error;
+    const errorMock = mock((..._args: unknown[]) => {});
+    console.error = errorMock;
+
+    try {
+      renderHook(() => useHarness());
+      const es = MockEventSource.instances[0];
+
+      act(() => { es.onopen?.(); });
+      act(() => { es.fireEvent('settings_error'); });
+
+      expect(errorMock).toHaveBeenCalledWith('[useSettingsSync] Settings stream failed on the server');
+    } finally {
+      console.error = origError;
+    }
+  });
+});

--- a/src/hooks/__tests__/useStackStatus.test.ts
+++ b/src/hooks/__tests__/useStackStatus.test.ts
@@ -122,6 +122,24 @@ describe('useStackStatus', () => {
     expect(result.current.statusMap.has('server2/plex')).toBe(true);
   });
 
+  it('surfaces stack_status_error events and clears the error on next data', () => {
+    const { result } = renderHook(() => useStackStatus());
+    const es = MockEventSource.instances[0];
+
+    act(() => { es.onopen?.(); });
+    act(() => { es.fireEvent('stack_status_error'); });
+
+    expect(result.current.error).toBe('Stack status stream unavailable');
+
+    act(() => {
+      es.onmessage?.({
+        data: JSON.stringify([{ stack: 'plex', host: 'server1', containers: [], updated_at: '2026-03-21T00:00:00Z' }]),
+      });
+    });
+
+    expect(result.current.error).toBeNull();
+  });
+
   it('cleans up EventSource on unmount', () => {
     const { unmount } = renderHook(() => useStackStatus());
     const es = MockEventSource.instances[0];

--- a/src/hooks/useDockerInventory.ts
+++ b/src/hooks/useDockerInventory.ts
@@ -28,8 +28,10 @@ function mergeUpsert(
 
 export function useDockerInventory(): UseDockerInventoryResult {
   const [inventory, setInventory] = useState<Map<string, DockerInventorySnapshotContainer>>(new Map());
+  const [serviceError, setServiceError] = useState<Error | null>(null);
 
   const handleData = useCallback((event: DockerInventoryBroadcastEvent) => {
+    setServiceError(null);
     if (event.type === 'init') {
       const next = new Map<string, DockerInventorySnapshotContainer>();
       for (const container of event.containers) {
@@ -55,10 +57,16 @@ export function useDockerInventory(): UseDockerInventoryResult {
     }
   }, []);
 
+  const handleServiceError = useCallback(() => {
+    setServiceError(new Error('Inventory stream unavailable'));
+  }, []);
+
   const { isConnected, error } = useEventSource<DockerInventoryBroadcastEvent>({
     url: apiUrl('/api/docker-inventory'),
     onData: handleData,
+    onServiceError: handleServiceError,
+    errorEventName: 'inventory_error',
   });
 
-  return { inventory, isConnected, error };
+  return { inventory, isConnected, error: error ?? serviceError };
 }

--- a/src/hooks/useEventSource.ts
+++ b/src/hooks/useEventSource.ts
@@ -14,6 +14,13 @@ interface UseEventSourceOptions<T> {
    * use this to backfill the gap left by a dropped connection.
    */
   onReconnect?: () => void;
+  /**
+   * Named SSE event that signals a server-side failure for this stream.
+   * Stats endpoints emit `stats_error` (the default); broadcast endpoints
+   * emit per-route names (`settings_error`, `inventory_error`,
+   * `stack_status_error`) that consumers must pass explicitly.
+   */
+  errorEventName?: string;
   debug?: boolean;
 }
 
@@ -32,6 +39,7 @@ export function useEventSource<T>({
   onData,
   onServiceError,
   onReconnect,
+  errorEventName = 'stats_error',
   debug = false,
 }: UseEventSourceOptions<T>): UseEventSourceResult {
   const [isConnected, setIsConnected] = useState(false);
@@ -106,7 +114,7 @@ export function useEventSource<T>({
         }
       };
 
-      eventSource.addEventListener('stats_error', () => {
+      eventSource.addEventListener(errorEventName, () => {
         if (mounted) onServiceErrorRef.current?.();
       });
 
@@ -178,7 +186,7 @@ export function useEventSource<T>({
         eventSourceRef.current = null;
       }
     };
-  }, [url, debug]);
+  }, [url, errorEventName, debug]);
 
   return { isConnected, error };
 }

--- a/src/hooks/useSettingsSync.ts
+++ b/src/hooks/useSettingsSync.ts
@@ -24,8 +24,14 @@ export function useSettingsSync(): void {
     }
   }, [setRaw]);
 
+  const handleServiceError = useCallback(() => {
+    console.error('[useSettingsSync] Settings stream failed on the server');
+  }, []);
+
   useEventSource<SettingsSSEMessage>({
     url: apiUrl('/api/settings'),
     onData: handleData,
+    onServiceError: handleServiceError,
+    errorEventName: 'settings_error',
   });
 }

--- a/src/hooks/useStackStatus.ts
+++ b/src/hooks/useStackStatus.ts
@@ -30,8 +30,10 @@ function shallowEqualContainers(
 export function useStackStatus() {
   const [statusMap, setStatusMap] = useState<Map<string, StackStatusEntry>>(new Map());
   const [deployVersion, setDeployVersion] = useState(0);
+  const [serviceError, setServiceError] = useState<Error | null>(null);
 
   const handleData = useCallback((data: StackSSEMessage) => {
+    setServiceError(null);
     if (isDeployChanged(data)) {
       setDeployVersion((v) => v + 1);
       return;
@@ -51,10 +53,16 @@ export function useStackStatus() {
     });
   }, []);
 
+  const handleServiceError = useCallback(() => {
+    setServiceError(new Error('Stack status stream unavailable'));
+  }, []);
+
   const { isConnected, error } = useEventSource<StackSSEMessage>({
     url: apiUrl('/api/stack-status'),
     onData: handleData,
+    onServiceError: handleServiceError,
+    errorEventName: 'stack_status_error',
   });
 
-  return { statusMap, isConnected, error: error?.message ?? null, deployVersion };
+  return { statusMap, isConnected, error: (error ?? serviceError)?.message ?? null, deployVersion };
 }


### PR DESCRIPTION
## Summary

`useEventSource` only registered a listener for the hard-coded `stats_error` named SSE event. The broadcast SSE factory (`createBroadcastSseHandler`) emits configurable per-route error events (`settings_error`, `inventory_error`, `stack_status_error`) when `loadSubscribe()` rejects, so those frames reached the browser but no client code handled them and a failed subscription stalled silently.

Changes:

- `src/hooks/useEventSource.ts`: new `errorEventName` option, defaulting to `stats_error` so existing stats consumers (`useTimeSeriesStream`) are unchanged. The effect re-subscribes if the name changes.
- `src/hooks/useDockerInventory.ts`: listens for `inventory_error`, exposes it through the returned `error` (`Inventory stream unavailable`), and clears it when data resumes.
- `src/hooks/useStackStatus.ts`: same pattern for `stack_status_error` (`Stack status stream unavailable`).
- `src/hooks/useSettingsSync.ts`: listens for `settings_error` and logs via `console.error` (the hook returns void and has no error surface).
- Tests added for the new option in `useEventSource` (custom name fires, default name no longer fires when overridden) and for each consumer hook, including a new `useSettingsSync` test file covering init/change merging and the error path.

## Testing

- `bun run typecheck:all`: pass.
- `bun test --isolate src/hooks/__tests__/useEventSource.test.ts src/hooks/__tests__/useDockerInventory.test.ts src/hooks/__tests__/useStackStatus.test.ts src/hooks/__tests__/useSettingsSync.test.ts src/hooks/__tests__/useTimeSeriesStream.test.ts`: 62 pass, 0 fail.
- `bun test --isolate src/hooks`: 247 pass, 2 fail; the 2 failures (`useSettings.test.ts` rollback cases) reproduce identically without this branch's changes and are an environment artifact: the machine has bun 1.3.6 while `.bun-version` pins 1.3.13, and `--isolate` does not isolate module mocks on 1.3.6, so cross-file mock leakage breaks unrelated suites in multi-file runs. Each affected file passes in isolation. CI on the pinned bun should be green.

Closes #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)
