### PR TITLE
fix(sse): add periodic heartbeats to web factories and agent streams

### DIFF
--- a/agent/src/__tests__/containers-events.test.ts
+++ b/agent/src/__tests__/containers-events.test.ts
@@ -102,6 +102,20 @@ describe('handleContainerEvents: response headers', () => {
   });
 });
 
+describe('handleContainerEvents: heartbeat', () => {
+  test('emits heartbeat comment pings while no container events occur', async () => {
+    const docker = makeDocker([]);
+    const ac = new AbortController();
+    const request = new Request('http://localhost/containers/events', { signal: ac.signal });
+    const response = await handleContainerEvents(docker as any, request, 10);
+
+    const text = await readUntil(response, (s) => s.includes(': ping'));
+    ac.abort();
+
+    expect(text).toContain(': ping\n\n');
+  });
+});
+
 describe('handleContainerEvents: init snapshot', () => {
   test('emits init event with all containers on connect', async () => {
     const containers = [

--- a/agent/src/__tests__/stats.test.ts
+++ b/agent/src/__tests__/stats.test.ts
@@ -211,6 +211,18 @@ describe('handleStatsStream', () => {
     expect(response.headers.get('Connection')).toBe('keep-alive');
   });
 
+  test('emits heartbeat comment pings while the stream is idle', async () => {
+    const mockDocker = { listContainers: mock(() => Promise.resolve([])) };
+    const ac = new AbortController();
+    const request = new Request('http://localhost/stats/stream', { signal: ac.signal });
+    const response = handleStatsStream(mockDocker as any, request, { heartbeatIntervalMs: 10 });
+
+    const text = await readUntil(response, (s) => s.includes(': ping'));
+    ac.abort();
+
+    expect(text).toContain(': ping\n\n');
+  });
+
   test('streams flat computed stats as SSE events', async () => {
     const statsEmitter = new EventEmitter();
 

--- a/agent/src/__tests__/zfs.test.ts
+++ b/agent/src/__tests__/zfs.test.ts
@@ -141,6 +141,31 @@ describe('handleZfsStatsStream', () => {
     expect(tankEvent.line).toContain('tank');
   });
 
+  test('emits heartbeat comment pings while iostat is silent', async () => {
+    const killMock = mock(() => {});
+    const readableStream = new ReadableStream<Uint8Array>({
+      start() {
+        // Keep stream open with no output; simulates a silent iostat
+      },
+    });
+
+    Bun.spawn = mock(() => ({
+      stdout: readableStream,
+      stderr: new ReadableStream(),
+      kill: killMock,
+      exited: new Promise(() => {}), // never resolves
+    })) as any;
+
+    const ac = new AbortController();
+    const request = new Request('http://localhost/zfs/stats/stream', { signal: ac.signal });
+    const response = handleZfsStatsStream(request, zfsAvailable, 10);
+
+    const text = await readUntil(response, (s) => s.includes(': ping'));
+    ac.abort();
+
+    expect(text).toContain(': ping\n\n');
+  });
+
   test('kills subprocess on client disconnect', async () => {
     const killMock = mock(() => {});
     const readableStream = new ReadableStream<Uint8Array>({

--- a/agent/src/lib/__tests__/sse-utils.test.ts
+++ b/agent/src/lib/__tests__/sse-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, mock, beforeAll, beforeEach, afterAll } from 'bun:test';
-import { sendSSE } from '../sse-utils';
+import { sendSSE, startSseHeartbeat } from '../sse-utils';
 
 const originalConsoleError = console.error;
 
@@ -99,5 +99,54 @@ describe('sendSSE', () => {
     expect(() => {
       sendSSE(controller, makeEncoder(), { value: false }, 'hello');
     }).toThrow(err);
+  });
+});
+
+describe('startSseHeartbeat', () => {
+  test('enqueues comment pings on each interval tick', async () => {
+    const { controller, enqueued } = makeController();
+    const stop = startSseHeartbeat(controller, makeEncoder(), () => false, 5);
+
+    await new Promise((r) => setTimeout(r, 20));
+    stop();
+
+    expect(enqueued.length).toBeGreaterThanOrEqual(1);
+    expect(enqueued[0]).toBe(': ping\n\n');
+  });
+
+  test('stops pinging once isClosed reports true', async () => {
+    const { controller, enqueued } = makeController();
+    let closed = false;
+    const stop = startSseHeartbeat(controller, makeEncoder(), () => closed, 5);
+
+    await new Promise((r) => setTimeout(r, 15));
+    closed = true;
+    await new Promise((r) => setTimeout(r, 15));
+    const countAtClose = enqueued.length;
+    await new Promise((r) => setTimeout(r, 15));
+    stop();
+
+    expect(enqueued.length).toBe(countAtClose);
+  });
+
+  test('clears itself when enqueue throws (controller already closed)', async () => {
+    const { controller, enqueued, makeEnqueueThrow } = makeController();
+    makeEnqueueThrow(new TypeError('Controller is closed'));
+    const stop = startSseHeartbeat(controller, makeEncoder(), () => false, 5);
+
+    await new Promise((r) => setTimeout(r, 30));
+    stop();
+
+    expect(enqueued).toHaveLength(0);
+  });
+
+  test('stop function prevents any further pings', async () => {
+    const { controller, enqueued } = makeController();
+    const stop = startSseHeartbeat(controller, makeEncoder(), () => false, 5);
+    stop();
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(enqueued).toHaveLength(0);
   });
 });

--- a/agent/src/lib/sse-utils.ts
+++ b/agent/src/lib/sse-utils.ts
@@ -1,3 +1,44 @@
+/**
+ * Default heartbeat period. Must stay below typical idle timeouts that kill
+ * quiet streams (Bun's idleTimeout, nginx's 60 s proxy_read_timeout).
+ */
+export const SSE_HEARTBEAT_INTERVAL_MS = 25_000;
+
+/**
+ * Start a periodic SSE comment ping (`: ping\n\n`) that keeps proxies and
+ * Bun's idleTimeout from killing streams with no traffic.
+ *
+ * The interval clears itself when `isClosed()` reports true or when enqueue
+ * throws (controller already closed). Callers should still invoke the
+ * returned stop function from their teardown path so the timer dies with the
+ * stream instead of one period later.
+ *
+ * @param controller - Stream controller the ping frames are enqueued on
+ * @param encoder - Shared TextEncoder for the session
+ * @param isClosed - Reports whether the session has been torn down
+ * @param intervalMs - Ping period in milliseconds (default: 25s)
+ * @returns Stop function that clears the interval
+ */
+export function startSseHeartbeat(
+  controller: ReadableStreamDefaultController<Uint8Array>,
+  encoder: TextEncoder,
+  isClosed: () => boolean,
+  intervalMs: number = SSE_HEARTBEAT_INTERVAL_MS,
+): () => void {
+  const timer = setInterval(() => {
+    if (isClosed()) {
+      clearInterval(timer);
+      return;
+    }
+    try {
+      controller.enqueue(encoder.encode(': ping\n\n'));
+    } catch {
+      clearInterval(timer);
+    }
+  }, intervalMs);
+  return () => clearInterval(timer);
+}
+
 /** Enqueue an SSE data event, silently swallowing enqueue-after-close TypeError. */
 export function sendSSE(
   controller: ReadableStreamDefaultController<Uint8Array>,

--- a/agent/src/routes/containers-events.ts
+++ b/agent/src/routes/containers-events.ts
@@ -1,7 +1,7 @@
 import type Dockerode from 'dockerode';
 import { subscribe as broadcasterSubscribe } from '../lib/docker-events-broadcaster';
 import type { MinimalContainerInfo, BroadcasterEvent } from '../lib/docker-events-broadcaster';
-import { sendSSE } from '../lib/sse-utils';
+import { sendSSE, startSseHeartbeat } from '../lib/sse-utils';
 import type {
   AgentContainerEvent,
   ContainerState,
@@ -63,16 +63,24 @@ function toUpdateContainer(c: MinimalContainerInfo): InventoryUpdateContainer {
  *
  * @param docker - Dockerode client used to interact with the Docker daemon
  * @param request - The HTTP request; its abort signal triggers cleanup
+ * @param heartbeatIntervalMs - Comment ping period in milliseconds (default: 25s)
  */
-export async function handleContainerEvents(docker: Dockerode, request: Request): Promise<Response> {
+export async function handleContainerEvents(
+  docker: Dockerode,
+  request: Request,
+  heartbeatIntervalMs?: number,
+): Promise<Response> {
   const encoder = new TextEncoder();
   const closed = { value: false };
   let unsubscribe: (() => void) | null = null;
 
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
+      let stopHeartbeat: () => void = () => {};
+
       request.signal.addEventListener('abort', () => {
         closed.value = true;
+        stopHeartbeat();
         unsubscribe?.();
         try {
           controller.close();
@@ -86,6 +94,16 @@ export async function handleContainerEvents(docker: Dockerode, request: Request)
         } catch {}
         return;
       }
+
+      // Inventory events only fire on container state changes, which can be
+      // hours apart; a comment ping keeps proxies and Bun's idleTimeout from
+      // killing the quiet stream.
+      stopHeartbeat = startSseHeartbeat(
+        controller,
+        encoder,
+        () => closed.value,
+        heartbeatIntervalMs,
+      );
 
       const sub = await broadcasterSubscribe(docker, (event: BroadcasterEvent) => {
         let message: AgentContainerEvent;

--- a/agent/src/routes/stats.ts
+++ b/agent/src/routes/stats.ts
@@ -1,5 +1,6 @@
 import type { Readable } from 'node:stream';
 import type Dockerode from 'dockerode';
+import { startSseHeartbeat } from '../lib/sse-utils';
 
 const DEFAULT_REFRESH_INTERVAL_MS = 60_000;
 const DEFAULT_POLL_INTERVAL_MS = 5_000;
@@ -10,6 +11,8 @@ export interface StatsStreamOptions {
   pollIntervalMs?: number;
   /** Close the stream after this many consecutive refresh failures (default: 10). */
   maxConsecutiveFailures?: number;
+  /** Heartbeat comment period in milliseconds (default: 25s). */
+  heartbeatIntervalMs?: number;
 }
 
 /** Flat computed metrics matching the worker's AgentStatsEvent interface. */
@@ -420,8 +423,18 @@ export function handleStatsStream(
         controller,
       };
 
+      // Stats frames stop flowing when no containers run; a comment ping
+      // keeps proxies and Bun's idleTimeout from killing the quiet stream.
+      const stopHeartbeat = startSseHeartbeat(
+        controller,
+        ctx.encoder,
+        () => ctx.closed,
+        options.heartbeatIntervalMs,
+      );
+
       request.signal.addEventListener('abort', () => {
         ctx.closed = true;
+        stopHeartbeat();
         destroyAllStreams(ctx.containerStreams);
         tryCloseController(controller);
       });
@@ -433,6 +446,8 @@ export function handleStatsStream(
         const msg = error instanceof Error ? error.message : String(error);
         sendSSE(ctx, JSON.stringify({ error: msg }), 'error');
         tryCloseController(controller);
+      } finally {
+        stopHeartbeat();
       }
     },
   });

--- a/agent/src/routes/zfs.ts
+++ b/agent/src/routes/zfs.ts
@@ -1,14 +1,18 @@
 import type { ZfsCapabilities } from '../lib/zfs-capabilities';
+import { startSseHeartbeat } from '../lib/sse-utils';
 
 /**
  * GET /zfs/stats/stream: SSE endpoint that streams `zpool iostat -v 1` output.
  *
  * Each non-empty line from the subprocess is emitted as an SSE event with
  * `{ line, timestamp }`. The subprocess is killed when the client disconnects.
+ *
+ * @param heartbeatIntervalMs - Comment ping period in milliseconds (default: 25s)
  */
 export function handleZfsStatsStream(
   request: Request,
   capabilities: ZfsCapabilities,
+  heartbeatIntervalMs?: number,
 ): Response {
   if (!capabilities.available) {
     return Response.json(
@@ -29,8 +33,19 @@ export function handleZfsStatsStream(
 
         let closed = false;
 
+        // `zpool iostat 1` normally emits every second, but a wedged pool or
+        // stalled subprocess can go silent; a comment ping keeps proxies and
+        // Bun's idleTimeout from killing the connection in the meantime.
+        const stopHeartbeat = startSseHeartbeat(
+          controller,
+          encoder,
+          () => closed,
+          heartbeatIntervalMs,
+        );
+
         request.signal.addEventListener('abort', () => {
           closed = true;
+          stopHeartbeat();
           proc.kill();
           try {
             controller.close();
@@ -71,6 +86,7 @@ export function handleZfsStatsStream(
             console.error('ZFS stats stream error:', err);
           }
         } finally {
+          stopHeartbeat();
           proc.kill();
           if (!closed) {
             closed = true;

--- a/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
@@ -7,7 +7,10 @@ mock.module('@/lib/auth/sse-auth', () => ({
 
 type Event = { n: number };
 
-function setup(serialize: (e: Event) => string = (e) => `data: ${JSON.stringify(e)}\n\n`) {
+function setup(
+  serialize: (e: Event) => string = (e) => `data: ${JSON.stringify(e)}\n\n`,
+  heartbeatIntervalMs?: number,
+) {
   let captured: ((event: Event) => void) | null = null;
   const unsubscribe = mock(() => {});
   const subscribe = mock((cb: (event: Event) => void) => {
@@ -19,6 +22,7 @@ function setup(serialize: (e: Event) => string = (e) => `data: ${JSON.stringify(
     loadSubscribe: async () => subscribe,
     serialize,
     errorEvent: 'test_error',
+    heartbeatIntervalMs,
   });
 
   return {
@@ -212,6 +216,57 @@ describe('createBroadcastSseHandler', () => {
 
     reader.cancel();
     ac.abort();
+  });
+
+  it('emits periodic comment pings on the heartbeat interval', async () => {
+    const { handler } = setup(undefined, 5);
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+    const decoder = new TextDecoder();
+
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toBe(': ok\n\n');
+
+    const second = await reader.read();
+    expect(decoder.decode(second.value)).toBe(': ping\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('tears down when the heartbeat ping hits a dead consumer', async () => {
+    const { handler, unsubscribe } = setup(undefined, 5);
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+    await reader.read(); // initial flush comment
+
+    // Cancelling the reader closes the controller without firing abort, so
+    // the next ping's enqueue throws and must trigger teardown.
+    await reader.cancel();
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+    ac.abort();
+  });
+
+  it('stops the heartbeat after abort', async () => {
+    const clearSpy = spyOn(globalThis, 'clearInterval');
+    try {
+      const { handler } = setup(undefined, 5);
+      const ac = new AbortController();
+
+      await handler({ request: makeRequest(ac) });
+      ac.abort();
+
+      expect(clearSpy).toHaveBeenCalled();
+    } finally {
+      clearSpy.mockRestore();
+    }
   });
 
   it('returns 401 when authenticateSSE returns null', async () => {

--- a/src/lib/sse/__tests__/create-stats-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-stats-sse-handler.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { createStatsSseHandler } from '../create-stats-sse-handler';
+
+mock.module('@/lib/auth/sse-auth', () => ({
+  authenticateSSE: mock(async () => ({ id: 1, role: 'admin' })),
+}));
+
+mock.module('@/lib/server-init', () => ({}));
+
+type SendData = (rows: unknown[]) => void;
+type SendError = () => void;
+
+const unsubscribe = mock(() => {});
+const subscribeState: {
+  sendData: SendData | null;
+  sendError: SendError | null;
+  impl: (() => void) | null;
+} = { sendData: null, sendError: null, impl: null };
+
+const subscribe = mock((_source: string, sendData: SendData, sendError: SendError) => {
+  subscribeState.sendData = sendData;
+  subscribeState.sendError = sendError;
+  subscribeState.impl?.();
+  return unsubscribe;
+});
+
+mock.module('@/lib/database/subscription-service', () => ({
+  statsPollService: { subscribe },
+}));
+
+function makeRequest(ac: AbortController): Request {
+  return new Request('http://localhost/', { signal: ac.signal });
+}
+
+function readerOf(res: Response): ReadableStreamDefaultReader<Uint8Array> {
+  if (!res.body) throw new Error('Response had no body');
+  return res.body.getReader();
+}
+
+describe('createStatsSseHandler', () => {
+  beforeEach(() => {
+    unsubscribe.mockClear();
+    subscribe.mockClear();
+    subscribeState.sendData = null;
+    subscribeState.sendError = null;
+    subscribeState.impl = null;
+  });
+
+  it('returns an SSE response with the standard headers', async () => {
+    const handler = createStatsSseHandler('docker');
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(res.headers.get('Cache-Control')).toBe('no-cache');
+    expect(res.headers.get('Connection')).toBe('keep-alive');
+
+    ac.abort();
+  });
+
+  it('subscribes with the configured source and streams rows after the flush comment', async () => {
+    const handler = createStatsSseHandler('zfs');
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+    const decoder = new TextDecoder();
+
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toBe(': ok\n\n');
+    expect(subscribe).toHaveBeenCalledWith('zfs', expect.any(Function), expect.any(Function));
+
+    subscribeState.sendData?.([{ host: 'h1' }]);
+    const second = await reader.read();
+    expect(decoder.decode(second.value)).toBe('data: [{"host":"h1"}]\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('emits a stats_error frame when the poll service reports an error', async () => {
+    const handler = createStatsSseHandler('proxmox');
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+    const decoder = new TextDecoder();
+    await reader.read(); // flush comment
+
+    subscribeState.sendError?.();
+    const frame = await reader.read();
+    expect(decoder.decode(frame.value)).toBe('event: stats_error\ndata: {}\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('emits stats_error and closes the stream when subscribe throws', async () => {
+    subscribeState.impl = () => {
+      throw new Error('db offline');
+    };
+    const handler = createStatsSseHandler('docker');
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+    const decoder = new TextDecoder();
+
+    let body = '';
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      body += decoder.decode(value);
+    }
+
+    expect(body).toContain(': ok\n\n');
+    expect(body).toContain('event: stats_error\ndata: {}\n\n');
+
+    ac.abort();
+  });
+
+  it('unsubscribes when the request aborts and drops later rows', async () => {
+    const handler = createStatsSseHandler('docker');
+    const ac = new AbortController();
+
+    await handler({ request: makeRequest(ac) });
+    ac.abort();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+    expect(() => subscribeState.sendData?.([{ host: 'late' }])).not.toThrow();
+  });
+
+  it('emits periodic comment pings on the heartbeat interval', async () => {
+    const handler = createStatsSseHandler('docker', { heartbeatIntervalMs: 5 });
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+    const decoder = new TextDecoder();
+
+    const first = await reader.read();
+    expect(decoder.decode(first.value)).toBe(': ok\n\n');
+
+    const second = await reader.read();
+    expect(decoder.decode(second.value)).toBe(': ping\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('tears down when the heartbeat ping hits a dead consumer', async () => {
+    const handler = createStatsSseHandler('docker', { heartbeatIntervalMs: 5 });
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+    await reader.read(); // flush comment
+
+    // Cancelling the reader closes the controller without firing abort, so
+    // the next ping's enqueue throws and must trigger teardown.
+    await reader.cancel();
+    await new Promise((r) => setTimeout(r, 30));
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+
+    ac.abort();
+  });
+
+  it('returns 401 when authenticateSSE returns null', async () => {
+    const { authenticateSSE } = require('@/lib/auth/sse-auth') as { authenticateSSE: ReturnType<typeof mock> };
+    authenticateSSE.mockImplementationOnce(async () => null);
+
+    const handler = createStatsSseHandler('docker');
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+
+    expect(res.status).toBe(401);
+    expect(subscribe).not.toHaveBeenCalled();
+    ac.abort();
+  });
+});

--- a/src/lib/sse/create-broadcast-sse-handler.ts
+++ b/src/lib/sse/create-broadcast-sse-handler.ts
@@ -6,10 +6,17 @@
  * a broadcast service, forward each event via a caller-provided serializer,
  * and tear down on request abort or enqueue failure.
  *
- * The heartbeat (`: ok\n\n`) forces Nitro to flush response headers
- * immediately so clients don't stall waiting for the first byte.
+ * The initial comment (`: ok\n\n`) forces Nitro to flush response headers
+ * immediately so clients don't stall waiting for the first byte. Periodic
+ * `: ping\n\n` comments then keep idle connections alive.
  */
 type Unsubscribe = () => void;
+
+/**
+ * Default heartbeat period. Must stay below typical idle timeouts that kill
+ * quiet streams (Bun's idleTimeout, nginx's 60 s proxy_read_timeout).
+ */
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 25_000;
 
 export interface BroadcastSseHandlerOptions<Event> {
   /**
@@ -29,6 +36,8 @@ export interface BroadcastSseHandlerOptions<Event> {
    * surface the failure instead of silently stalling on an empty stream.
    */
   errorEvent: string;
+  /** Heartbeat comment period in milliseconds (default: 25s). */
+  heartbeatIntervalMs?: number;
 }
 
 function isCloseRelatedError(err: unknown): boolean {
@@ -38,6 +47,9 @@ function isCloseRelatedError(err: unknown): boolean {
 export function createBroadcastSseHandler<Event>(
   options: BroadcastSseHandlerOptions<Event>,
 ) {
+  const heartbeatIntervalMs =
+    options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+
   return async ({ request }: { request: Request }): Promise<Response> => {
     const { authenticateSSE } = await import('@/lib/auth/sse-auth');
     const user = await authenticateSSE(request);
@@ -57,11 +69,24 @@ export function createBroadcastSseHandler<Event>(
         const teardown = () => {
           if (closed) return;
           closed = true;
+          clearInterval(heartbeat);
           unsubscribe();
           try {
             controller.close();
           } catch {}
         };
+
+        // Broadcast events can be minutes apart (settings changes, deploys);
+        // a periodic comment frame keeps proxies and Bun's idleTimeout from
+        // killing the connection in between.
+        const heartbeat = setInterval(() => {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(': ping\n\n'));
+          } catch {
+            teardown();
+          }
+        }, heartbeatIntervalMs);
 
         const sendEvent = (event: Event) => {
           if (closed) return;
@@ -91,10 +116,7 @@ export function createBroadcastSseHandler<Event>(
               ),
             );
           } catch {}
-          closed = true;
-          try {
-            controller.close();
-          } catch {}
+          teardown();
           return;
         }
 

--- a/src/lib/sse/create-stats-sse-handler.ts
+++ b/src/lib/sse/create-stats-sse-handler.ts
@@ -1,11 +1,28 @@
 import type { StatsSource } from '@/lib/database/subscription-service';
 
 /**
+ * Default heartbeat period. Must stay below typical idle timeouts that kill
+ * quiet streams (Bun's idleTimeout, nginx's 60 s proxy_read_timeout).
+ */
+const DEFAULT_HEARTBEAT_INTERVAL_MS = 25_000;
+
+export interface StatsSseHandlerOptions {
+  /** Heartbeat comment period in milliseconds (default: 25s). */
+  heartbeatIntervalMs?: number;
+}
+
+/**
  * Factory for stats SSE route handlers.
  * All three stats endpoints (docker, zfs, proxmox) share identical logic;
  * only the source string differs.
  */
-export function createStatsSseHandler(source: StatsSource) {
+export function createStatsSseHandler(
+  source: StatsSource,
+  options: StatsSseHandlerOptions = {},
+) {
+  const heartbeatIntervalMs =
+    options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+
   return async ({ request }: { request: Request }) => {
     const { authenticateSSE } = await import('@/lib/auth/sse-auth');
     const user = await authenticateSSE(request);
@@ -33,6 +50,7 @@ export function createStatsSseHandler(source: StatsSource) {
         const teardown = () => {
           if (closed) return;
           closed = true;
+          clearInterval(heartbeat);
           unsubscribe();
           try {
             controller.close();
@@ -40,6 +58,18 @@ export function createStatsSseHandler(source: StatsSource) {
             // Already closed
           }
         };
+
+        // Stats rows only flow while the poll service has data; a periodic
+        // comment frame keeps proxies and Bun's idleTimeout from killing the
+        // connection during quiet stretches.
+        const heartbeat = setInterval(() => {
+          if (closed) return;
+          try {
+            controller.enqueue(encoder.encode(': ping\n\n'));
+          } catch {
+            teardown();
+          }
+        }, heartbeatIntervalMs);
 
         const sendData = (rows: unknown[]) => {
           if (closed) return;
@@ -64,8 +94,7 @@ export function createStatsSseHandler(source: StatsSource) {
           unsubscribe = statsPollService.subscribe(source, sendData, sendError);
         } catch {
           sendError();
-          closed = true;
-          try { controller.close(); } catch { /* already closed */ }
+          teardown();
           return;
         }
 


### PR DESCRIPTION
## Summary

- Both web SSE factories (`createStatsSseHandler`, `createBroadcastSseHandler`) now run a 25 s `setInterval` comment ping (`: ping`), guarded by the `closed` flag and cleared in `teardown`. A ping that hits a dead consumer (enqueue throws) triggers full teardown, so abandoned streams unsubscribe instead of lingering.
- The factory error paths (subscribe throws, `loadSubscribe` rejects) now route through `teardown` so the interval cannot leak.
- Added a shared `startSseHeartbeat` helper to `agent/src/lib/sse-utils.ts` and wired it into the agent stats, zfs, and containers-events streams (cleared on abort and in each stream's teardown/finally path). The logs route already had its own heartbeat.
- Heartbeat interval is injectable (`heartbeatIntervalMs` option/param, default 25 s) so tests run with millisecond intervals.
- Verified consumers are unaffected: worker collectors skip SSE messages without a `data: ` line, and browser `EventSource` ignores comment frames natively.

## Testing

- `bun run typecheck` and `bun run typecheck:agent` pass.
- New test file `src/lib/sse/__tests__/create-stats-sse-handler.test.ts` (headers, flush comment, data/error frames, subscribe failure, abort teardown, heartbeat ping, dead-consumer teardown, 401).
- Extended `create-broadcast-sse-handler.test.ts` with heartbeat ping, dead-consumer teardown, and interval-cleared-on-abort tests.
- Extended agent `sse-utils.test.ts` with `startSseHeartbeat` coverage (ping cadence, isClosed stop, enqueue-throw self-clear, stop function).
- Added one idle-heartbeat test each to agent `stats.test.ts`, `zfs.test.ts`, `containers-events.test.ts`.
- All affected files green under `bun test --isolate` (21 web + 68 agent tests).

Closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)
