### PR TITLE
fix(agent): cap per-container Docker stat stream fan-out

### DIFF
--- a/agent/src/__tests__/stats.test.ts
+++ b/agent/src/__tests__/stats.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test, mock, beforeAll } from 'bun:test';
 import { EventEmitter } from 'node:events';
-import { handleStatsStream, computeMetrics, type StatsStreamOptions, type ComputedStats } from '../routes/stats';
+import { handleStatsStream, computeMetrics, resolveMaxStatStreams, type StatsStreamOptions, type ComputedStats } from '../routes/stats';
 
 beforeAll(() => {
   console.error = mock(() => {});
@@ -622,5 +622,111 @@ describe('handleStatsStream: container refresh', () => {
     expect(text).toContain('event: container-error');
     expect(text).toContain('"type":"refresh_failed"');
     expect(text).toContain('"error":"Docker daemon down"');
+  });
+});
+
+describe('resolveMaxStatStreams', () => {
+  test('defaults to 300 when env var is unset', () => {
+    expect(resolveMaxStatStreams(undefined)).toBe(300);
+  });
+
+  test('parses a valid integer', () => {
+    expect(resolveMaxStatStreams('50')).toBe(50);
+  });
+
+  test('falls back to default for non-numeric values', () => {
+    expect(resolveMaxStatStreams('abc')).toBe(300);
+  });
+
+  test('falls back to default for zero or negative values', () => {
+    expect(resolveMaxStatStreams('0')).toBe(300);
+    expect(resolveMaxStatStreams('-5')).toBe(300);
+  });
+
+  test('falls back to default for non-integer values', () => {
+    expect(resolveMaxStatStreams('1.5')).toBe(300);
+  });
+});
+
+describe('handleStatsStream: stat stream cap', () => {
+  test('streams only the first maxStatStreams containers and emits stream-cap-exceeded', async () => {
+    const containers = [
+      { Id: 'cap1', Names: ['/one'], Image: 'a:latest' },
+      { Id: 'cap2', Names: ['/two'], Image: 'b:latest' },
+      { Id: 'cap3', Names: ['/three'], Image: 'c:latest' },
+    ];
+    const requestedIds: string[] = [];
+
+    const mockDocker = {
+      listContainers: mock(() => Promise.resolve(containers)),
+      getContainer: mock((id: string) => {
+        requestedIds.push(id);
+        return { stats: mock(() => Promise.resolve(new EventEmitter())) };
+      }),
+    };
+
+    const ac = new AbortController();
+    const request = new Request('http://localhost/stats/stream', { signal: ac.signal });
+    const response = handleStatsStream(mockDocker as any, request, { maxStatStreams: 2 });
+
+    const text = await readUntil(response, (s) =>
+      s.includes('event: stream-cap-exceeded') && s.includes('event: containers')
+    );
+    ac.abort();
+
+    expect(requestedIds).toEqual(['cap1', 'cap2']);
+    expect(text).toContain('event: stream-cap-exceeded');
+    expect(text).toContain('"maxStatStreams":2');
+    expect(text).toContain('"totalContainers":3');
+    expect(text).toContain('"skippedContainers":1');
+    expect(text).toContain('"cap1"');
+    expect(text).toContain('"cap2"');
+    expect(text).not.toContain('"cap3"');
+  });
+
+  test('does not emit stream-cap-exceeded when at or under the cap', async () => {
+    const container = { Id: 'under1', Names: ['/under'], Image: 'a:latest' };
+    const mockDocker = {
+      listContainers: mock(() => Promise.resolve([container])),
+      getContainer: mock(() => ({ stats: mock(() => Promise.resolve(new EventEmitter())) })),
+    };
+
+    const ac = new AbortController();
+    const request = new Request('http://localhost/stats/stream', { signal: ac.signal });
+    const response = handleStatsStream(mockDocker as any, request, { maxStatStreams: 1 });
+
+    const text = await readUntil(response, (s) => s.includes('event: containers'));
+    ac.abort();
+
+    expect(text).not.toContain('stream-cap-exceeded');
+    expect(text).toContain('"under1"');
+  });
+
+  test('re-applies the cap on container list refresh', async () => {
+    const container1 = { Id: 'ref1', Names: ['/one'], Image: 'a:latest' };
+    const container2 = { Id: 'ref2', Names: ['/two'], Image: 'b:latest' };
+
+    let callCount = 0;
+    const mockDocker = {
+      listContainers: mock(() => {
+        callCount++;
+        // First call returns 1 container (under cap), refresh returns 2 (over cap)
+        return Promise.resolve(callCount <= 1 ? [container1] : [container1, container2]);
+      }),
+      getContainer: mock(() => ({ stats: mock(() => Promise.resolve(new EventEmitter())) })),
+    };
+
+    const ac = new AbortController();
+    const request = new Request('http://localhost/stats/stream', { signal: ac.signal });
+    const response = handleStatsStream(mockDocker as any, request, { ...fastOptions, maxStatStreams: 1 });
+
+    const text = await readUntil(response, (s) => s.includes('event: stream-cap-exceeded'), 2000);
+    ac.abort();
+
+    expect(text).toContain('event: stream-cap-exceeded');
+    expect(text).toContain('"maxStatStreams":1');
+    expect(text).toContain('"totalContainers":2');
+    // The capped container never gets a stream
+    expect(mockDocker.getContainer).not.toHaveBeenCalledWith('ref2');
   });
 });

--- a/agent/src/routes/stats.ts
+++ b/agent/src/routes/stats.ts
@@ -4,12 +4,31 @@ import type Dockerode from 'dockerode';
 const DEFAULT_REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
 const DEFAULT_MAX_CONSECUTIVE_FAILURES = 10;
+const DEFAULT_MAX_STAT_STREAMS = 300;
 
 export interface StatsStreamOptions {
   refreshIntervalMs?: number;
   pollIntervalMs?: number;
   /** Close the stream after this many consecutive refresh failures (default: 10). */
   maxConsecutiveFailures?: number;
+  /** Cap on concurrent per-container stat streams (default: AGENT_MAX_STAT_STREAMS env var or 300). */
+  maxStatStreams?: number;
+}
+
+/**
+ * Resolve the per-container stat stream cap from AGENT_MAX_STAT_STREAMS.
+ * Each streamed container holds one open connection to dockerd, so an
+ * unbounded fan-out on a host with hundreds of containers can exhaust
+ * dockerd connection limits. Invalid values fall back to the default.
+ */
+export function resolveMaxStatStreams(envValue = process.env.AGENT_MAX_STAT_STREAMS): number {
+  if (!envValue) return DEFAULT_MAX_STAT_STREAMS;
+  const parsed = Number(envValue);
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    console.error(`Invalid AGENT_MAX_STAT_STREAMS: '${envValue}'. Using default ${DEFAULT_MAX_STAT_STREAMS}.`);
+    return DEFAULT_MAX_STAT_STREAMS;
+  }
+  return parsed;
 }
 
 /** Flat computed metrics matching the worker's AgentStatsEvent interface. */
@@ -293,6 +312,29 @@ function reconcileContainers(
   sendSSE(ctx, JSON.stringify({ ids: [...currentIds] }), 'containers');
 }
 
+/**
+ * Truncate the container list to the stat stream cap. When over the cap,
+ * only the first `maxStatStreams` containers (Docker list order) get streams
+ * and a `stream-cap-exceeded` SSE event reports the truncation so the worker
+ * can surface the gap instead of silently missing containers.
+ */
+function capContainers(
+  ctx: StreamContext,
+  containers: Dockerode.ContainerInfo[],
+  maxStatStreams: number,
+): Dockerode.ContainerInfo[] {
+  if (containers.length <= maxStatStreams) return containers;
+  const skipped = containers.length - maxStatStreams;
+  console.error(`Stat stream cap exceeded: streaming ${maxStatStreams} of ${containers.length} containers (${skipped} skipped). Raise AGENT_MAX_STAT_STREAMS to stream more.`);
+  sendErrorSSE(ctx, {
+    error: `Stat stream cap exceeded: streaming ${maxStatStreams} of ${containers.length} containers`,
+    maxStatStreams,
+    totalContainers: containers.length,
+    skippedContainers: skipped,
+  }, 'stream-cap-exceeded');
+  return containers.slice(0, maxStatStreams);
+}
+
 /** Try to close a ReadableStream controller, ignoring errors if already closed. */
 function tryCloseController(controller: ReadableStreamDefaultController<Uint8Array>): void {
   try {
@@ -313,9 +355,10 @@ async function tryRefreshContainers(
   failureCount: number,
   maxFailures: number,
   prevFrames: Map<string, PreviousFrame>,
+  maxStatStreams: number,
 ): Promise<{ containers: Dockerode.ContainerInfo[]; shouldBreak: boolean } | null> {
   try {
-    const current = await docker.listContainers({ all: false });
+    const current = capContainers(ctx, await docker.listContainers({ all: false }), maxStatStreams);
     if (ctx.closed) return { containers: current, shouldBreak: true };
     reconcileContainers(ctx, docker, previous, current, prevFrames);
     return { containers: current, shouldBreak: false };
@@ -340,9 +383,10 @@ async function runStatsLoop(
   pollIntervalMs: number,
   refreshIntervalMs: number,
   maxConsecutiveFailures: number,
+  maxStatStreams: number,
 ): Promise<void> {
   const prevFrames = new Map<string, PreviousFrame>();
-  let containers = await docker.listContainers({ all: false });
+  let containers = capContainers(ctx, await docker.listContainers({ all: false }), maxStatStreams);
   if (ctx.closed) return;
   let lastRefresh = Date.now();
   let consecutiveFailures = 0;
@@ -361,7 +405,7 @@ async function runStatsLoop(
     if (now - lastRefresh < refreshIntervalMs) continue;
     lastRefresh = now;
 
-    const result = await tryRefreshContainers(ctx, docker, containers, consecutiveFailures, maxConsecutiveFailures, prevFrames);
+    const result = await tryRefreshContainers(ctx, docker, containers, consecutiveFailures, maxConsecutiveFailures, prevFrames, maxStatStreams);
     if (!result) {
       consecutiveFailures++;
       if (consecutiveFailures >= maxConsecutiveFailures) break;
@@ -380,16 +424,20 @@ async function runStatsLoop(
 /**
  * Create an SSE Response that streams live Docker container stats.
  *
- * Opens a `stats({ stream: true })` connection per running container and forwards
- * NDJSON frames as SSE `data` events. A background poll loop refreshes the container
- * list every `refreshIntervalMs` (checked every `pollIntervalMs`), opening streams for
- * new containers and destroying stale ones.
+ * Opens a `stats({ stream: true })` connection per running container (capped at
+ * `maxStatStreams`, see `resolveMaxStatStreams`) and forwards NDJSON frames as SSE
+ * `data` events. A background poll loop refreshes the container list every
+ * `refreshIntervalMs` (checked every `pollIntervalMs`), opening streams for new
+ * containers and destroying stale ones.
  *
  * SSE event types emitted:
  * - `data` (default): `{ containerId, containerName, image, cpuPercent, memoryUsage, ... }`, pre-computed metrics
  * - `containers`: `{ ids: string[] }`, emitted after each container list refresh
  * - `container-error`: `{ containerId, error }`, per-container stream or open failure
  * - `container-error` with `type: "refresh_failed"`: `{ error, type }`, container list refresh failure
+ * - `stream-cap-exceeded`: `{ error, maxStatStreams, totalContainers, skippedContainers }`,
+ *   emitted when the running container count exceeds the stat stream cap; only the first
+ *   `maxStatStreams` containers are streamed
  * - `error`: `{ error }`, fatal stream-level failure (e.g. initial listContainers fails)
  *
  * Clients MUST handle the `error` and `container-error` SSE events since the HTTP
@@ -410,6 +458,7 @@ export function handleStatsStream(
   const refreshIntervalMs = options.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS;
   const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
   const maxConsecutiveFailures = options.maxConsecutiveFailures ?? DEFAULT_MAX_CONSECUTIVE_FAILURES;
+  const maxStatStreams = options.maxStatStreams ?? resolveMaxStatStreams();
 
   const stream = new ReadableStream({
     async start(controller) {
@@ -427,7 +476,7 @@ export function handleStatsStream(
       });
 
       try {
-        await runStatsLoop(ctx, docker, pollIntervalMs, refreshIntervalMs, maxConsecutiveFailures);
+        await runStatsLoop(ctx, docker, pollIntervalMs, refreshIntervalMs, maxConsecutiveFailures, maxStatStreams);
       } catch (error) {
         console.error('Failed to start stats stream:', error);
         const msg = error instanceof Error ? error.message : String(error);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -164,6 +164,7 @@ A separate Bun package that runs as a sidecar container alongside each managed D
 - Ed25519 JWT authentication (trusted public JWK loaded from `AGENT_TRUSTED_PUBKEY[_FILE]` at startup; per-request JWTs verified against it)
 - Optional TLS via `TLS_CERT_PATH` and `TLS_KEY_PATH`
 - Connects to Docker via `DOCKER_HOST` env var (socket proxy recommended)
+- Per-container stat stream fan-out capped via `AGENT_MAX_STAT_STREAMS` (default 300). Each streamed container holds one open dockerd connection; when the running container count exceeds the cap, only the first N containers are streamed and a `stream-cap-exceeded` SSE event reports the truncation
 - Subprocess timeout (5 minutes) for `docker compose` operations
 
 **Endpoints:**


### PR DESCRIPTION
## Summary

`handleStatsStream` in `agent/src/routes/stats.ts` opened one `stats({ stream: true })` connection per running container with no ceiling, so a host with 500 containers held 500 concurrent dockerd connections.

This change:

- Adds `resolveMaxStatStreams()`, which reads `AGENT_MAX_STAT_STREAMS` (default 300, invalid values fall back to the default with a logged error), plus a `maxStatStreams` option on `StatsStreamOptions` for callers and tests.
- Truncates the container list to the cap at initial load and on every container list refresh. Only the first N containers (Docker list order) get stat streams.
- Emits a named `stream-cap-exceeded` SSE event (`{ error, maxStatStreams, totalContainers, skippedContainers }`) whenever the list is truncated, so consumers know stats are incomplete instead of silently missing containers. Also logs the truncation server-side.
- Documents `AGENT_MAX_STAT_STREAMS` in the Agent Container section of `docs/architecture.md` and in the `handleStatsStream` JSDoc event list.

## Testing

- `bun run typecheck:all` (homelab-manager + agent): pass
- `bun run test:agent`: 271 pass, 0 fail
- `bun run test:coverage:agent`: functions 99.72%, lines 98.54%, thresholds met
- New tests: `resolveMaxStatStreams` parsing/fallback, over-cap truncation with `stream-cap-exceeded` event and skipped `getContainer` calls, no event at or under the cap, and cap re-applied on refresh

Closes #239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
