### PR TITLE
fix(auth): verify ID token signature against provider JWKS

### DIFF
--- a/src/lib/auth/__tests__/callback-handler.test.ts
+++ b/src/lib/auth/__tests__/callback-handler.test.ts
@@ -51,13 +51,20 @@ function encodedStateParam(state: string, nonce: string): string {
   return encodeURIComponent(JSON.stringify({ state, nonce }));
 }
 
+function makeOidcClient(
+  overrides?: Partial<CallbackHandlerDeps['oidcClient']>,
+): CallbackHandlerDeps['oidcClient'] {
+  return {
+    exchangeCode: mock(async () => makeTokens()),
+    getUserGroups: mock(async () => ['homelab-viewers']),
+    verifyIdToken: mock(async () => makeIdTokenClaims()),
+    ...overrides,
+  };
+}
+
 function makeDeps(overrides?: Partial<CallbackHandlerDeps>): CallbackHandlerDeps {
   return {
-    oidcClient: {
-      exchangeCode: mock(async () => makeTokens()),
-      getUserGroups: mock(async () => ['homelab-viewers']),
-    },
-    extractIdTokenClaims: mock(() => makeIdTokenClaims()),
+    oidcClient: makeOidcClient(),
     mapGroupsToRole: mock(() => 'viewer' as Role | null),
     userRepo: {
       upsertFromOidc: mock(async () => makeUser()),
@@ -138,9 +145,38 @@ describe('handleCallback', () => {
       expect(response.status).not.toBe(400);
     });
 
+    it('returns 401 when ID token signature verification fails', async () => {
+      const deps = makeDeps({
+        oidcClient: makeOidcClient({
+          verifyIdToken: mock(async () => {
+            throw new Error('signature verification failed');
+          }),
+        }),
+      });
+      const originalConsoleError = console.error;
+      console.error = () => {};
+      try {
+        const response = await handleCallback(
+          deps,
+          'auth-code',
+          validState,
+          validCookieHeader(),
+          null,
+          null,
+        );
+        expect(response.status).toBe(401);
+        expect(await response.text()).toBe('ID token verification failed');
+        expect(deps.sessionManager.createSession).not.toHaveBeenCalled();
+      } finally {
+        console.error = originalConsoleError;
+      }
+    });
+
     it('returns 400 when id_token nonce does not match stored nonce', async () => {
       const deps = makeDeps({
-        extractIdTokenClaims: mock(() => makeIdTokenClaims({ nonce: 'wrong-nonce' })),
+        oidcClient: makeOidcClient({
+          verifyIdToken: mock(async () => makeIdTokenClaims({ nonce: 'wrong-nonce' })),
+        }),
       });
       const response = await handleCallback(
         deps,
@@ -156,7 +192,9 @@ describe('handleCallback', () => {
 
     it('returns 400 when id_token is missing sub claim', async () => {
       const deps = makeDeps({
-        extractIdTokenClaims: mock(() => makeIdTokenClaims({ sub: undefined })),
+        oidcClient: makeOidcClient({
+          verifyIdToken: mock(async () => makeIdTokenClaims({ sub: undefined })),
+        }),
       });
       const response = await handleCallback(
         deps,
@@ -172,7 +210,9 @@ describe('handleCallback', () => {
 
     it('returns 400 when id_token has empty sub claim', async () => {
       const deps = makeDeps({
-        extractIdTokenClaims: mock(() => makeIdTokenClaims({ sub: '' })),
+        oidcClient: makeOidcClient({
+          verifyIdToken: mock(async () => makeIdTokenClaims({ sub: '' })),
+        }),
       });
       const response = await handleCallback(
         deps,
@@ -188,7 +228,9 @@ describe('handleCallback', () => {
 
     it('returns 400 when id_token is missing email claim', async () => {
       const deps = makeDeps({
-        extractIdTokenClaims: mock(() => makeIdTokenClaims({ email: undefined })),
+        oidcClient: makeOidcClient({
+          verifyIdToken: mock(async () => makeIdTokenClaims({ email: undefined })),
+        }),
       });
       const response = await handleCallback(
         deps,
@@ -204,7 +246,9 @@ describe('handleCallback', () => {
 
     it('returns 400 when id_token has empty email claim', async () => {
       const deps = makeDeps({
-        extractIdTokenClaims: mock(() => makeIdTokenClaims({ email: '' })),
+        oidcClient: makeOidcClient({
+          verifyIdToken: mock(async () => makeIdTokenClaims({ email: '' })),
+        }),
       });
       const response = await handleCallback(
         deps,
@@ -321,13 +365,12 @@ describe('handleCallback', () => {
   describe('group merging', () => {
     it('merges groups from userinfo and id_token, deduplicating', async () => {
       const deps = makeDeps({
-        oidcClient: {
-          exchangeCode: mock(async () => makeTokens()),
+        oidcClient: makeOidcClient({
           getUserGroups: mock(async () => ['group-a', 'group-b']),
-        },
-        extractIdTokenClaims: mock(() =>
-          makeIdTokenClaims({ groups: ['group-b', 'group-c'] }),
-        ),
+          verifyIdToken: mock(async () =>
+            makeIdTokenClaims({ groups: ['group-b', 'group-c'] }),
+          ),
+        }),
         mapGroupsToRole: mock((groups: string[]) => {
           if (
             groups.includes('group-a') &&
@@ -363,11 +406,9 @@ describe('handleCallback', () => {
 
     it('handles empty id_token groups gracefully', async () => {
       const deps = makeDeps({
-        oidcClient: {
-          exchangeCode: mock(async () => makeTokens()),
-          getUserGroups: mock(async () => ['homelab-viewers']),
-        },
-        extractIdTokenClaims: mock(() => makeIdTokenClaims({ groups: undefined })),
+        oidcClient: makeOidcClient({
+          verifyIdToken: mock(async () => makeIdTokenClaims({ groups: undefined })),
+        }),
       });
 
       const response = await handleCallback(
@@ -392,7 +433,9 @@ describe('handleCallback', () => {
         groups: [],
       });
       const deps = makeDeps({
-        extractIdTokenClaims: mock(() => claims),
+        oidcClient: makeOidcClient({
+          verifyIdToken: mock(async () => claims),
+        }),
         mapGroupsToRole: mock(() => 'admin' as Role | null),
       });
 

--- a/src/lib/auth/__tests__/oidc-client.test.ts
+++ b/src/lib/auth/__tests__/oidc-client.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, afterEach } from 'bun:test';
+import { SignJWT, exportJWK, generateKeyPair } from 'jose';
 import { OidcClient } from '@/lib/auth/oidc-client';
 import type { OidcConfig } from '@/lib/auth/oidc-client';
 
@@ -11,10 +12,14 @@ function asFetch(fn: (input: RequestInfo | URL, init?: RequestInit) => Promise<R
 
 const DISCOVERY_URL = 'https://auth.example.com/.well-known/openid-configuration';
 
+const JWKS_URL = 'https://auth.example.com/jwks';
+
 const DISCOVERY_BODY = {
+  issuer: 'https://auth.example.com',
   authorization_endpoint: 'https://auth.example.com/authorize',
   token_endpoint: 'https://auth.example.com/token',
   userinfo_endpoint: 'https://auth.example.com/userinfo',
+  jwks_uri: JWKS_URL,
 };
 
 const DISCOVERY_BODY_WITH_END_SESSION = {
@@ -141,22 +146,28 @@ describe('OidcClient', () => {
 
       const client = new OidcClient(config, missingFetch);
       await expect(client.discoverEndpoints()).rejects.toThrow(
-        'OIDC discovery response missing required endpoints (authorization_endpoint, token_endpoint, userinfo_endpoint)',
+        'OIDC discovery response missing required fields (issuer, authorization_endpoint, token_endpoint, userinfo_endpoint, jwks_uri)',
+      );
+    });
+
+    it('throws when discovery response is missing jwks_uri', async () => {
+      const { jwks_uri: _omitted, ...withoutJwks } = DISCOVERY_BODY;
+      const missingFetch = asFetch(async () => makeResponse(withoutJwks));
+
+      const client = new OidcClient(config, missingFetch);
+      await expect(client.discoverEndpoints()).rejects.toThrow(
+        'OIDC discovery response missing required fields (issuer, authorization_endpoint, token_endpoint, userinfo_endpoint, jwks_uri)',
       );
     });
 
     it('throws when discovery response has non-string endpoint fields', async () => {
       const badFetch = asFetch(async () =>
-        makeResponse({
-          authorization_endpoint: 42,
-          token_endpoint: 'https://auth.example.com/token',
-          userinfo_endpoint: 'https://auth.example.com/userinfo',
-        }),
+        makeResponse({ ...DISCOVERY_BODY, authorization_endpoint: 42 }),
       );
 
       const client = new OidcClient(config, badFetch);
       await expect(client.discoverEndpoints()).rejects.toThrow(
-        'OIDC discovery response missing required endpoints (authorization_endpoint, token_endpoint, userinfo_endpoint)',
+        'OIDC discovery response missing required fields (issuer, authorization_endpoint, token_endpoint, userinfo_endpoint, jwks_uri)',
       );
     });
   });
@@ -380,27 +391,141 @@ describe('OidcClient', () => {
     });
   });
 
-  describe('extractIdTokenClaims', () => {
-    it('decodes JWT payload without verification', () => {
-      const payload = { sub: 'user-123', email: 'user@example.com', nonce: 'abc' };
-      const encoded = btoa(JSON.stringify(payload));
-      const idToken = `header.${encoded}.signature`;
+  describe('verifyIdToken', () => {
+    interface SigningSetup {
+      client: OidcClient;
+      privateKey: CryptoKey;
+      jwksFetchCount: () => number;
+    }
 
-      const claims = OidcClient.extractIdTokenClaims(idToken);
+    async function makeSigningSetup(advertisedAlgs?: string[]): Promise<SigningSetup> {
+      const { privateKey, publicKey } = await generateKeyPair('ES256');
+      const jwk = { ...(await exportJWK(publicKey)), kid: 'test-key', alg: 'ES256', use: 'sig' };
+
+      const discovery =
+        advertisedAlgs === undefined
+          ? DISCOVERY_BODY
+          : { ...DISCOVERY_BODY, id_token_signing_alg_values_supported: advertisedAlgs };
+
+      let jwksFetches = 0;
+      const fetchFn = asFetch(async (input) => {
+        const url = input.toString();
+        if (url === DISCOVERY_URL) return makeResponse(discovery);
+        if (url === JWKS_URL) {
+          jwksFetches++;
+          return makeResponse({ keys: [jwk] });
+        }
+        return makeResponse({}, 404);
+      });
+
+      return {
+        client: new OidcClient(config, fetchFn),
+        privateKey,
+        jwksFetchCount: () => jwksFetches,
+      };
+    }
+
+    function signIdToken(
+      privateKey: CryptoKey,
+      claims: Record<string, unknown>,
+      overrides?: { issuer?: string; audience?: string },
+    ): Promise<string> {
+      return new SignJWT(claims)
+        .setProtectedHeader({ alg: 'ES256', kid: 'test-key' })
+        .setIssuer(overrides?.issuer ?? 'https://auth.example.com')
+        .setAudience(overrides?.audience ?? 'my-client')
+        .setIssuedAt()
+        .setExpirationTime('5m')
+        .sign(privateKey);
+    }
+
+    it('returns claims for a token signed by the provider key', async () => {
+      const { client, privateKey } = await makeSigningSetup(['ES256']);
+      const idToken = await signIdToken(privateKey, {
+        sub: 'user-123',
+        email: 'user@example.com',
+        nonce: 'abc',
+      });
+
+      const claims = await client.verifyIdToken(idToken);
 
       expect(claims['sub']).toBe('user-123');
       expect(claims['email']).toBe('user@example.com');
       expect(claims['nonce']).toBe('abc');
+      expect(claims['iss']).toBe('https://auth.example.com');
+      expect(claims['aud']).toBe('my-client');
     });
 
-    it('throws on invalid JWT format (fewer than 3 parts)', () => {
-      expect(() => OidcClient.extractIdTokenClaims('header.payload')).toThrow(
-        'Invalid ID token format',
+    it('rejects a token signed by a different key', async () => {
+      const { client } = await makeSigningSetup(['ES256']);
+      const { privateKey: attackerKey } = await generateKeyPair('ES256');
+      const forged = await signIdToken(attackerKey, { sub: 'user-123' });
+
+      await expect(client.verifyIdToken(forged)).rejects.toThrow();
+    });
+
+    it('rejects a token with the wrong issuer', async () => {
+      const { client, privateKey } = await makeSigningSetup(['ES256']);
+      const idToken = await signIdToken(
+        privateKey,
+        { sub: 'user-123' },
+        { issuer: 'https://evil.example.com' },
       );
+
+      await expect(client.verifyIdToken(idToken)).rejects.toThrow();
     });
 
-    it('throws on invalid JWT format (more than 3 parts)', () => {
-      expect(() => OidcClient.extractIdTokenClaims('a.b.c.d')).toThrow('Invalid ID token format');
+    it('rejects a token with the wrong audience', async () => {
+      const { client, privateKey } = await makeSigningSetup(['ES256']);
+      const idToken = await signIdToken(
+        privateKey,
+        { sub: 'user-123' },
+        { audience: 'other-client' },
+      );
+
+      await expect(client.verifyIdToken(idToken)).rejects.toThrow();
+    });
+
+    it('rejects a token whose alg is not advertised by the provider', async () => {
+      const { client, privateKey } = await makeSigningSetup(['RS256']);
+      const idToken = await signIdToken(privateKey, { sub: 'user-123' });
+
+      await expect(client.verifyIdToken(idToken)).rejects.toThrow();
+    });
+
+    it('defaults to RS256 when the provider advertises no signing algs', async () => {
+      const { client, privateKey } = await makeSigningSetup();
+      const idToken = await signIdToken(privateKey, { sub: 'user-123' });
+
+      // ES256-signed token rejected because only the RS256 default is allowed
+      await expect(client.verifyIdToken(idToken)).rejects.toThrow();
+    });
+
+    it('never accepts alg "none" even when advertised', async () => {
+      const { client } = await makeSigningSetup(['none']);
+      const header = btoa(JSON.stringify({ alg: 'none' })).replace(/=+$/, '');
+      const payload = btoa(
+        JSON.stringify({
+          sub: 'user-123',
+          iss: 'https://auth.example.com',
+          aud: 'my-client',
+          exp: Math.floor(Date.now() / 1000) + 300,
+        }),
+      ).replace(/=+$/, '');
+      const unsigned = `${header}.${payload}.`;
+
+      await expect(client.verifyIdToken(unsigned)).rejects.toThrow();
+    });
+
+    it('caches the remote JWK set across verifications', async () => {
+      const { client, privateKey, jwksFetchCount } = await makeSigningSetup(['ES256']);
+      const first = await signIdToken(privateKey, { sub: 'user-1' });
+      const second = await signIdToken(privateKey, { sub: 'user-2' });
+
+      await client.verifyIdToken(first);
+      await client.verifyIdToken(second);
+
+      expect(jwksFetchCount()).toBe(1);
     });
   });
 });

--- a/src/lib/auth/callback-handler.ts
+++ b/src/lib/auth/callback-handler.ts
@@ -4,6 +4,7 @@ import type { UserRow } from '@/lib/database/repositories/user-repository';
 export interface CallbackOidcClient {
   exchangeCode(code: string): Promise<OidcTokens>;
   getUserGroups(accessToken: string): Promise<string[]>;
+  verifyIdToken(idToken: string): Promise<Record<string, unknown>>;
 }
 
 export interface CallbackUserRepo {
@@ -27,7 +28,6 @@ export interface CallbackSessionManager {
 
 export interface CallbackHandlerDeps {
   oidcClient: CallbackOidcClient;
-  extractIdTokenClaims: (idToken: string) => Record<string, unknown>;
   mapGroupsToRole: (groups: string[], mapping: RoleMappingConfig) => Role | null;
   userRepo: CallbackUserRepo;
   sessionManager: CallbackSessionManager;
@@ -71,7 +71,16 @@ export async function handleCallback(
 
   // Providers vary on whether groups appear in userinfo or id_token; merge both.
   const userinfoGroups = await deps.oidcClient.getUserGroups(tokens.accessToken);
-  const idTokenClaims = deps.extractIdTokenClaims(tokens.idToken);
+
+  // Signature verification (issuer, audience, alg pinned to the discovery document)
+  // must happen before the nonce check, otherwise the nonce binds to a forgeable payload.
+  let idTokenClaims: Record<string, unknown>;
+  try {
+    idTokenClaims = await deps.oidcClient.verifyIdToken(tokens.idToken);
+  } catch (err) {
+    console.error('[auth/callback] ID token verification failed:', err);
+    return new Response('ID token verification failed', { status: 401 });
+  }
 
   if (idTokenClaims.nonce !== storedState.nonce) {
     return new Response('Nonce mismatch', { status: 400 });
@@ -184,7 +193,6 @@ export async function callbackGetHandler({
     return handleCallback(
       {
         oidcClient: oidc,
-        extractIdTokenClaims: OidcClient.extractIdTokenClaims,
         mapGroupsToRole,
         userRepo,
         sessionManager,

--- a/src/lib/auth/oidc-client.ts
+++ b/src/lib/auth/oidc-client.ts
@@ -1,3 +1,4 @@
+import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
 import type { OidcTokens } from '@/lib/auth/types';
 
 export interface OidcConfig {
@@ -8,14 +9,18 @@ export interface OidcConfig {
 }
 
 interface OidcEndpoints {
+  issuer: string;
   authorizationEndpoint: string;
   tokenEndpoint: string;
   userinfoEndpoint: string;
+  jwksUri: string;
   endSessionEndpoint: string | null;
+  idTokenSigningAlgs: string[];
 }
 
 export class OidcClient {
   private endpoints: OidcEndpoints | null = null;
+  private jwks: ReturnType<typeof createRemoteJWKSet> | null = null;
   private readonly fetchFn: typeof fetch;
 
   constructor(
@@ -49,14 +54,38 @@ export class OidcClient {
     }
 
     const body = await response.json();
+    const issuer = body.issuer;
     const authEndpoint = body.authorization_endpoint;
     const tokenEndpoint = body.token_endpoint;
     const userinfoEndpoint = body.userinfo_endpoint;
-    if (typeof authEndpoint !== 'string' || typeof tokenEndpoint !== 'string' || typeof userinfoEndpoint !== 'string') {
-      throw new Error('OIDC discovery response missing required endpoints (authorization_endpoint, token_endpoint, userinfo_endpoint)');
+    const jwksUri = body.jwks_uri;
+    if (
+      typeof issuer !== 'string' ||
+      typeof authEndpoint !== 'string' ||
+      typeof tokenEndpoint !== 'string' ||
+      typeof userinfoEndpoint !== 'string' ||
+      typeof jwksUri !== 'string'
+    ) {
+      throw new Error('OIDC discovery response missing required fields (issuer, authorization_endpoint, token_endpoint, userinfo_endpoint, jwks_uri)');
     }
     const endSessionEndpoint = typeof body.end_session_endpoint === 'string' ? body.end_session_endpoint : null;
-    this.endpoints = { authorizationEndpoint: authEndpoint, tokenEndpoint, userinfoEndpoint, endSessionEndpoint };
+    // 'none' is never acceptable for ID tokens; RS256 is the OIDC Core default when the
+    // provider does not advertise id_token_signing_alg_values_supported.
+    const advertisedAlgs = Array.isArray(body.id_token_signing_alg_values_supported)
+      ? body.id_token_signing_alg_values_supported.filter(
+          (alg: unknown): alg is string => typeof alg === 'string' && alg !== 'none',
+        )
+      : [];
+    const idTokenSigningAlgs = advertisedAlgs.length > 0 ? advertisedAlgs : ['RS256'];
+    this.endpoints = {
+      issuer,
+      authorizationEndpoint: authEndpoint,
+      tokenEndpoint,
+      userinfoEndpoint,
+      jwksUri,
+      endSessionEndpoint,
+      idTokenSigningAlgs,
+    };
     return this.endpoints;
   }
 
@@ -129,13 +158,22 @@ export class OidcClient {
     return Array.isArray(body.groups) ? body.groups : [];
   }
 
-  /** Decode JWT payload without verification (server already verified via token endpoint) */
-  static extractIdTokenClaims(idToken: string): Record<string, unknown> {
-    const parts = idToken.split('.');
-    if (parts.length !== 3) throw new Error('Invalid ID token format');
-    // JWT payloads are base64url-encoded (RFC 7519): replace - and _ then pad to 4-char boundary
-    const base64 = parts[1].replace(/-/g, '+').replace(/_/g, '/');
-    const padded = base64.padEnd(base64.length + ((4 - (base64.length % 4)) % 4), '=');
-    return JSON.parse(atob(padded));
+  /**
+   * Verifies the ID token signature against the provider's JWKS and returns its claims.
+   * Pins issuer, audience (client_id), and the signing algorithms advertised in the
+   * discovery document, so the nonce check downstream binds to an authenticated document.
+   * The remote JWK set is cached per client instance; jose handles refresh on key rotation.
+   */
+  async verifyIdToken(idToken: string): Promise<Record<string, unknown>> {
+    const endpoints = await this.discoverEndpoints();
+    this.jwks ??= createRemoteJWKSet(new URL(endpoints.jwksUri), {
+      [customFetch]: this.fetchFn,
+    });
+    const { payload } = await jwtVerify(idToken, this.jwks, {
+      issuer: endpoints.issuer,
+      audience: this.config.clientId,
+      algorithms: endpoints.idTokenSigningAlgs,
+    });
+    return payload;
   }
 }

--- a/src/lib/auth/oidc-client.ts
+++ b/src/lib/auth/oidc-client.ts
@@ -1,5 +1,32 @@
 import { createRemoteJWKSet, customFetch, jwtVerify } from 'jose';
+import { z } from 'zod';
 import type { OidcTokens } from '@/lib/auth/types';
+
+// These payloads come from the OIDC provider over the network, so validate them like any
+// other untrusted input. Required fields must be strings; optional fields are parsed
+// leniently (`.catch`) because providers vary in what they advertise and a malformed
+// optional field should not fail discovery or token exchange.
+const discoveryResponseSchema = z.object({
+  issuer: z.string(),
+  authorization_endpoint: z.string(),
+  token_endpoint: z.string(),
+  userinfo_endpoint: z.string(),
+  jwks_uri: z.string(),
+  end_session_endpoint: z.string().optional().catch(undefined),
+  id_token_signing_alg_values_supported: z.array(z.string()).optional().catch(undefined),
+});
+
+const tokenResponseSchema = z.object({
+  access_token: z.string(),
+  id_token: z.string(),
+  refresh_token: z.string().optional().catch(undefined),
+});
+
+const userinfoResponseSchema = z
+  .object({
+    groups: z.array(z.string()).catch([]),
+  })
+  .catch({ groups: [] });
 
 export interface OidcConfig {
   issuerUrl: string;
@@ -53,37 +80,24 @@ export class OidcClient {
       throw new Error(`OIDC discovery failed (HTTP ${response.status})`);
     }
 
-    const body = await response.json();
-    const issuer = body.issuer;
-    const authEndpoint = body.authorization_endpoint;
-    const tokenEndpoint = body.token_endpoint;
-    const userinfoEndpoint = body.userinfo_endpoint;
-    const jwksUri = body.jwks_uri;
-    if (
-      typeof issuer !== 'string' ||
-      typeof authEndpoint !== 'string' ||
-      typeof tokenEndpoint !== 'string' ||
-      typeof userinfoEndpoint !== 'string' ||
-      typeof jwksUri !== 'string'
-    ) {
+    const parsed = discoveryResponseSchema.safeParse(await response.json());
+    if (!parsed.success) {
       throw new Error('OIDC discovery response missing required fields (issuer, authorization_endpoint, token_endpoint, userinfo_endpoint, jwks_uri)');
     }
-    const endSessionEndpoint = typeof body.end_session_endpoint === 'string' ? body.end_session_endpoint : null;
+    const body = parsed.data;
     // 'none' is never acceptable for ID tokens; RS256 is the OIDC Core default when the
     // provider does not advertise id_token_signing_alg_values_supported.
-    const advertisedAlgs = Array.isArray(body.id_token_signing_alg_values_supported)
-      ? body.id_token_signing_alg_values_supported.filter(
-          (alg: unknown): alg is string => typeof alg === 'string' && alg !== 'none',
-        )
-      : [];
+    const advertisedAlgs = (body.id_token_signing_alg_values_supported ?? []).filter(
+      (alg) => alg !== 'none',
+    );
     const idTokenSigningAlgs = advertisedAlgs.length > 0 ? advertisedAlgs : ['RS256'];
     this.endpoints = {
-      issuer,
-      authorizationEndpoint: authEndpoint,
-      tokenEndpoint,
-      userinfoEndpoint,
-      jwksUri,
-      endSessionEndpoint,
+      issuer: body.issuer,
+      authorizationEndpoint: body.authorization_endpoint,
+      tokenEndpoint: body.token_endpoint,
+      userinfoEndpoint: body.userinfo_endpoint,
+      jwksUri: body.jwks_uri,
+      endSessionEndpoint: body.end_session_endpoint ?? null,
       idTokenSigningAlgs,
     };
     return this.endpoints;
@@ -132,14 +146,14 @@ export class OidcClient {
       throw new Error(`OIDC token exchange failed (HTTP ${response.status}): ${body}`);
     }
 
-    const body = await response.json();
-    if (typeof body.access_token !== 'string' || typeof body.id_token !== 'string') {
+    const parsed = tokenResponseSchema.safeParse(await response.json());
+    if (!parsed.success) {
       throw new Error('OIDC token response missing required fields (access_token, id_token)');
     }
     return {
-      accessToken: body.access_token,
-      refreshToken: body.refresh_token ?? null,
-      idToken: body.id_token,
+      accessToken: parsed.data.access_token,
+      refreshToken: parsed.data.refresh_token ?? null,
+      idToken: parsed.data.id_token,
     };
   }
 
@@ -154,8 +168,7 @@ export class OidcClient {
       throw new Error(`Userinfo endpoint returned HTTP ${response.status}`);
     }
 
-    const body = await response.json();
-    return Array.isArray(body.groups) ? body.groups : [];
+    return userinfoResponseSchema.parse(await response.json()).groups;
   }
 
   /**


### PR DESCRIPTION
## Summary

extractIdTokenClaims base64url-decoded the ID token payload without checking the signature, so the nonce comparison and the sub/email/groups claims were read from an unauthenticated document. Anyone who could reach the callback with a crafted token body could influence the resulting session identity.

The raw decode is replaced with jose jwtVerify against a remote JWK set built from the jwks_uri in the discovery document. Issuer, audience (client_id), and the provider's advertised signing algorithms are pinned; "none" is rejected and RS256 is the fallback when the provider advertises no algorithms. The JWK set is cached per client instance and fetched through the client's injected fetch so tests can sign tokens with a local keypair. Verification failures return 401 from the callback handler.

## Testing

- bun run typecheck: clean
- bun test --isolate src/lib/auth/__tests__/oidc-client.test.ts: 33 pass, 0 fail
- bun test --isolate src/lib/auth/__tests__/callback-handler.test.ts: 28 pass, 0 fail

Note: the implementing agent was killed by a usage limit after committing, so this PR was published from the verified commit; CI is the authoritative gate.

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ID token verification now properly validates token signatures, issuer, and audience claims to prevent unauthorized access
  * Invalid ID tokens now correctly return a 401 error response

* **Tests**
  * Enhanced authentication test coverage for token verification scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->