### PR TITLE
feat(db): serialize migrations with a PostgreSQL advisory lock

### DIFF
--- a/src/lib/database/__tests__/migrate.test.ts
+++ b/src/lib/database/__tests__/migrate.test.ts
@@ -1,0 +1,134 @@
+import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { readdirSync } from 'fs';
+import { join } from 'path';
+import { runMigrations, MIGRATIONS_ADVISORY_LOCK_KEY } from '@/lib/database/migrate';
+import type { DatabaseClient } from '@/lib/clients/database-client';
+
+const migrationFiles = readdirSync(join(import.meta.dir, '..', '..', '..', '..', 'migrations'))
+  .filter((file) => file.endsWith('.sql'))
+  .sort();
+
+interface QueryCall {
+  text: string;
+  values?: unknown[];
+}
+
+interface FakeClient {
+  calls: QueryCall[];
+  releaseCount: number;
+  query(text: string, values?: unknown[]): Promise<{ rows: unknown[] }>;
+  release(): void;
+}
+
+function createFakeClient(
+  handler: (text: string, values?: unknown[]) => { rows: unknown[] } | undefined,
+): FakeClient {
+  const client: FakeClient = {
+    calls: [],
+    releaseCount: 0,
+    async query(text: string, values?: unknown[]) {
+      client.calls.push({ text, values });
+      return handler(text, values) ?? { rows: [] };
+    },
+    release() {
+      client.releaseCount += 1;
+    },
+  };
+  return client;
+}
+
+function createFakeDb(client: FakeClient): DatabaseClient {
+  return {
+    getPool: () => ({ connect: async () => client }),
+  } as unknown as DatabaseClient;
+}
+
+describe('runMigrations', () => {
+  let logSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    logSpy = spyOn(console, 'log').mockImplementation(() => {});
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  test('takes the advisory lock first and releases it last on the same connection', async () => {
+    const client = createFakeClient((text) => {
+      if (text.startsWith('SELECT 1 FROM migrations')) return { rows: [{ applied: 1 }] };
+      return undefined;
+    });
+
+    await runMigrations(createFakeDb(client));
+
+    expect(client.calls[0]).toEqual({
+      text: 'SELECT pg_advisory_lock($1)',
+      values: [MIGRATIONS_ADVISORY_LOCK_KEY],
+    });
+    expect(client.calls[client.calls.length - 1]).toEqual({
+      text: 'SELECT pg_advisory_unlock($1)',
+      values: [MIGRATIONS_ADVISORY_LOCK_KEY],
+    });
+    expect(client.releaseCount).toBe(1);
+  });
+
+  test('skips already-applied migrations without opening transactions', async () => {
+    const client = createFakeClient((text) => {
+      if (text.startsWith('SELECT 1 FROM migrations')) return { rows: [{ applied: 1 }] };
+      return undefined;
+    });
+
+    await runMigrations(createFakeDb(client));
+
+    const texts = client.calls.map((c) => c.text);
+    expect(texts).not.toContain('BEGIN');
+    expect(texts.filter((t) => t.startsWith('SELECT 1 FROM migrations'))).toHaveLength(
+      migrationFiles.length,
+    );
+  });
+
+  test('applies a pending migration inside a transaction and records it', async () => {
+    let pendingChecks = 0;
+    const client = createFakeClient((text) => {
+      if (text.startsWith('SELECT 1 FROM migrations')) {
+        pendingChecks += 1;
+        // First file is pending, the rest already applied.
+        return pendingChecks === 1 ? { rows: [] } : { rows: [{ applied: 1 }] };
+      }
+      return undefined;
+    });
+
+    await runMigrations(createFakeDb(client));
+
+    const texts = client.calls.map((c) => c.text);
+    const beginIdx = texts.indexOf('BEGIN');
+    const commitIdx = texts.indexOf('COMMIT');
+    const insertIdx = texts.findIndex((t) => t.startsWith('INSERT INTO migrations'));
+    expect(beginIdx).toBeGreaterThan(0);
+    expect(insertIdx).toBeGreaterThan(beginIdx);
+    expect(commitIdx).toBeGreaterThan(insertIdx);
+    expect(client.calls[insertIdx].values).toEqual([migrationFiles[0]]);
+  });
+
+  test('rolls back on failure and still unlocks and releases the connection', async () => {
+    const client = createFakeClient((text) => {
+      if (text.startsWith('SELECT 1 FROM migrations')) return { rows: [] };
+      if (text.startsWith('INSERT INTO migrations')) throw new Error('insert failed');
+      return undefined;
+    });
+
+    await expect(runMigrations(createFakeDb(client))).rejects.toThrow('insert failed');
+
+    const texts = client.calls.map((c) => c.text);
+    expect(texts).toContain('ROLLBACK');
+    expect(client.calls[client.calls.length - 1]).toEqual({
+      text: 'SELECT pg_advisory_unlock($1)',
+      values: [MIGRATIONS_ADVISORY_LOCK_KEY],
+    });
+    expect(client.releaseCount).toBe(1);
+  });
+});

--- a/src/lib/database/migrate.ts
+++ b/src/lib/database/migrate.ts
@@ -1,4 +1,5 @@
 import type { DatabaseClient } from '../clients/database-client';
+import type { PoolClient } from 'pg';
 import { readFileSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
@@ -9,14 +10,35 @@ const projectRoot = join(currentDir, '..', '..', '..');
 const migrationsDir = join(projectRoot, 'migrations');
 
 /**
+ * Advisory lock key ("hlm1" in ASCII) that serializes runMigrations. Web and
+ * worker boot concurrently; without it the loser hits the migrations.name
+ * unique constraint and logs a spurious error.
+ */
+export const MIGRATIONS_ADVISORY_LOCK_KEY = 0x686c6d31;
+
+/**
  * Run all pending database migrations
  * Migrations are applied sequentially and tracked in the migrations table
  */
 export async function runMigrations(db: DatabaseClient): Promise<void> {
-  const pool = db.getPool();
+  // Advisory locks are session-scoped, so lock/migrations/unlock must share one
+  // connection; Pool.query() may route each statement to a different one.
+  const client = await db.getPool().connect();
+  try {
+    await client.query('SELECT pg_advisory_lock($1)', [MIGRATIONS_ADVISORY_LOCK_KEY]);
+    try {
+      await applyPendingMigrations(client);
+    } finally {
+      await client.query('SELECT pg_advisory_unlock($1)', [MIGRATIONS_ADVISORY_LOCK_KEY]);
+    }
+  } finally {
+    client.release();
+  }
+}
 
+async function applyPendingMigrations(client: PoolClient): Promise<void> {
   // Create migrations table if it doesn't exist
-  await pool.query(`
+  await client.query(`
     CREATE TABLE IF NOT EXISTS migrations (
       id SERIAL PRIMARY KEY,
       name VARCHAR(255) UNIQUE NOT NULL,
@@ -33,7 +55,7 @@ export async function runMigrations(db: DatabaseClient): Promise<void> {
 
   for (const migrationFile of migrationFiles) {
     // Check if migration has already been run
-    const result = await pool.query(
+    const result = await client.query(
       'SELECT 1 FROM migrations WHERE name = $1',
       [migrationFile]
     );
@@ -49,16 +71,16 @@ export async function runMigrations(db: DatabaseClient): Promise<void> {
     const sql = readFileSync(migrationPath, 'utf-8');
 
     try {
-      await pool.query('BEGIN');
-      await pool.query(sql);
-      await pool.query(
+      await client.query('BEGIN');
+      await client.query(sql);
+      await client.query(
         'INSERT INTO migrations (name) VALUES ($1)',
         [migrationFile]
       );
-      await pool.query('COMMIT');
+      await client.query('COMMIT');
       console.log(`[Migrations] ✓ Successfully applied ${migrationFile}`);
     } catch (err) {
-      await pool.query('ROLLBACK');
+      await client.query('ROLLBACK');
       console.error(`[Migrations] ✗ Failed to apply ${migrationFile}:`, err);
       throw err;
     }

--- a/src/lib/deploy/startup-recovery.ts
+++ b/src/lib/deploy/startup-recovery.ts
@@ -4,6 +4,8 @@ import type { StackRepoWriter } from '@/lib/deploy/pipeline';
 import { retry } from '@/lib/utils/backoff';
 
 export interface StartupRecoveryRepo extends WatchdogRepo {
+  // Fails ALL pending/in_progress rows, so it is safe only when exactly one
+  // web process runs against the database.
   recoverStuckDeploys(logMessage: string): Promise<StuckDeployRow[]>;
   findSucceededPostSuccessDeploys(kind: 'removeFromManifest'): Promise<PostSuccessDeployRow[]>;
 }

--- a/src/lib/git/repo.ts
+++ b/src/lib/git/repo.ts
@@ -13,6 +13,11 @@ export class FileNotFoundError extends Error {
 
 const repoLocks = new Map<string, Promise<void>>();
 
+/**
+ * Serializes repo mutations via an in-memory promise chain, so it only guards
+ * callers within this process. A second app instance writing to the same bare
+ * repo is not protected: run one web instance per git data directory.
+ */
 export async function withRepoLock<T>(repoPath: string, fn: () => Promise<T>): Promise<T> {
   const previous = repoLocks.get(repoPath) ?? Promise.resolve();
   let release: () => void;


### PR DESCRIPTION
## Summary

When the web and worker processes boot at the same time, both run the migration loop. The loser of the race fails on the `migrations.name` unique constraint and logs a spurious error even though the schema ends up correct.

Changes:

- `src/lib/database/migrate.ts`: `runMigrations` now acquires `pg_advisory_lock` on a fixed key (`MIGRATIONS_ADVISORY_LOCK_KEY = 0x686c6d31`) before the migration loop and releases it in a `finally` block. The lock, the per-migration transactions, and the unlock all run on one dedicated pool client because advisory locks are session-scoped and `Pool.query()` can route each statement to a different connection. The loop itself was extracted to `applyPendingMigrations(client)`; this also fixes the prior BEGIN/COMMIT running through the pool, where statements were not guaranteed to share a connection.
- `src/lib/git/repo.ts`: documented that `withRepoLock` is an in-memory promise chain, so it only serializes callers within one process (single-instance by design).
- `src/lib/deploy/startup-recovery.ts`: documented at `StartupRecoveryRepo.recoverStuckDeploys` that it fails all pending/in_progress rows and is safe only with exactly one web process per database (matching the existing note on the repository implementation).
- `src/lib/database/__tests__/migrate.test.ts`: new tests covering lock-first/unlock-last ordering on the same connection, skip of already-applied migrations, transactional apply of a pending migration, and rollback plus unlock/release on failure.

## Testing

- `bun run typecheck`: clean.
- `bun test --isolate src/lib/database/__tests__/migrate.test.ts`: 4 pass, 0 fail.
- `bun test --isolate src/lib/deploy src/lib/git src/lib/database`: 387 pass, 0 fail.
- Full `bun test --isolate`: 2343 pass, 359 fail, 8 errors. Identical run on detached `main` in the same environment: 2339 pass, 359 fail, 8 errors. The failures are pre-existing sandbox/environment issues; this branch adds 4 passing tests and no new failures.

Closes #242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
