### PR TITLE
fix(auth): add Max-Age and __Host- prefix to session cookie

### DIFF
--- a/src/data/__tests__/auth.functions.auth-enabled.test.ts
+++ b/src/data/__tests__/auth.functions.auth-enabled.test.ts
@@ -34,6 +34,8 @@ const mockLoadAuthConfig = mock(() => ({
 mock.module('@/lib/config/auth-config', () => ({
   isAuthDisabled: () => false,
   loadAuthConfig: mockLoadAuthConfig,
+  // http redirect URI above -> plain "session" name is the active one.
+  isSecureCookie: () => false,
 }));
 
 mock.module('@/middleware/auth-middleware', () => ({

--- a/src/lib/auth/__tests__/callback-handler.test.ts
+++ b/src/lib/auth/__tests__/callback-handler.test.ts
@@ -1,11 +1,11 @@
 import { describe, it, expect, mock, afterEach } from 'bun:test';
 import {
   handleCallback,
-  buildSessionCookie,
   CLEAR_STATE_COOKIE,
   callbackGetHandler,
 } from '@/lib/auth/callback-handler';
 import type { CallbackHandlerDeps } from '@/lib/auth/callback-handler';
+import { buildSessionCookie } from '@/lib/auth/session-cookie';
 import type { OidcTokens, Role } from '@/lib/auth/types';
 import type { UserRow } from '@/lib/database/repositories/user-repository';
 
@@ -79,6 +79,7 @@ function makeDeps(overrides?: Partial<CallbackHandlerDeps>): CallbackHandlerDeps
       viewer: 'homelab-viewers',
     },
     isSecure: false,
+    sessionTtlHours: 8,
     ...overrides,
   };
 }
@@ -370,29 +371,30 @@ describe('handleCallback', () => {
     });
   });
 
-  describe('buildSessionCookie helper', () => {
-    it('includes HttpOnly, SameSite=Lax, and Path=/ for non-secure', () => {
-      const cookie = buildSessionCookie('my-raw-token', false);
-      expect(cookie).toContain('HttpOnly');
-      expect(cookie).toContain('SameSite=Lax');
-      expect(cookie).toContain('Path=/');
-      expect(cookie).not.toContain('Secure');
+  describe('session cookie on success', () => {
+    // Happy-DOM hides Set-Cookie on Response (browser forbidden response
+    // header), so cookie attribute assertions live in session-cookie.test.ts.
+    // These tests exercise the secure and TTL deps through the success path.
+    it('succeeds with isSecure=true and a custom TTL', async () => {
+      const deps = makeDeps({ isSecure: true, sessionTtlHours: 2 });
+      const response = await handleCallback(
+        deps,
+        'auth-code',
+        validState,
+        validCookieHeader(),
+        null,
+        null,
+      );
+
+      expect(response.status).toBe(302);
+      expect(response.headers.get('Location')).toBe('/');
     });
 
-    it('includes Secure flag when isSecure=true', () => {
-      const cookie = buildSessionCookie('my-raw-token', true);
-      expect(cookie).toContain('Secure');
-    });
-
-    it('encodes the raw token in the cookie value', () => {
-      const token = 'raw/token+value';
-      const cookie = buildSessionCookie(token, false);
-      expect(cookie).toContain(`session=${encodeURIComponent(token)}`);
-    });
-
-    it('starts with session= prefix', () => {
-      const cookie = buildSessionCookie('abc', false);
+    it('builds the session cookie with Max-Age derived from sessionTtlHours', () => {
+      // 8 hours * 3600 = 28800 seconds, the same conversion handleCallback applies.
+      const cookie = buildSessionCookie('raw-session-token-abc', false, 8 * 3600);
       expect(cookie).toMatch(/^session=/);
+      expect(cookie).toContain('Max-Age=28800');
     });
   });
 

--- a/src/lib/auth/__tests__/logout-handler.test.ts
+++ b/src/lib/auth/__tests__/logout-handler.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect, mock, afterEach } from 'bun:test';
 import {
   handleLogout,
-  buildClearSessionCookie,
   logoutGetHandler,
   logoutWithCookie,
   type LogoutHandlerDeps,
 } from '@/lib/auth/logout-handler';
+import { buildClearSessionCookie } from '@/lib/auth/session-cookie';
 
 // mock.module intercepts dynamic imports inside logoutGetHandler.
 const mockIsAuthDisabled = mock(() => false);
+const mockIsSecureCookie = mock(() => false);
 const mockLoadAuthConfig = mock(() => ({
   issuerUrl: 'https://pocketid.example.com',
   clientId: 'homelab-manager',
@@ -19,6 +20,7 @@ const mockLoadAuthConfig = mock(() => ({
 
 mock.module('@/lib/config/auth-config', () => ({
   isAuthDisabled: mockIsAuthDisabled,
+  isSecureCookie: mockIsSecureCookie,
   loadAuthConfig: mockLoadAuthConfig,
 }));
 
@@ -214,32 +216,27 @@ describe('handleLogout', () => {
 });
 
 // ------------------------------------------------------------------
-// buildClearSessionCookie helper
+// Clear-cookie behavior in handleLogout
 // ------------------------------------------------------------------
 
-describe('buildClearSessionCookie', () => {
-  it('includes HttpOnly, SameSite=Lax, Path=/, and Max-Age=0', () => {
-    const cookie = buildClearSessionCookie(false);
-    expect(cookie).toContain('session=');
-    expect(cookie).toContain('HttpOnly');
-    expect(cookie).toContain('SameSite=Lax');
-    expect(cookie).toContain('Path=/');
-    expect(cookie).toContain('Max-Age=0');
+describe('handleLogout clear cookies', () => {
+  // Happy-DOM hides Set-Cookie on Response (browser forbidden response
+  // header), so cookie attribute assertions live in session-cookie.test.ts.
+  // These tests exercise both isSecure branches through handleLogout.
+  it('redirects successfully when isSecure=false (plain clear cookie)', async () => {
+    const deps = makeDeps({ isSecure: false });
+    const response = await handleLogout(deps, 'raw-session-token');
+
+    expect(response.status).toBe(302);
+    expect(buildClearSessionCookie(false)).toMatch(/^session=;/);
   });
 
-  it('does not include Secure when isSecure=false', () => {
-    const cookie = buildClearSessionCookie(false);
-    expect(cookie).not.toContain('Secure');
-  });
+  it('redirects successfully when isSecure=true (__Host- clear cookie)', async () => {
+    const deps = makeDeps({ isSecure: true });
+    const response = await handleLogout(deps, 'raw-session-token');
 
-  it('includes Secure flag when isSecure=true', () => {
-    const cookie = buildClearSessionCookie(true);
-    expect(cookie).toContain('Secure');
-  });
-
-  it('sets session to empty value (clears the cookie)', () => {
-    const cookie = buildClearSessionCookie(false);
-    expect(cookie).toMatch(/^session=;/);
+    expect(response.status).toBe(302);
+    expect(buildClearSessionCookie(true)).toMatch(/^__Host-session=;/);
   });
 });
 
@@ -253,6 +250,7 @@ describe('logoutGetHandler', () => {
   afterEach(() => {
     process.env = { ...originalEnv };
     mockIsAuthDisabled.mockReset();
+    mockIsSecureCookie.mockReset();
     mockLoadAuthConfig.mockReset();
     mockGetIdToken.mockReset();
     mockRevokeSession.mockReset();
@@ -261,6 +259,7 @@ describe('logoutGetHandler', () => {
 
   it('redirects to /login?prompt=login when auth is disabled', async () => {
     mockIsAuthDisabled.mockImplementation(() => true);
+    mockIsSecureCookie.mockImplementation(() => false);
 
     const response = await logoutGetHandler({
       request: new Request('http://localhost/api/auth/logout'),
@@ -268,6 +267,18 @@ describe('logoutGetHandler', () => {
 
     expect(response.status).toBe(302);
     expect(response.headers.get('Location')).toBe('/login?prompt=login');
+  });
+
+  // Happy-DOM strips Set-Cookie off Response, so assert the name is derived rather
+  // than hardcoded to the non-secure one; buildClearSessionCookie covers the value.
+  it('derives the cleared cookie name from isSecureCookie when auth is disabled', async () => {
+    mockIsAuthDisabled.mockImplementation(() => true);
+    mockIsSecureCookie.mockImplementation(() => true);
+
+    await logoutGetHandler({ request: new Request('http://localhost/api/auth/logout') });
+
+    expect(mockIsSecureCookie).toHaveBeenCalled();
+    expect(buildClearSessionCookie(mockIsSecureCookie())).toMatch(/^__Host-session=;/);
   });
 
   it('with session cookie: revokes session and redirects via OIDC logout URL', async () => {
@@ -288,6 +299,24 @@ describe('logoutGetHandler', () => {
 
     expect(response.status).toBe(302);
     expect(response.headers.get('Location')).toContain('pocketid.example.com/end-session');
+    expect(mockRevokeSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts the session token under the __Host-session cookie name', async () => {
+    mockIsAuthDisabled.mockImplementation(() => false);
+    mockLoadAuthConfig.mockImplementation(() => ({
+      issuerUrl: 'https://pocketid.example.com',
+      clientId: 'homelab-manager',
+      redirectUri: 'https://homelab.example.com/api/auth/callback',
+      sessionTtlHours: 8,
+      roleMapping: { admin: 'homelab-admins', operator: 'homelab-operators', viewer: 'homelab-viewers' },
+    }));
+    mockGetIdToken.mockImplementation(async () => 'id-tok');
+    mockGetLogoutUrl.mockImplementation(async () => null);
+
+    const response = await logoutWithCookie('__Host-session=rawtoken456');
+
+    expect(response.status).toBe(302);
     expect(mockRevokeSession).toHaveBeenCalledTimes(1);
   });
 

--- a/src/lib/auth/__tests__/resolve-user.test.ts
+++ b/src/lib/auth/__tests__/resolve-user.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { resolveUserFromCookie, parseCookie, resetAuthResolverState } from '@/lib/auth/resolve-user';
+import { resolveUserFromCookie, resetAuthResolverState } from '@/lib/auth/resolve-user';
 import { SYNTHETIC_ADMIN } from '@/lib/auth/types';
 import type { AuthUser } from '@/lib/auth/types';
 
 let authDisabled = false;
+let secureCookie = false;
 mock.module('@/lib/config/auth-config', () => ({
   isAuthDisabled: () => authDisabled,
+  isSecureCookie: () => secureCookie,
 }));
 
 const mockValidateSession = mock(async (_token: string) => null as AuthUser | null);
@@ -38,36 +40,10 @@ function makeRequest(cookieHeader?: string): Request {
   } as unknown as Request;
 }
 
-describe('parseCookie', () => {
-  it('returns the value for a matching cookie', () => {
-    expect(parseCookie('session=abc123', 'session')).toBe('abc123');
-  });
-
-  it('returns null when header is null', () => {
-    expect(parseCookie(null, 'session')).toBeNull();
-  });
-
-  it('returns null when cookie name not present', () => {
-    expect(parseCookie('other=xyz', 'session')).toBeNull();
-  });
-
-  it('handles multiple cookies and returns the right one', () => {
-    expect(parseCookie('foo=bar; session=tok123; baz=qux', 'session')).toBe('tok123');
-  });
-
-  it('URL-decodes the cookie value', () => {
-    const encoded = encodeURIComponent('value with spaces');
-    expect(parseCookie(`session=${encoded}`, 'session')).toBe('value with spaces');
-  });
-
-  it('returns null for empty header string', () => {
-    expect(parseCookie('', 'session')).toBeNull();
-  });
-});
-
 describe('resolveUserFromCookie', () => {
   beforeEach(() => {
     authDisabled = false;
+    secureCookie = false;
     resetAuthResolverState();
     mockValidateSession.mockClear();
     mockBuildSessionManager.mockClear();
@@ -108,6 +84,27 @@ describe('resolveUserFromCookie', () => {
 
     expect(result).toEqual(user);
     expect(mockValidateSession).toHaveBeenCalledWith('valid-token');
+  });
+
+  it('reads the __Host-session cookie when the deployment is https', async () => {
+    secureCookie = true;
+    const user = makeUser({ id: 7, email: 'eve@example.com', role: 'admin' });
+    mockValidateSession.mockImplementation(async () => user);
+
+    const result = await resolveUserFromCookie(makeRequest('__Host-session=host-token-xyz'));
+
+    expect(result).toEqual(user);
+    expect(mockValidateSession).toHaveBeenCalledWith('host-token-xyz');
+  });
+
+  it('ignores a plain session cookie when the deployment is https', async () => {
+    secureCookie = true;
+    mockValidateSession.mockImplementation(async () => makeUser());
+
+    const result = await resolveUserFromCookie(makeRequest('session=planted-token'));
+
+    expect(result).toBeNull();
+    expect(mockBuildSessionManager).not.toHaveBeenCalled();
   });
 
   it('returns null for an expired or invalid session token', async () => {

--- a/src/lib/auth/__tests__/session-cookie.test.ts
+++ b/src/lib/auth/__tests__/session-cookie.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  SESSION_COOKIE_NAME,
+  HOST_SESSION_COOKIE_NAME,
+  getSessionCookieName,
+  buildSessionCookie,
+  buildClearSessionCookie,
+  parseCookie,
+  parseSessionCookie,
+} from '@/lib/auth/session-cookie';
+
+describe('parseCookie', () => {
+  it('returns the value for a matching cookie', () => {
+    expect(parseCookie('session=abc123', 'session')).toBe('abc123');
+  });
+
+  it('returns null when header is null', () => {
+    expect(parseCookie(null, 'session')).toBeNull();
+  });
+
+  it('returns null when cookie name not present', () => {
+    expect(parseCookie('other=xyz', 'session')).toBeNull();
+  });
+
+  it('handles multiple cookies and returns the right one', () => {
+    expect(parseCookie('foo=bar; session=tok123; baz=qux', 'session')).toBe('tok123');
+  });
+
+  it('URL-decodes the cookie value', () => {
+    const encoded = encodeURIComponent('value with spaces');
+    expect(parseCookie(`session=${encoded}`, 'session')).toBe('value with spaces');
+  });
+
+  it('returns null for empty header string', () => {
+    expect(parseCookie('', 'session')).toBeNull();
+  });
+});
+
+describe('getSessionCookieName', () => {
+  it('returns the __Host- prefixed name when secure', () => {
+    expect(getSessionCookieName(true)).toBe(HOST_SESSION_COOKIE_NAME);
+  });
+
+  it('returns the plain name when not secure', () => {
+    expect(getSessionCookieName(false)).toBe(SESSION_COOKIE_NAME);
+  });
+});
+
+describe('buildSessionCookie', () => {
+  it('includes HttpOnly, SameSite=Lax, Path=/, and Max-Age for non-secure', () => {
+    const cookie = buildSessionCookie('my-raw-token', false, 28800);
+    expect(cookie).toMatch(/^session=/);
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('SameSite=Lax');
+    expect(cookie).toContain('Path=/');
+    expect(cookie).toContain('Max-Age=28800');
+    expect(cookie).not.toContain('Secure');
+  });
+
+  it('uses the __Host- name and Secure flag when isSecure=true', () => {
+    const cookie = buildSessionCookie('my-raw-token', true, 3600);
+    expect(cookie).toMatch(/^__Host-session=/);
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('Path=/');
+    expect(cookie).toContain('Max-Age=3600');
+  });
+
+  it('encodes the raw token in the cookie value', () => {
+    const token = 'raw/token+value';
+    const cookie = buildSessionCookie(token, false, 60);
+    expect(cookie).toContain(`session=${encodeURIComponent(token)}`);
+  });
+});
+
+describe('buildClearSessionCookie', () => {
+  it('returns the plain clear cookie when not secure', () => {
+    const cookie = buildClearSessionCookie(false);
+    expect(cookie).toMatch(/^session=;/);
+    expect(cookie).toContain('Max-Age=0');
+    expect(cookie).toContain('HttpOnly');
+    expect(cookie).toContain('Path=/');
+    expect(cookie).not.toContain('Secure');
+  });
+
+  it('returns the __Host- clear cookie when secure', () => {
+    const cookie = buildClearSessionCookie(true);
+    expect(cookie).toMatch(/^__Host-session=;/);
+    expect(cookie).toContain('Secure');
+    expect(cookie).toContain('Max-Age=0');
+    expect(cookie).toContain('Path=/');
+  });
+});
+
+describe('parseSessionCookie', () => {
+  it('returns null for a null header', () => {
+    expect(parseSessionCookie(null, false)).toBeNull();
+    expect(parseSessionCookie(null, true)).toBeNull();
+  });
+
+  it('returns null when the active name is not present', () => {
+    expect(parseSessionCookie('other=abc; foo=bar', false)).toBeNull();
+  });
+
+  it('reads the plain session cookie when not secure', () => {
+    expect(parseSessionCookie('foo=bar; session=tok123; baz=qux', false)).toBe('tok123');
+  });
+
+  it('reads the __Host-session cookie when secure', () => {
+    expect(parseSessionCookie('foo=bar; __Host-session=tok456', true)).toBe('tok456');
+  });
+
+  it('ignores the plain name when secure', () => {
+    // A plain "session" cookie planted by a subdomain must not fixate a session.
+    expect(parseSessionCookie('session=legacy-tok', true)).toBeNull();
+  });
+
+  it('ignores the __Host- name when not secure', () => {
+    expect(parseSessionCookie('__Host-session=host-tok', false)).toBeNull();
+  });
+
+  it('URL-decodes the token value', () => {
+    const token = 'token with spaces';
+    expect(parseSessionCookie(`__Host-session=${encodeURIComponent(token)}`, true)).toBe(token);
+  });
+
+  it('returns null when the value is malformed percent-encoding', () => {
+    expect(parseSessionCookie('session=%E0%A4%A', false)).toBeNull();
+  });
+
+  it('does not treat "__Host-session=" as the plain "session=" name', () => {
+    // The plain-name regex must not match "session=" inside "__Host-session=".
+    expect(parseSessionCookie('__Host-session=only-host', false)).toBeNull();
+    expect(parseSessionCookie('x__Host-session=weird', false)).toBeNull();
+  });
+});

--- a/src/lib/auth/callback-handler.ts
+++ b/src/lib/auth/callback-handler.ts
@@ -1,5 +1,6 @@
 import type { OidcTokens, Role, RoleMappingConfig } from '@/lib/auth/types';
 import type { UserRow } from '@/lib/database/repositories/user-repository';
+import { buildSessionCookie } from '@/lib/auth/session-cookie';
 
 export interface CallbackOidcClient {
   exchangeCode(code: string, codeVerifier: string): Promise<OidcTokens>;
@@ -33,11 +34,8 @@ export interface CallbackHandlerDeps {
   sessionManager: CallbackSessionManager;
   roleMapping: RoleMappingConfig;
   isSecure: boolean;
-}
-
-export function buildSessionCookie(rawToken: string, isSecure: boolean): string {
-  const securePart = isSecure ? ' Secure;' : '';
-  return `session=${encodeURIComponent(rawToken)}; HttpOnly;${securePart} SameSite=Lax; Path=/`;
+  /** Session TTL in hours, drives the cookie Max-Age so it matches the DB session lifetime. */
+  sessionTtlHours: number;
 }
 
 export const CLEAR_STATE_COOKIE =
@@ -134,7 +132,11 @@ export async function handleCallback(
     userAgent,
   );
 
-  const sessionCookie = buildSessionCookie(rawSessionToken, deps.isSecure);
+  const sessionCookie = buildSessionCookie(
+    rawSessionToken,
+    deps.isSecure,
+    deps.sessionTtlHours * 3600,
+  );
 
   return new Response(null, {
     status: 302,
@@ -203,6 +205,7 @@ export async function callbackGetHandler({
         sessionManager,
         roleMapping: config.roleMapping,
         isSecure,
+        sessionTtlHours: config.sessionTtlHours,
       },
       code,
       state,

--- a/src/lib/auth/logout-handler.ts
+++ b/src/lib/auth/logout-handler.ts
@@ -1,10 +1,5 @@
 import { createHash } from 'node:crypto';
-
-/** Builds the Set-Cookie header value that clears the session cookie. */
-export function buildClearSessionCookie(isSecure: boolean): string {
-  const securePart = isSecure ? ' Secure;' : '';
-  return `session=; HttpOnly;${securePart} SameSite=Lax; Path=/; Max-Age=0`;
-}
+import { buildClearSessionCookie, parseSessionCookie } from '@/lib/auth/session-cookie';
 
 export interface LogoutHandlerDeps {
   /**
@@ -61,7 +56,6 @@ export async function handleLogout(
     }
   }
 
-  const clearCookie = buildClearSessionCookie(deps.isSecure);
   // prompt=login forces re-auth when the provider still holds a valid browser session.
   const redirectTo = oidcLogoutUrl ?? '/login?prompt=login';
 
@@ -69,20 +63,22 @@ export async function handleLogout(
     status: 302,
     headers: {
       Location: redirectTo,
-      'Set-Cookie': clearCookie,
+      'Set-Cookie': buildClearSessionCookie(deps.isSecure),
     },
   });
 }
 
 export async function logoutWithCookie(cookieHeader: string): Promise<Response> {
-  const { isAuthDisabled, loadAuthConfig } = await import('@/lib/config/auth-config');
+  const { isAuthDisabled, isSecureCookie, loadAuthConfig } = await import(
+    '@/lib/config/auth-config'
+  );
 
   if (isAuthDisabled()) {
     return new Response(null, {
       status: 302,
       headers: {
         Location: '/login?prompt=login',
-        'Set-Cookie': buildClearSessionCookie(false),
+        'Set-Cookie': buildClearSessionCookie(isSecureCookie()),
       },
     });
   }
@@ -91,8 +87,7 @@ export async function logoutWithCookie(cookieHeader: string): Promise<Response> 
   const isSecure = config.redirectUri.startsWith('https://');
   const postLogoutRedirectUri = `${new URL(config.redirectUri).origin}/login`;
 
-  const match = cookieHeader.match(/(?:^|;\s*)session=([^;]*)/);
-  const token = match ? decodeURIComponent(match[1]) : null;
+  const token = parseSessionCookie(cookieHeader, isSecure);
 
   // Build session manager lazily: only connect to the DB when there's an active session to revoke.
   const getSessionManager = async () => {

--- a/src/lib/auth/resolve-user.ts
+++ b/src/lib/auth/resolve-user.ts
@@ -1,22 +1,11 @@
 import type { AuthUser } from '@/lib/auth/types';
+import { parseSessionCookie } from '@/lib/auth/session-cookie';
 
 let cachedSessionManager: import('@/lib/auth/session-manager').SessionManager | null = null;
 
-export function parseCookie(header: string | null, name: string): string | null {
-  if (!header) return null;
-  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const match = header.match(new RegExp(`(?:^|;\\s*)${escapedName}=([^;]*)`));
-  if (!match) return null;
-  try {
-    return decodeURIComponent(match[1]);
-  } catch {
-    return null;
-  }
-}
-
 /** Single seam for cookie-to-AuthUser resolution; callers pick their own error mode around the result. */
 export async function resolveUserFromCookie(request: Request): Promise<AuthUser | null> {
-  const { isAuthDisabled } = await import('@/lib/config/auth-config');
+  const { isAuthDisabled, isSecureCookie } = await import('@/lib/config/auth-config');
   if (isAuthDisabled()) {
     const { SYNTHETIC_ADMIN } = await import('@/lib/auth/types');
     return SYNTHETIC_ADMIN;
@@ -24,7 +13,7 @@ export async function resolveUserFromCookie(request: Request): Promise<AuthUser 
 
   // Check the cookie before building the session manager to skip DB connections on unauthenticated requests.
   const cookieHeader = request.headers.get('cookie');
-  const sessionToken = parseCookie(cookieHeader, 'session');
+  const sessionToken = parseSessionCookie(cookieHeader, isSecureCookie());
   if (!sessionToken) return null;
 
   if (!cachedSessionManager) {

--- a/src/lib/auth/session-cookie.ts
+++ b/src/lib/auth/session-cookie.ts
@@ -1,0 +1,46 @@
+/**
+ * A deployment uses exactly one session cookie name, chosen by isSecure. http
+ * (local dev) cannot use the __Host- prefix because browsers reject it without
+ * Secure, so build, clear, and parse must all key off the same flag or a request
+ * is read under a name that was never issued.
+ */
+export const SESSION_COOKIE_NAME = 'session';
+export const HOST_SESSION_COOKIE_NAME = '__Host-session';
+
+export function getSessionCookieName(isSecure: boolean): string {
+  return isSecure ? HOST_SESSION_COOKIE_NAME : SESSION_COOKIE_NAME;
+}
+
+export function parseCookie(header: string | null, name: string): string | null {
+  if (!header) return null;
+  const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const match = header.match(new RegExp(`(?:^|;\\s*)${escapedName}=([^;]*)`));
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return null;
+  }
+}
+
+/** @param maxAgeSeconds - Cookie lifetime, mirrors the DB session TTL so the cookie survives browser restarts for exactly as long as the server-side session. */
+export function buildSessionCookie(
+  rawToken: string,
+  isSecure: boolean,
+  maxAgeSeconds: number,
+): string {
+  const securePart = isSecure ? ' Secure;' : '';
+  const name = getSessionCookieName(isSecure);
+  return `${name}=${encodeURIComponent(rawToken)}; HttpOnly;${securePart} SameSite=Lax; Path=/; Max-Age=${maxAgeSeconds}`;
+}
+
+export function buildClearSessionCookie(isSecure: boolean): string {
+  const securePart = isSecure ? ' Secure;' : '';
+  const name = getSessionCookieName(isSecure);
+  return `${name}=; HttpOnly;${securePart} SameSite=Lax; Path=/; Max-Age=0`;
+}
+
+/** Reads only the name matching isSecure, so on https a plain "session" cookie planted by a subdomain cannot fixate a session under the __Host- name. */
+export function parseSessionCookie(header: string | null, isSecure: boolean): string | null {
+  return parseCookie(header, getSessionCookieName(isSecure));
+}

--- a/src/lib/config/auth-config.ts
+++ b/src/lib/config/auth-config.ts
@@ -68,6 +68,15 @@ export function enforceAuthConfig(): void {
   }
 }
 
+/**
+ * Picks the session cookie name on read paths that hold no parsed AuthConfig.
+ * Unlike loadAuthConfig(), this must never throw on incomplete OIDC env vars:
+ * an unauthenticated request has to resolve to null, not a 500.
+ */
+export function isSecureCookie(): boolean {
+  return process.env.OIDC_REDIRECT_URI?.startsWith('https://') ?? false;
+}
+
 export function loadAuthConfig(): AuthConfig {
   const issuerUrl = process.env.OIDC_ISSUER_URL;
   const clientId = process.env.OIDC_CLIENT_ID;


### PR DESCRIPTION
## Summary

- The session cookie was a browser-session cookie with no Max-Age, so it expired with the browser while the DB session stayed valid for SESSION_TTL_HOURS. It also lacked the __Host- prefix on https deployments.
- New shared module `src/lib/auth/session-cookie.ts` owns the cookie name, build, clear, and parse logic. `buildSessionCookie` now sets `Max-Age` from `SESSION_TTL_HOURS` (hours * 3600).
- A deployment uses exactly one cookie name, keyed on isSecure: https issues `__Host-session` (browser enforces Secure, Path=/, no Domain), http (local dev) keeps `session` since browsers reject the prefix without Secure.
- Reads resolve the active name in one place. `resolveUserFromCookie` now reads through `parseSessionCookie(isSecureCookie())` instead of the hardcoded plain name, so the auth middleware, SSE auth, and the session-read server fn in `auth.functions.tsx` all follow from that single seam. `isSecureCookie()` derives isSecure from `OIDC_REDIRECT_URI` and stays separate from `loadAuthConfig()`, which would throw on an unauthenticated request when the OIDC env vars are incomplete. Logout reuses the isSecure it already derives from config. On https a plain `session` cookie is ignored, so a cookie planted under the plain name cannot fixate a session past the __Host- guard.
- `parseCookie` moves from `resolve-user.ts` into `session-cookie.ts` so the auth path has one cookie parser rather than two copies of the same regex.
- The `AUTH_DISABLED` logout path built its clear-cookie from a hardcoded `false`, which left a stale `__Host-session` cookie behind on https deployments. It now derives the name from `isSecureCookie()` like every other site.
- `CallbackHandlerDeps` gains `sessionTtlHours`, wired from `loadAuthConfig()` in `callbackGetHandler`.

## Migration

There is no dual-name support: the cookie is never read or cleared under two names at once. On https deployments this means every live session is invalidated on deploy, since the browser still holds `session` while the server now reads only `__Host-session`. Each user is bounced to `/login` once and re-authenticates through the OIDC provider. No data migration or operator action is required, and http deployments are unaffected because the name does not change there.

## Testing

- `bun run typecheck:all` passes.
- Co-located test file `src/lib/auth/__tests__/session-cookie.test.ts` covers name selection, Max-Age, Secure/__Host- attributes, single-name clearing, and parse precedence/decoding edge cases (including that the plain name is ignored on https, the __Host- name is ignored on http, and that `__Host-session=` does not satisfy a read for the plain `session` name).
- `resolve-user.test.ts` covers the secure-name read path and asserts a plain `session` cookie is rejected on an https deployment without ever building a session manager.
- Callback, logout, and auth.functions tests updated for the new deps shape and single-name reads. Note: Happy-DOM hides Set-Cookie on Response objects, so attribute assertions live in the helper tests, matching the existing test pattern.

Closes #247

🤖 Generated with [Claude Code](https://claude.com/claude-code)
