### PR TITLE
chore(claude): tighten Bash permission allowlist wildcards

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,15 +16,13 @@
   "permissions": {
     "allow": [
       "Bash(bun test --isolate)",
-      "Bash(bun test --isolate *)",
+      "Bash(bun test --isolate src/**)",
+      "Bash(bun test --isolate agent/**)",
       "Bash(bun test --isolate --watch)",
       "Bash(bun run typecheck)",
-      "Bash(bun run typecheck *)",
       "Bash(bun run typecheck:all)",
-      "Bash(bun run typecheck:all *)",
       "Bash(bun run typecheck:agent)",
-      "Bash(bun run typecheck:agent *)",
-      "Bash(bun run test:all *)",
+      "Bash(bun run test:all)",
       "mcp__plugin_context7_context7__query-docs",
       "mcp__plugin_context7_context7__resolve-library-id"
     ]


### PR DESCRIPTION
## What

Tightens the `permissions.allow` list in `.claude/settings.json` by removing the five `Bash(... *)` wildcard entries.

## Why

A trailing `*` widens the matcher so *any* argument auto-approves. For `Bash(bun test --isolate *)` that includes `bun test --isolate --preload <module>` (arbitrary module execution) and arbitrary out-of-tree paths like `/tmp/...`. An automated commit security review flagged these as allowlist semantic escapes.

## Changes

- `bun test --isolate *` → `bun test --isolate src/**` and `bun test --isolate agent/**`, so positional test paths within the repo still run without a prompt, but out-of-tree paths and `--preload`-style flag injection require explicit approval.
- Removed the redundant `typecheck`, `typecheck:all`, and `typecheck:agent` wildcard variants; the bare no-arg entries already cover the canonical invocations.
- Replaced `test:all *` with the bare `test:all`.

No functional code changes; harness config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)