### PR TITLE
docs(shared-table): record React Compiler constraint in SparklineCell

### DIFF
--- a/src/components/shared-table/SparklineCell.tsx
+++ b/src/components/shared-table/SparklineCell.tsx
@@ -42,6 +42,14 @@ export default memo(function SparklineCell({ data, color }: SparklineCellProps) 
   //
   // WARNING: Do not change the timestamp-based assumptions (e.g. switching to index-
   // based filtering or adding non-deterministic logic) without revisiting this pattern.
+  //
+  // React Compiler constraint: this pattern violates the react-hooks refs rule
+  // (no ref reads/writes during render), so the compiler cannot be enabled while
+  // this component exists in its current form. Before adopting the compiler, move
+  // the accumulator into an entity-keyed external store (keyed by host-prefixed
+  // entity ID) and subscribe via useSyncExternalStore. That store is also what
+  // survives virtualizer remounts (see CLAUDE.md gotcha 12), so the migration
+  // solves both problems at once.
   if (data.length > 0) {
     const latest = data.at(-1)!.timestamp;
 


### PR DESCRIPTION
## Summary

Comment-only. SparklineCell mutates accumulator refs during render as a deliberate perf tradeoff (avoids a second commit per SSE tick across ~168 sparklines). That violates the react-hooks refs rule, so React Compiler cannot be enabled while this pattern exists. This documents the constraint next to the existing tradeoff comment and spells out the migration path (entity-keyed external store, per CLAUDE.md gotcha 12).

## Testing

Comment-only change; no behavior affected.

Closes #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)
