### PR TITLE
fix(agent): trim unauthenticated /health payload to bare status

### DIFF
--- a/agent/src/__tests__/health.test.ts
+++ b/agent/src/__tests__/health.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, mock, beforeAll } from 'bun:test';
-import { handleHealth } from '../routes/health';
+import { handleHealth, handleInfo } from '../routes/health';
 import type { ZfsCapabilities } from '../lib/zfs-capabilities';
 import pkg from '../../package.json';
 
@@ -27,18 +27,65 @@ const zfsUnavailable: ZfsCapabilities = {
   permissions: [],
 };
 
+function mockDockerClient() {
+  return {
+    version: mock(() =>
+      Promise.resolve({
+        Version: '24.0.7',
+        ApiVersion: '1.43',
+      })
+    ),
+  };
+}
+
 describe('handleHealth', () => {
-  test('reports Docker and ZFS capabilities when both available', async () => {
+  test('returns healthy status when Docker is available', async () => {
+    const response = await handleHealth(mockDockerClient() as any, zfsUnavailable);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: 'healthy' });
+  });
+
+  test('returns healthy status when only ZFS is available', async () => {
+    const response = await handleHealth(null, zfsAvailable);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toEqual({ status: 'healthy' });
+  });
+
+  test('does not expose version or capability detail (endpoint is unauthenticated)', async () => {
+    const response = await handleHealth(mockDockerClient() as any, zfsWithSnapshots);
+    const body = await response.json();
+
+    expect(Object.keys(body)).toEqual(['status']);
+  });
+
+  test('returns unhealthy when neither capability is available', async () => {
+    const response = await handleHealth(null, zfsUnavailable);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({ status: 'unhealthy' });
+  });
+
+  test('returns unhealthy when Docker unreachable and no ZFS', async () => {
     const mockDocker = {
-      version: mock(() =>
-        Promise.resolve({
-          Version: '24.0.7',
-          ApiVersion: '1.43',
-        })
-      ),
+      version: mock(() => Promise.reject(new Error('Connection refused'))),
     };
 
-    const response = await handleHealth(mockDocker as any, zfsAvailable);
+    const response = await handleHealth(mockDocker as any, zfsUnavailable);
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body).toEqual({ status: 'unhealthy' });
+  });
+});
+
+describe('handleInfo', () => {
+  test('reports Docker and ZFS capabilities when both available', async () => {
+    const response = await handleInfo(mockDockerClient() as any, zfsAvailable);
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -58,16 +105,7 @@ describe('handleHealth', () => {
   });
 
   test('reports only Docker when ZFS unavailable', async () => {
-    const mockDocker = {
-      version: mock(() =>
-        Promise.resolve({
-          Version: '24.0.7',
-          ApiVersion: '1.43',
-        })
-      ),
-    };
-
-    const response = await handleHealth(mockDocker as any, zfsUnavailable);
+    const response = await handleInfo(mockDockerClient() as any, zfsUnavailable);
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -77,7 +115,7 @@ describe('handleHealth', () => {
   });
 
   test('reports only ZFS when Docker is null', async () => {
-    const response = await handleHealth(null, zfsWithSnapshots);
+    const response = await handleInfo(null, zfsWithSnapshots);
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -92,7 +130,7 @@ describe('handleHealth', () => {
   });
 
   test('returns unhealthy when neither available', async () => {
-    const response = await handleHealth(null, zfsUnavailable);
+    const response = await handleInfo(null, zfsUnavailable);
     const body = await response.json();
 
     expect(response.status).toBe(503);
@@ -102,16 +140,7 @@ describe('handleHealth', () => {
   });
 
   test('returns healthy with Docker when no ZFS capabilities provided', async () => {
-    const mockDocker = {
-      version: mock(() =>
-        Promise.resolve({
-          Version: '24.0.7',
-          ApiVersion: '1.43',
-        })
-      ),
-    };
-
-    const response = await handleHealth(mockDocker as any);
+    const response = await handleInfo(mockDockerClient() as any);
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -125,7 +154,7 @@ describe('handleHealth', () => {
       version: mock(() => Promise.reject(new Error('Connection refused'))),
     };
 
-    const response = await handleHealth(mockDocker as any, zfsUnavailable);
+    const response = await handleInfo(mockDocker as any, zfsUnavailable);
     const body = await response.json();
 
     expect(response.status).toBe(503);
@@ -133,5 +162,4 @@ describe('handleHealth', () => {
     expect(body.capabilities.docker).toEqual({ available: false });
     expect(body.capabilities.zfs).toEqual({ available: false });
   });
-
 });

--- a/agent/src/__tests__/middleware.test.ts
+++ b/agent/src/__tests__/middleware.test.ts
@@ -120,4 +120,17 @@ describe('authenticateRequest (JWT)', () => {
     );
     expect(withAuth).toBeNull();
   });
+
+  it('requires auth on /info (version and capability detail is not public)', async () => {
+    const { trusted, sign } = await makeAuth();
+    const noAuth = await authenticateRequest(new Headers(), trusted, '/info');
+    expect(noAuth?.status).toBe(401);
+    const jwt = await sign();
+    const withAuth = await authenticateRequest(
+      new Headers({ Authorization: `Bearer ${jwt}` }),
+      trusted,
+      '/info',
+    );
+    expect(withAuth).toBeNull();
+  });
 });

--- a/agent/src/__tests__/middleware.test.ts
+++ b/agent/src/__tests__/middleware.test.ts
@@ -123,13 +123,14 @@ describe('authenticateRequest (JWT)', () => {
 
   it('requires auth on /info (version and capability detail is not public)', async () => {
     const { trusted, sign } = await makeAuth();
-    const noAuth = await authenticateRequest(new Headers(), trusted, '/info');
+    const noAuth = await authenticateRequest(new Headers(), trusted, '/info', HOST);
     expect(noAuth?.status).toBe(401);
     const jwt = await sign();
     const withAuth = await authenticateRequest(
       new Headers({ Authorization: `Bearer ${jwt}` }),
       trusted,
       '/info',
+      HOST,
     );
     expect(withAuth).toBeNull();
   });

--- a/agent/src/__tests__/middleware.test.ts
+++ b/agent/src/__tests__/middleware.test.ts
@@ -123,14 +123,13 @@ describe('authenticateRequest (JWT)', () => {
 
   it('requires auth on /info (version and capability detail is not public)', async () => {
     const { trusted, sign } = await makeAuth();
-    const noAuth = await authenticateRequest(new Headers(), trusted, '/info', HOST);
+    const noAuth = await authenticateRequest(new Headers(), trusted, '/info');
     expect(noAuth?.status).toBe(401);
     const jwt = await sign();
     const withAuth = await authenticateRequest(
       new Headers({ Authorization: `Bearer ${jwt}` }),
       trusted,
       '/info',
-      HOST,
     );
     expect(withAuth).toBeNull();
   });

--- a/agent/src/index.ts
+++ b/agent/src/index.ts
@@ -1,6 +1,6 @@
 import Dockerode from 'dockerode';
 import { authenticateRequest } from './middleware';
-import { handleHealth } from './routes/health';
+import { handleHealth, handleInfo } from './routes/health';
 import { handleStatsStream } from './routes/stats';
 import { handleLogStream } from './routes/logs';
 import { handleStackDeploy, handleStackUpdate, handleStackTeardown, handleStackRestart, handleStackStart, handleStackStop, handleStackStatus } from './routes/stacks';
@@ -123,6 +123,7 @@ if (!docker && !zfsCapabilities.available) {
  */
 function matchRoute(request: Request, url: URL): Promise<Response> | Response | null {
   if (url.pathname === '/health' && request.method === 'GET') return handleHealth(docker, zfsCapabilities);
+  if (url.pathname === '/info' && request.method === 'GET') return handleInfo(docker, zfsCapabilities);
   if (url.pathname === '/auth/verify' && request.method === 'GET') return Response.json({ status: 'ok' });
 
   if (docker) {

--- a/agent/src/routes/health.ts
+++ b/agent/src/routes/health.ts
@@ -28,23 +28,51 @@ async function getDockerCapability(
   }
 }
 
+async function checkHealthy(
+  docker: Dockerode | null,
+  zfsCapabilities?: ZfsCapabilities
+): Promise<{ dockerCapability: DockerCapability; zfsAvailable: boolean; isHealthy: boolean }> {
+  const dockerCapability = docker
+    ? await getDockerCapability(docker)
+    : { available: false };
+  const zfsAvailable = zfsCapabilities?.available ?? false;
+  return { dockerCapability, zfsAvailable, isHealthy: dockerCapability.available || zfsAvailable };
+}
+
 /**
- * Perform a health check and produce an HTTP JSON Response describing agent capabilities.
+ * Liveness check for the unauthenticated /health endpoint. Returns only the
+ * status field: this endpoint bypasses auth, so it must not expose version or
+ * capability detail to unauthenticated callers. Use /info (authenticated) for
+ * version and capability data.
  *
  * @param docker - Dockerode client, or null when Docker is not configured
  * @param zfsCapabilities - Pre-detected ZFS capabilities (detected once at startup)
- * @returns An HTTP Response whose JSON body includes status, agentVersion, and capabilities
+ * @returns 200 with status healthy, or 503 with status unhealthy
  */
 export async function handleHealth(
   docker: Dockerode | null,
   zfsCapabilities?: ZfsCapabilities
 ): Promise<Response> {
-  const dockerCapability = docker
-    ? await getDockerCapability(docker)
-    : { available: false };
+  const { isHealthy } = await checkHealthy(docker, zfsCapabilities);
+  return Response.json(
+    { status: isHealthy ? 'healthy' : 'unhealthy' },
+    { status: isHealthy ? 200 : 503 }
+  );
+}
 
-  const zfsAvailable = zfsCapabilities?.available ?? false;
-  const isHealthy = dockerCapability.available || zfsAvailable;
+/**
+ * Detailed agent info for the authenticated /info endpoint: agent version plus
+ * Docker and ZFS capability detail.
+ *
+ * @param docker - Dockerode client, or null when Docker is not configured
+ * @param zfsCapabilities - Pre-detected ZFS capabilities (detected once at startup)
+ * @returns An HTTP Response whose JSON body includes status, agentVersion, and capabilities
+ */
+export async function handleInfo(
+  docker: Dockerode | null,
+  zfsCapabilities?: ZfsCapabilities
+): Promise<Response> {
+  const { dockerCapability, zfsAvailable, isHealthy } = await checkHealthy(docker, zfsCapabilities);
 
   return Response.json(
     {

--- a/agent/src/types.ts
+++ b/agent/src/types.ts
@@ -11,24 +11,34 @@ export interface AgentStackResponse {
   exitCode?: number;
 }
 
-/** Successful /health response (HTTP 200). */
-export interface AgentHealthyResponse {
-  status: 'healthy';
+/**
+ * Liveness response from the unauthenticated /health endpoint
+ * (HTTP 200 when healthy, 503 when unhealthy). Status only:
+ * version and capability detail require the authenticated /info endpoint.
+ */
+export interface AgentHealthCheckResponse {
+  status: 'healthy' | 'unhealthy';
+}
+
+export interface AgentDockerCapability {
+  available: boolean;
+  version?: string;
+  apiVersion?: string;
+}
+
+export interface AgentZfsCapability {
+  available: boolean;
+  version?: string;
+  tier?: number;
+  permissions?: string[];
+}
+
+/** Detail response from the authenticated /info endpoint (HTTP 200 when healthy, 503 when unhealthy). */
+export interface AgentInfoResponse {
+  status: 'healthy' | 'unhealthy';
   agentVersion: string;
-  docker: {
-    version: string;
-    apiVersion: string;
+  capabilities: {
+    docker: AgentDockerCapability;
+    zfs: AgentZfsCapability;
   };
 }
-
-export type AgentUnhealthyError = 'docker_unreachable' | 'auth_failed' | 'timeout';
-
-/** Failed /health response (HTTP 503). */
-export interface AgentUnhealthyResponse {
-  status: 'unhealthy';
-  agentVersion: string;
-  error: AgentUnhealthyError;
-  detail: string;
-}
-
-export type AgentHealthCheckResponse = AgentHealthyResponse | AgentUnhealthyResponse;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -170,7 +170,8 @@ A separate Bun package that runs as a sidecar container alongside each managed D
 
 | Method | Path | Purpose |
 |--------|------|---------|
-| GET | `/health` | Docker version + ZFS capability check + heartbeat |
+| GET | `/health` | Liveness heartbeat, status only (unauthenticated) |
+| GET | `/info` | Agent version + Docker/ZFS capability detail (authenticated) |
 | GET | `/auth/verify` | JWT verification |
 | GET | `/stats/stream` | SSE container stats with pre-computed metrics |
 | GET | `/logs/:containerId` | SSE container log streaming (backlog + live phases) |

--- a/src/data/hosts/__tests__/handlers.test.ts
+++ b/src/data/hosts/__tests__/handlers.test.ts
@@ -151,6 +151,19 @@ describe('handleRefreshHostStatus', () => {
     await expect(handleRefreshHostStatus(deps, { hostId: 999 })).rejects.toThrow('not found');
   });
 
+  it('passes the host name to checkHealth', async () => {
+    let capturedHostName = '';
+    const checkHealth = mock((_url: string, hostName: string): Promise<HealthCheckOutcome> => {
+      capturedHostName = hostName;
+      return Promise.resolve({ healthy: true as const });
+    });
+    const repo = mockRepo({
+      findById: mock(() => Promise.resolve(mockRow({ name: 'my-host', agentUrl: 'http://x:9090' }))),
+    });
+    await handleRefreshHostStatus({ ...baseDeps(), repo, checkHealth }, { hostId: 1 });
+    expect(capturedHostName).toBe('my-host');
+  });
+
 });
 
 describe('handleVerifyHost', () => {
@@ -624,6 +637,25 @@ describe('handleUpdateAgent', () => {
       expect(result.error).toContain('ECONNREFUSED');
       expect(result.suggestions).toBeDefined();
     }
+    fetchSpy.mockRestore();
+  });
+
+  it('does not treat undefined version as a version change during polling', async () => {
+    let callCount = 0;
+    const checkHealth = mock((): Promise<HealthCheckOutcome> => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve({ healthy: true, version: '1.0.0' });
+      // /info fails transiently on first poll; should not exit the loop
+      if (callCount === 2) return Promise.resolve({ healthy: true, version: undefined });
+      return Promise.resolve({ healthy: true, version: '2.0.0' });
+    });
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }));
+    const deps = updateDeps(undefined, { checkHealth });
+
+    const result = await handleUpdateAgent(deps, { hostId: 1 });
+
+    expect(result.healthy).toBe(true);
+    if (result.healthy) expect(result.version).toBe('2.0.0');
     fetchSpy.mockRestore();
   });
 

--- a/src/data/hosts/__tests__/handlers.test.ts
+++ b/src/data/hosts/__tests__/handlers.test.ts
@@ -626,6 +626,46 @@ describe('handleUpdateAgent', () => {
     fetchSpy.mockRestore();
   });
 
+  it('treats a pre-update /info 404 followed by a readable version as a successful upgrade', async () => {
+    let callCount = 0;
+    const checkHealth = mock((): Promise<HealthCheckOutcome> => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve({ healthy: true, infoSupported: false });
+      return Promise.resolve({ healthy: true, version: '2.0.0', infoSupported: true });
+    });
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }));
+    const deps = updateDeps(undefined, { checkHealth });
+
+    const result = await handleUpdateAgent(deps, { hostId: 1 });
+
+    expect(result.healthy).toBe(true);
+    if (result.healthy) expect(result.version).toBe('2.0.0');
+    fetchSpy.mockRestore();
+  });
+
+  it('does not claim success when the pre-update version was unreadable for a reason other than a 404', async () => {
+    let callCount = 0;
+    const checkHealth = mock((): Promise<HealthCheckOutcome> => {
+      callCount++;
+      if (callCount === 1) return Promise.resolve({ healthy: true, version: undefined });
+      return Promise.resolve({ healthy: true, version: '2.0.0', infoSupported: true });
+    });
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 202 }));
+    const repo = mockRepo();
+    const deps = updateDeps(undefined, { checkHealth });
+    deps.repo = repo;
+
+    const result = await handleUpdateAgent(deps, { hostId: 1 });
+
+    expect(result.healthy).toBe(false);
+    if (!result.healthy) {
+      expect(result.error).toContain('could not be confirmed');
+      expect(result.suggestions).toBeDefined();
+    }
+    expect(repo.updateAgentVersion).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
   it('returns unhealthy with suggestions when POST to agent update endpoint throws', async () => {
     const fetchSpy = spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'));
     const deps = updateDeps();

--- a/src/data/hosts/functions.tsx
+++ b/src/data/hosts/functions.tsx
@@ -30,6 +30,25 @@ async function loadKeypairsRepo(): Promise<import('@/lib/database/repositories/a
   return new AgentKeypairsRepository(dbClient.getPool(), keyring);
 }
 
+/**
+ * Build a checkHealth function that probes the unauthenticated /health endpoint
+ * for liveness, then pulls version detail from the authenticated /info endpoint
+ * with a JWT minted from the host's keypair. Hosts without an enrolled keypair
+ * still get a liveness verdict, just without version info.
+ */
+async function buildCheckHealth(
+  keypairs: import('@/lib/database/repositories/agent-keypairs-repository').AgentKeypairsRepository,
+): Promise<(url: string, hostName: string) => Promise<import('@/lib/services/agent-health-service').AgentHealthResult>> {
+  const { checkAgentHealth } = await import('@/lib/services/agent-health-service');
+  const { signAgentJwt } = await import('@/lib/crypto/agent-jwt');
+  return (url, hostName) =>
+    checkAgentHealth(url, undefined, fetch, async () => {
+      const privateKey = await keypairs.getPrivateKeyForHost(hostName);
+      if (!privateKey) throw new Error(`No agent keypair found for host ${hostName}`);
+      return signAgentJwt(privateKey, hostName);
+    });
+}
+
 async function loadDockerClient(socketProxyUrl: string) {
   const Dockerode = (await import('dockerode')).default;
   let parsed: URL;
@@ -49,7 +68,6 @@ export const addHost = createServerFn()
     requireRole('admin')(context.user);
     const baseDeps = await loadDeps();
     const { AgentProvisioningService } = await import('@/lib/services/agent-provisioning-service');
-    const { checkAgentHealth } = await import('@/lib/services/agent-health-service');
     const keypairs = await loadKeypairsRepo();
     const provService = new AgentProvisioningService();
     return handleAddHost({
@@ -58,7 +76,7 @@ export const addHost = createServerFn()
         createForHost: (name) => keypairs.createForHost(name).then((r) => ({ publicJwk: r.publicJwk })),
         deleteForHost: (name) => keypairs.deleteForHost(name),
       },
-      checkHealth: checkAgentHealth,
+      checkHealth: await buildCheckHealth(keypairs),
       provision: async (url, opts) => {
         const docker = await loadDockerClient(url);
         return provService.provision(docker, opts);
@@ -141,7 +159,6 @@ export const updateAgent = createServerFn()
     requireRole('admin')(context.user);
     const baseDeps = await loadDeps();
     const keypairs = await loadKeypairsRepo();
-    const { checkAgentHealth } = await import('@/lib/services/agent-health-service');
     const { signAgentJwt } = await import('@/lib/crypto/agent-jwt');
     return handleUpdateAgent({
       ...baseDeps,
@@ -150,7 +167,7 @@ export const updateAgent = createServerFn()
         if (!privateKey) throw new Error(`No agent keypair found for host ${hostname}`);
         return () => signAgentJwt(privateKey, hostname);
       },
-      checkHealth: checkAgentHealth,
+      checkHealth: await buildCheckHealth(keypairs),
     }, data);
   });
 
@@ -159,8 +176,8 @@ export const checkHostHealth = createServerFn()
   .inputValidator(checkHostHealthSchema)
   .handler(async ({ data }): Promise<HostOperationResult> => {
     const baseDeps = await loadDeps();
-    const { checkAgentHealth } = await import('@/lib/services/agent-health-service');
-    return handleCheckHostHealth({ ...baseDeps, checkHealth: checkAgentHealth }, data);
+    const keypairs = await loadKeypairsRepo();
+    return handleCheckHostHealth({ ...baseDeps, checkHealth: await buildCheckHealth(keypairs) }, data);
   });
 
 export const updateHost = createServerFn()

--- a/src/data/hosts/functions.tsx
+++ b/src/data/hosts/functions.tsx
@@ -49,6 +49,25 @@ async function buildCheckHealth(
     });
 }
 
+/**
+ * checkHealth for read-only probes. The keypair repo needs a master key a deployment
+ * may not have, so an unusable keyring degrades to liveness instead of throwing.
+ */
+async function buildProbeCheckHealth(): Promise<
+  (url: string, hostName: string) => Promise<import('@/lib/services/agent-health-service').AgentHealthResult>
+> {
+  try {
+    return await buildCheckHealth(await loadKeypairsRepo());
+  } catch (err) {
+    console.info(
+      '[hosts] Agent keypairs unavailable, probing liveness without version detail:',
+      err instanceof Error ? err.message : err,
+    );
+    const { checkAgentHealth } = await import('@/lib/services/agent-health-service');
+    return (url) => checkAgentHealth(url);
+  }
+}
+
 async function loadDockerClient(socketProxyUrl: string) {
   const Dockerode = (await import('dockerode')).default;
   let parsed: URL;
@@ -176,8 +195,7 @@ export const checkHostHealth = createServerFn()
   .inputValidator(checkHostHealthSchema)
   .handler(async ({ data }): Promise<HostOperationResult> => {
     const baseDeps = await loadDeps();
-    const keypairs = await loadKeypairsRepo();
-    return handleCheckHostHealth({ ...baseDeps, checkHealth: await buildCheckHealth(keypairs) }, data);
+    return handleCheckHostHealth({ ...baseDeps, checkHealth: await buildProbeCheckHealth() }, data);
   });
 
 export const updateHost = createServerFn()

--- a/src/data/hosts/handlers.ts
+++ b/src/data/hosts/handlers.ts
@@ -199,7 +199,7 @@ export async function handleUpdateAgent(
   for (const delay of HEALTH_CHECK_DELAYS_MS) {
     await new Promise((resolve) => setTimeout(resolve, delay));
     lastResult = await deps.checkHealth(host.agentUrl, host.name);
-    if (lastResult.healthy && lastResult.version !== currentVersion) {
+    if (lastResult.healthy && lastResult.version !== undefined && lastResult.version !== currentVersion) {
       newVersion = lastResult.version;
       break;
     }

--- a/src/data/hosts/handlers.ts
+++ b/src/data/hosts/handlers.ts
@@ -43,7 +43,7 @@ export async function handleListHosts(deps: HostHandlerDeps): Promise<HostListIt
 }
 
 export async function handleCheckHostHealth(
-  deps: HostHandlerDeps & { checkHealth: (url: string) => Promise<HealthCheckOutcome> },
+  deps: HostHandlerDeps & { checkHealth: (url: string, hostName: string) => Promise<HealthCheckOutcome> },
   data: { hostId: number },
 ): Promise<HostOperationResult> {
 
@@ -51,7 +51,7 @@ export async function handleCheckHostHealth(
   const host = await deps.repo.findById(data.hostId);
   if (!host) throw new Error(`Host with id ${data.hostId} not found`);
 
-  const healthResult = await deps.checkHealth(host.agentUrl);
+  const healthResult = await deps.checkHealth(host.agentUrl, host.name);
   const newStatus: HostStatus = healthResult.healthy ? 'healthy' : 'unhealthy';
   await deps.repo.updateStatus(host.id, newStatus);
 
@@ -82,13 +82,13 @@ export async function handleRemoveHost(
 }
 
 export async function handleRefreshHostStatus(
-  deps: HostHandlerDeps & { checkHealth: (url: string) => Promise<HealthCheckOutcome> },
+  deps: HostHandlerDeps & { checkHealth: (url: string, hostName: string) => Promise<HealthCheckOutcome> },
   data: { hostId: number },
 ): Promise<HostOperationResult> {
   const host = await deps.repo.findById(data.hostId);
   if (!host) throw new Error(`Host with id ${data.hostId} not found`);
 
-  const healthResult = await deps.checkHealth(host.agentUrl);
+  const healthResult = await deps.checkHealth(host.agentUrl, host.name);
   const newStatus: HostStatus = healthResult.healthy ? 'healthy' : 'unhealthy';
   await deps.repo.updateStatus(host.id, newStatus);
   if (healthResult.healthy && healthResult.version) {
@@ -103,7 +103,7 @@ export async function handleRefreshHostStatus(
 export async function handleUpdateAgent(
   deps: HostHandlerDeps & {
     getSigner: (hostname: string) => Promise<() => Promise<string>>;
-    checkHealth: (url: string) => Promise<HealthCheckOutcome>;
+    checkHealth: (url: string, hostName: string) => Promise<HealthCheckOutcome>;
   },
   data: { hostId: number },
 ): Promise<HostOperationResult> {
@@ -111,7 +111,7 @@ export async function handleUpdateAgent(
   if (!host) throw new Error(`Host with id ${data.hostId} not found`);
 
   // 1. Record current version before update
-  const preCheck = await deps.checkHealth(host.agentUrl);
+  const preCheck = await deps.checkHealth(host.agentUrl, host.name);
   if (!preCheck.healthy) {
     return {
       hostId: host.id,
@@ -198,7 +198,7 @@ export async function handleUpdateAgent(
 
   for (const delay of HEALTH_CHECK_DELAYS_MS) {
     await new Promise((resolve) => setTimeout(resolve, delay));
-    lastResult = await deps.checkHealth(host.agentUrl);
+    lastResult = await deps.checkHealth(host.agentUrl, host.name);
     if (lastResult.healthy && lastResult.version !== currentVersion) {
       newVersion = lastResult.version;
       break;
@@ -358,7 +358,7 @@ async function tryDeleteKeypair(
 interface AddHostDeps extends HostHandlerDeps {
   provision: (socketProxyUrl: string, opts: { hostId: number; hostName: string; agentPort: number; publicJwkJson: string; agentImage: string; socketProxyUrl: string }) => Promise<{ agentUrl: string }>;
   keypairs: KeypairsDep;
-  checkHealth: (url: string) => Promise<HealthCheckOutcome>;
+  checkHealth: (url: string, hostName: string) => Promise<HealthCheckOutcome>;
   removeAgent: (socketProxyUrl: string, hostId: number) => Promise<void>;
 }
 
@@ -449,7 +449,7 @@ export async function handleAddHost(
     await rollbackPostProvision(deps, host.id, data, err, `for ${data.name} after post-provision failure`);
   }
 
-  const healthResult = await retryHealthCheck(deps.checkHealth, provisionResult.agentUrl, [500, 1000, 2000]);
+  const healthResult = await retryHealthCheck((url) => deps.checkHealth(url, data.name), provisionResult.agentUrl, [500, 1000, 2000]);
 
   if (!healthResult.healthy) {
     return rollbackHealthCheckFailure(deps, host.id, data, healthResult.error);

--- a/src/data/hosts/handlers.ts
+++ b/src/data/hosts/handlers.ts
@@ -124,6 +124,9 @@ export async function handleUpdateAgent(
     };
   }
   const currentVersion = preCheck.version;
+  // A missing pre-update version only implies an upgrade when /info 404s; any
+  // other cause would make a later version read look like a change that never happened.
+  const preInfoUnsupported = preCheck.infoSupported === false;
 
   // 2. Retrieve signer and mint a JWT for the request
   let signer: () => Promise<string>;
@@ -199,14 +202,15 @@ export async function handleUpdateAgent(
   for (const delay of HEALTH_CHECK_DELAYS_MS) {
     await new Promise((resolve) => setTimeout(resolve, delay));
     lastResult = await deps.checkHealth(host.agentUrl, host.name);
-    if (lastResult.healthy && lastResult.version !== undefined && lastResult.version !== currentVersion) {
+    if (!lastResult.healthy || lastResult.version === undefined) continue;
+    if (preInfoUnsupported || (currentVersion !== undefined && lastResult.version !== currentVersion)) {
       newVersion = lastResult.version;
       break;
     }
   }
 
   if (!newVersion) {
-    if (lastResult.healthy) {
+    if (lastResult.healthy && currentVersion !== undefined && lastResult.version === currentVersion) {
       return {
         hostId: host.id,
         healthy: false,
@@ -214,6 +218,18 @@ export async function handleUpdateAgent(
         suggestions: [
           'Verify the image registry has a newer build',
           'Check that the current version matches your expectations',
+        ],
+      };
+    }
+    if (lastResult.healthy) {
+      return {
+        hostId: host.id,
+        healthy: false,
+        error: 'Agent is reachable but its version could not be read, so the update could not be confirmed',
+        suggestions: [
+          'Run `docker logs hlm-agent` to check which image the agent is running',
+          'Verify the agent has been enrolled with a generated public JWK',
+          'Re-run the health check once the agent settles to refresh its reported version',
         ],
       };
     }

--- a/src/lib/clients/__tests__/agent-client.test.ts
+++ b/src/lib/clients/__tests__/agent-client.test.ts
@@ -354,12 +354,15 @@ describe('AgentClient', () => {
   });
 
   describe('health', () => {
-    it('returns health info from GET /health', async () => {
+    it('returns agent info from GET /info', async () => {
       fetchMock.mockResolvedValueOnce(
         new Response(JSON.stringify({
           status: 'healthy',
           agentVersion: '0.1.0',
-          docker: { version: '24.0.7', apiVersion: '1.43' },
+          capabilities: {
+            docker: { available: true, version: '24.0.7', apiVersion: '1.43' },
+            zfs: { available: false },
+          },
         }), {
           status: 200,
           headers: { 'Content-Type': 'application/json' },
@@ -369,6 +372,7 @@ describe('AgentClient', () => {
       const result = await client.health();
       expect(result.status).toBe('healthy');
       expect(result.version).toBe('0.1.0');
+      expect(fetchMock.mock.calls[0][0]).toBe('http://agent:9090/info');
     });
 
     it('throws AgentClientError when agent is unreachable', async () => {

--- a/src/lib/clients/agent-client.ts
+++ b/src/lib/clients/agent-client.ts
@@ -1,4 +1,4 @@
-import type { AgentStackResponse, AgentHealthCheckResponse } from '@homelab-manager/agent/types';
+import type { AgentStackResponse, AgentInfoResponse } from '@homelab-manager/agent/types';
 import type { AgentDeployPayload, AgentDeployResponse, AgentUpdatePayload } from '@/lib/deploy/types';
 import { retry } from '@/lib/utils/backoff';
 
@@ -142,11 +142,10 @@ export class AgentClient {
   }
 
   async health(): Promise<AgentHealthResponse> {
-    const raw = await this.getJson<AgentHealthCheckResponse>('/health');
-    const version = raw.status === 'healthy'
-      ? raw.agentVersion ?? raw.docker.version
-      : raw.agentVersion;
-    return { status: raw.status, version };
+    // /health is liveness-only (no version field); the authenticated /info
+    // endpoint carries the agent version, and this client always has a signer.
+    const raw = await this.getJson<AgentInfoResponse>('/info');
+    return { status: raw.status, version: raw.agentVersion };
   }
 
   async getZfsPools(): Promise<ZfsPool[]> {

--- a/src/lib/hosts/host-utils.ts
+++ b/src/lib/hosts/host-utils.ts
@@ -20,7 +20,7 @@ export interface HostListItem {
 }
 
 export type HealthCheckOutcome =
-  | { healthy: true; version?: string; dockerVersion?: string }
+  | { healthy: true; version?: string; dockerVersion?: string; infoSupported?: boolean }
   | { healthy: false; error: string };
 
 /**

--- a/src/lib/services/__tests__/agent-health-service.test.ts
+++ b/src/lib/services/__tests__/agent-health-service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, mock, spyOn } from 'bun:test';
 import { checkAgentHealth } from '../agent-health-service';
 
 // Use dependency injection (fetchFn parameter) instead of global fetch mock
@@ -112,6 +112,17 @@ describe('agent-health-service', () => {
       if (!result.healthy) expect(result.error).toContain('non-JSON response');
     });
 
+    it('returns unhealthy when /health body is JSON but missing status field', async () => {
+      const fetchFn = mock(async () =>
+        new Response(JSON.stringify({ ok: true }), { status: 200 })
+      ) as unknown as typeof fetch;
+
+      const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn);
+
+      expect(result.healthy).toBe(false);
+      if (!result.healthy) expect(result.error).toContain('status');
+    });
+
     it('returns unhealthy when agent URL returns a redirect (3xx)', async () => {
       const fetchFn = mock(async () =>
         new Response(null, { status: 301, headers: { Location: 'http://169.254.169.254/metadata' } })
@@ -157,7 +168,8 @@ describe('agent-health-service', () => {
       expect(headers.Authorization).toBe('Bearer jwt-123');
     });
 
-    it('stays healthy without version when /info request fails', async () => {
+    it('stays healthy without version when /info request fails, and logs the error', async () => {
+      const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
       const fetchFn = mock(async (input: string | URL | Request) => {
         const url = typeof input === 'string' ? input : input.toString();
         if (url.endsWith('/health')) return new Response(healthBody, { status: 200 });
@@ -168,9 +180,12 @@ describe('agent-health-service', () => {
 
       expect(result.healthy).toBe(true);
       if (result.healthy) expect(result.version).toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('401'));
+      consoleSpy.mockRestore();
     });
 
-    it('stays healthy without version when getToken throws (no keypair enrolled)', async () => {
+    it('stays healthy without version when getToken throws, and does not log', async () => {
+      const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
       const fetchFn = mock(async () =>
         new Response(healthBody, { status: 200 })
       ) as unknown as typeof fetch;
@@ -181,9 +196,12 @@ describe('agent-health-service', () => {
 
       expect(result.healthy).toBe(true);
       if (result.healthy) expect(result.version).toBeUndefined();
+      expect(consoleSpy).not.toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
 
-    it('stays healthy without version when /info returns non-JSON', async () => {
+    it('stays healthy without version when /info returns non-JSON, and logs the error', async () => {
+      const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
       const fetchFn = mock(async (input: string | URL | Request) => {
         const url = typeof input === 'string' ? input : input.toString();
         if (url.endsWith('/health')) return new Response(healthBody, { status: 200 });
@@ -194,6 +212,8 @@ describe('agent-health-service', () => {
 
       expect(result.healthy).toBe(true);
       if (result.healthy) expect(result.version).toBeUndefined();
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
     });
 
     it('does not call /info when /health already failed', async () => {

--- a/src/lib/services/__tests__/agent-health-service.test.ts
+++ b/src/lib/services/__tests__/agent-health-service.test.ts
@@ -216,6 +216,54 @@ describe('agent-health-service', () => {
       consoleSpy.mockRestore();
     });
 
+    it('reports infoSupported false and logs at info level when /info 404s', async () => {
+      const errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+      const infoSpy = spyOn(console, 'info').mockImplementation(() => {});
+      const fetchFn = mock(async (input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/health')) return new Response(healthBody, { status: 200 });
+        return new Response('Not Found', { status: 404 });
+      }) as unknown as typeof fetch;
+
+      const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn, async () => 'jwt-123');
+
+      expect(result.healthy).toBe(true);
+      if (result.healthy) {
+        expect(result.version).toBeUndefined();
+        expect(result.infoSupported).toBe(false);
+      }
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining('no /info endpoint'));
+      errorSpy.mockRestore();
+      infoSpy.mockRestore();
+    });
+
+    it('reports infoSupported true when /info answers', async () => {
+      const fetchFn = mock(async (input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/health')) return new Response(healthBody, { status: 200 });
+        return new Response(infoBody(), { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn, async () => 'jwt-123');
+
+      expect(result.healthy).toBe(true);
+      if (result.healthy) expect(result.infoSupported).toBe(true);
+    });
+
+    it('leaves infoSupported undefined when getToken throws', async () => {
+      const fetchFn = mock(async () =>
+        new Response(healthBody, { status: 200 })
+      ) as unknown as typeof fetch;
+
+      const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn, async () => {
+        throw new Error('No agent keypair found for host x');
+      });
+
+      expect(result.healthy).toBe(true);
+      if (result.healthy) expect(result.infoSupported).toBeUndefined();
+    });
+
     it('does not call /info when /health already failed', async () => {
       const calls: string[] = [];
       const fetchFn = mock(async (input: string | URL | Request) => {

--- a/src/lib/services/__tests__/agent-health-service.test.ts
+++ b/src/lib/services/__tests__/agent-health-service.test.ts
@@ -4,27 +4,32 @@ import { checkAgentHealth } from '../agent-health-service';
 // Use dependency injection (fetchFn parameter) instead of global fetch mock
 // per CLAUDE.md rule 7: avoid globalThis mocks, use narrow-scope DI instead.
 
+const healthBody = JSON.stringify({ status: 'healthy' });
+
+function infoBody(agentVersion = '0.1.0', dockerVersion = '24.0.7'): string {
+  return JSON.stringify({
+    status: 'healthy',
+    agentVersion,
+    capabilities: {
+      docker: { available: true, version: dockerVersion, apiVersion: '1.43' },
+      zfs: { available: false },
+    },
+  });
+}
+
 describe('agent-health-service', () => {
   describe('checkAgentHealth', () => {
     it('returns healthy result when agent responds with 200', async () => {
       const fetchFn = mock(async () =>
-        new Response(
-          JSON.stringify({
-            status: 'ok',
-            version: '0.1.0',
-            dockerVersion: '24.0.7',
-            uptime: 3600,
-          }),
-          { status: 200 }
-        )
+        new Response(healthBody, { status: 200 })
       ) as unknown as typeof fetch;
 
       const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn);
 
       expect(result.healthy).toBe(true);
       if (result.healthy) {
-        expect(result.version).toBe('0.1.0');
-        expect(result.dockerVersion).toBe('24.0.7');
+        expect(result.version).toBeUndefined();
+        expect(result.dockerVersion).toBeUndefined();
       }
     });
 
@@ -54,10 +59,7 @@ describe('agent-health-service', () => {
       let calledUrl = '';
       const fetchFn = mock(async (input: string | URL | Request) => {
         calledUrl = typeof input === 'string' ? input : input.toString();
-        return new Response(
-          JSON.stringify({ status: 'ok', version: '0.1.0' }),
-          { status: 200 }
-        );
+        return new Response(healthBody, { status: 200 });
       }) as unknown as typeof fetch;
 
       await checkAgentHealth('http://agent:9090', undefined, fetchFn);
@@ -67,10 +69,7 @@ describe('agent-health-service', () => {
     it('uses a timeout via AbortSignal', async () => {
       const fetchFn = mock(async (_input: string | URL | Request, init?: RequestInit) => {
         expect(init?.signal).toBeDefined();
-        return new Response(
-          JSON.stringify({ status: 'ok', version: '0.1.0' }),
-          { status: 200 }
-        );
+        return new Response(healthBody, { status: 200 });
       }) as unknown as typeof fetch;
 
       await checkAgentHealth('http://agent:9090', undefined, fetchFn);
@@ -128,10 +127,7 @@ describe('agent-health-service', () => {
       let capturedInit: RequestInit | undefined;
       const fetchFn = mock(async (_input: string | URL | Request, init?: RequestInit) => {
         capturedInit = init;
-        return new Response(
-          JSON.stringify({ status: 'ok', version: '0.1.0' }),
-          { status: 200 }
-        );
+        return new Response(healthBody, { status: 200 });
       }) as unknown as typeof fetch;
 
       await checkAgentHealth('http://agent:9090', undefined, fetchFn);
@@ -139,4 +135,79 @@ describe('agent-health-service', () => {
     });
   });
 
+  describe('checkAgentHealth with getToken (authenticated /info)', () => {
+    it('fetches version detail from /info with a bearer token', async () => {
+      const calls: Array<{ url: string; init?: RequestInit }> = [];
+      const fetchFn = mock(async (input: string | URL | Request, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        calls.push({ url, init });
+        if (url.endsWith('/health')) return new Response(healthBody, { status: 200 });
+        return new Response(infoBody('0.5.0', '27.1.1'), { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn, async () => 'jwt-123');
+
+      expect(result.healthy).toBe(true);
+      if (result.healthy) {
+        expect(result.version).toBe('0.5.0');
+        expect(result.dockerVersion).toBe('27.1.1');
+      }
+      expect(calls[1].url).toBe('http://agent:9090/info');
+      const headers = calls[1].init?.headers as Record<string, string>;
+      expect(headers.Authorization).toBe('Bearer jwt-123');
+    });
+
+    it('stays healthy without version when /info request fails', async () => {
+      const fetchFn = mock(async (input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/health')) return new Response(healthBody, { status: 200 });
+        return new Response('Unauthorized', { status: 401 });
+      }) as unknown as typeof fetch;
+
+      const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn, async () => 'jwt-123');
+
+      expect(result.healthy).toBe(true);
+      if (result.healthy) expect(result.version).toBeUndefined();
+    });
+
+    it('stays healthy without version when getToken throws (no keypair enrolled)', async () => {
+      const fetchFn = mock(async () =>
+        new Response(healthBody, { status: 200 })
+      ) as unknown as typeof fetch;
+
+      const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn, async () => {
+        throw new Error('No agent keypair found for host x');
+      });
+
+      expect(result.healthy).toBe(true);
+      if (result.healthy) expect(result.version).toBeUndefined();
+    });
+
+    it('stays healthy without version when /info returns non-JSON', async () => {
+      const fetchFn = mock(async (input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.endsWith('/health')) return new Response(healthBody, { status: 200 });
+        return new Response('not json', { status: 200 });
+      }) as unknown as typeof fetch;
+
+      const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn, async () => 'jwt-123');
+
+      expect(result.healthy).toBe(true);
+      if (result.healthy) expect(result.version).toBeUndefined();
+    });
+
+    it('does not call /info when /health already failed', async () => {
+      const calls: string[] = [];
+      const fetchFn = mock(async (input: string | URL | Request) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        calls.push(url);
+        return new Response('down', { status: 503 });
+      }) as unknown as typeof fetch;
+
+      const result = await checkAgentHealth('http://agent:9090', undefined, fetchFn, async () => 'jwt-123');
+
+      expect(result.healthy).toBe(false);
+      expect(calls).toEqual(['http://agent:9090/health']);
+    });
+  });
 });

--- a/src/lib/services/agent-health-service.ts
+++ b/src/lib/services/agent-health-service.ts
@@ -8,9 +8,11 @@ const HEALTH_CHECK_TIMEOUT_MS = 5000;
 
 /**
  * Fetch version and capability detail from the agent's authenticated /info
- * endpoint. Best-effort: returns an empty object on any failure (no keypair
- * yet, agent too old to serve /info, network error) so liveness reporting is
- * never blocked by missing detail.
+ * endpoint. Best-effort: returns an empty object on any failure so liveness
+ * reporting is never blocked by missing detail.
+ * getToken failures are silent (expected for pending/unenrolled hosts).
+ * HTTP errors and network failures are logged so operators can diagnose why
+ * version info is missing in Settings -> Managed Hosts.
  */
 async function fetchAgentInfo(
   agentUrl: string,
@@ -18,20 +20,33 @@ async function fetchAgentInfo(
   fetchFn: typeof fetch,
   getToken: () => Promise<string>
 ): Promise<{ version?: string; dockerVersion?: string }> {
+  let token: string;
   try {
-    const token = await getToken();
+    token = await getToken();
+  } catch {
+    return {};
+  }
+
+  try {
     const response = await fetchFn(`${agentUrl}/info`, {
       headers: { Authorization: `Bearer ${token}` },
       signal: AbortSignal.timeout(timeoutMs),
       redirect: 'manual',
     });
-    if (!response.ok) return {};
+    if (!response.ok) {
+      console.error(`[agent-health] /info returned ${response.status} for ${agentUrl}`);
+      return {};
+    }
     const data = (await response.json()) as AgentInfoResponse;
     return {
       version: data.agentVersion,
       dockerVersion: data.capabilities?.docker?.version,
     };
-  } catch {
+  } catch (err) {
+    console.error(
+      `[agent-health] /info request failed for ${agentUrl}:`,
+      err instanceof Error ? err.message : err
+    );
     return {};
   }
 }
@@ -69,12 +84,16 @@ export async function checkAgentHealth(
       };
     }
 
-    // Parse the body to confirm the URL points at an agent and not some other
-    // HTTP server that happens to return 200.
+    // Validate the body shape to confirm this is an agent response, not an
+    // unrelated HTTP server that happens to return 200.
+    let body: AgentHealthCheckResponse;
     try {
-      (await response.json()) as AgentHealthCheckResponse;
+      body = (await response.json()) as AgentHealthCheckResponse;
     } catch {
       return { healthy: false, error: `Agent returned non-JSON response (status ${response.status})` };
+    }
+    if (body?.status !== 'healthy') {
+      return { healthy: false, error: 'Agent /health response missing expected status field' };
     }
 
     const info = getToken

--- a/src/lib/services/agent-health-service.ts
+++ b/src/lib/services/agent-health-service.ts
@@ -1,7 +1,7 @@
 import type { AgentHealthCheckResponse, AgentInfoResponse } from '@homelab-manager/agent/types';
 
 export type AgentHealthResult =
-  | { healthy: true; version?: string; dockerVersion?: string }
+  | { healthy: true; version?: string; dockerVersion?: string; infoSupported?: boolean }
   | { healthy: false; error: string };
 
 const HEALTH_CHECK_TIMEOUT_MS = 5000;
@@ -13,13 +13,16 @@ const HEALTH_CHECK_TIMEOUT_MS = 5000;
  * getToken failures are silent (expected for pending/unenrolled hosts).
  * HTTP errors and network failures are logged so operators can diagnose why
  * version info is missing in Settings -> Managed Hosts.
+ *
+ * @returns `infoSupported: false` when the agent predates /info (404), which
+ * callers use to tell "version unknown" apart from "version unchanged".
  */
 async function fetchAgentInfo(
   agentUrl: string,
   timeoutMs: number,
   fetchFn: typeof fetch,
   getToken: () => Promise<string>
-): Promise<{ version?: string; dockerVersion?: string }> {
+): Promise<{ version?: string; dockerVersion?: string; infoSupported?: boolean }> {
   let token: string;
   try {
     token = await getToken();
@@ -33,6 +36,12 @@ async function fetchAgentInfo(
       signal: AbortSignal.timeout(timeoutMs),
       redirect: 'manual',
     });
+    if (response.status === 404) {
+      console.info(
+        `[agent-health] ${agentUrl} has no /info endpoint; agent predates authenticated version reporting`
+      );
+      return { infoSupported: false };
+    }
     if (!response.ok) {
       console.error(`[agent-health] /info returned ${response.status} for ${agentUrl}`);
       return {};
@@ -41,6 +50,7 @@ async function fetchAgentInfo(
     return {
       version: data.agentVersion,
       dockerVersion: data.capabilities?.docker?.version,
+      infoSupported: true,
     };
   } catch (err) {
     console.error(

--- a/src/lib/services/agent-health-service.ts
+++ b/src/lib/services/agent-health-service.ts
@@ -1,9 +1,4 @@
-export interface AgentHealthResponse {
-  status: string;
-  version: string;
-  dockerVersion?: string;
-  uptime?: number;
-}
+import type { AgentHealthCheckResponse, AgentInfoResponse } from '@homelab-manager/agent/types';
 
 export type AgentHealthResult =
   | { healthy: true; version?: string; dockerVersion?: string }
@@ -12,16 +7,50 @@ export type AgentHealthResult =
 const HEALTH_CHECK_TIMEOUT_MS = 5000;
 
 /**
- * Check the health of an agent by calling its /health endpoint.
- * Returns a result object indicating health status and version info.
+ * Fetch version and capability detail from the agent's authenticated /info
+ * endpoint. Best-effort: returns an empty object on any failure (no keypair
+ * yet, agent too old to serve /info, network error) so liveness reporting is
+ * never blocked by missing detail.
+ */
+async function fetchAgentInfo(
+  agentUrl: string,
+  timeoutMs: number,
+  fetchFn: typeof fetch,
+  getToken: () => Promise<string>
+): Promise<{ version?: string; dockerVersion?: string }> {
+  try {
+    const token = await getToken();
+    const response = await fetchFn(`${agentUrl}/info`, {
+      headers: { Authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(timeoutMs),
+      redirect: 'manual',
+    });
+    if (!response.ok) return {};
+    const data = (await response.json()) as AgentInfoResponse;
+    return {
+      version: data.agentVersion,
+      dockerVersion: data.capabilities?.docker?.version,
+    };
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Check the health of an agent by calling its unauthenticated /health endpoint
+ * (liveness only, the agent strips version and capability detail from it).
+ * When `getToken` is provided, version info is fetched from the authenticated
+ * /info endpoint; failures there do not affect the healthy verdict.
  * Never throws: all errors are captured in the result.
  *
  * @param fetchFn - Injectable fetch function for testing (defaults to globalThis.fetch)
+ * @param getToken - Optional JWT minter for the authenticated /info request
  */
 export async function checkAgentHealth(
   agentUrl: string,
   timeoutMs: number = HEALTH_CHECK_TIMEOUT_MS,
-  fetchFn: typeof fetch = globalThis.fetch
+  fetchFn: typeof fetch = globalThis.fetch,
+  getToken?: () => Promise<string>
 ): Promise<AgentHealthResult> {
   try {
     const response = await fetchFn(`${agentUrl}/health`, {
@@ -40,18 +69,19 @@ export async function checkAgentHealth(
       };
     }
 
-    let data: AgentHealthResponse;
+    // Parse the body to confirm the URL points at an agent and not some other
+    // HTTP server that happens to return 200.
     try {
-      data = (await response.json()) as AgentHealthResponse;
+      (await response.json()) as AgentHealthCheckResponse;
     } catch {
       return { healthy: false, error: `Agent returned non-JSON response (status ${response.status})` };
     }
 
-    return {
-      healthy: true,
-      version: data.version,
-      dockerVersion: data.dockerVersion,
-    };
+    const info = getToken
+      ? await fetchAgentInfo(agentUrl, timeoutMs, fetchFn, getToken)
+      : {};
+
+    return { healthy: true, ...info };
   } catch (err: unknown) {
     if (err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
       return {


### PR DESCRIPTION
## Summary

- Agent `/health` (intentionally unauthenticated) previously returned the agent version, Docker engine/API versions, and ZFS capability detail. It now returns only `{ status: "healthy" | "unhealthy" }` with the same 200/503 semantics, so liveness consumers (agent-updater `health-reporter`, the agent Dockerfile HEALTHCHECK, worker dev-seed) keep working unchanged.
- Added an authenticated `GET /info` endpoint on the agent that carries the previous detail payload (`agentVersion`, Docker and ZFS capabilities). The auth middleware only bypasses `/health`, so `/info` requires a valid JWT; a middleware test asserts this.
- Updated the shared contract types in `agent/src/types.ts`: `AgentHealthCheckResponse` is now status-only and a new `AgentInfoResponse` describes `/info`. The old `AgentHealthyResponse`/`AgentUnhealthyResponse` types did not match what the agent actually returned.
- `AgentClient.health()` now queries `/info` (it always has a signer) and reads `agentVersion`.
- `checkAgentHealth()` in the web app still probes `/health` for liveness, and accepts an optional token minter to fetch version/Docker version from `/info` afterward. Failures on `/info` (no keypair enrolled yet, older agent, network error) never affect the healthy verdict.
- Host server functions (`addHost`, `updateAgent`, `checkHostHealth`) wire a per-host JWT signer into the health check, so agent version reporting in Settings -> Managed Hosts is preserved (and now actually populated; the old code read a `version` field the agent never sent).
- Updated the agent endpoint table in `docs/architecture.md`.

## Testing

- `bun run typecheck` and `bun run typecheck:agent`: pass.
- Agent: full suite `bun test --isolate` (269 pass), including new `handleInfo` tests, status-only `/health` assertions, and a middleware test that `/info` requires auth.
- Web: `agent-health-service.test.ts` (liveness plus new authenticated `/info` paths: bearer token, 401, non-JSON, token minting failure, no `/info` call when `/health` fails), `agent-client.test.ts` (health() hits `/info`), `handlers.test.ts`, `host-utils.test.ts`: all pass.

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)
