### PR TITLE
fix(demo): stop demo site from redirecting to login

### DIFF
--- a/src/lib/mock/functions/auth.functions.ts
+++ b/src/lib/mock/functions/auth.functions.ts
@@ -1,0 +1,30 @@
+import { SYNTHETIC_ADMIN } from '@/lib/auth/types';
+import type { AuthUser, RoleMappingConfig } from '@/lib/auth/types';
+
+/**
+ * Demo mocks for the auth server functions.
+ *
+ * The demo is a static SPA with no backend, so the real server functions in
+ * `@/data/auth.functions` have no endpoint to hit. Vite aliases this module in
+ * its place (see `vite.config.ts`).
+ *
+ * `getSession` returns the synthetic admin so `useAuth` takes its auth-disabled
+ * branch (no /login redirect, user stays null). With user null the settings
+ * page never renders `AuthManagementCard`, so the admin-only functions below are
+ * never actually called; they exist only to satisfy module resolution.
+ */
+export const getSession = async (): Promise<AuthUser | null> => SYNTHETIC_ADMIN;
+
+export const listUsers = async (): Promise<AuthUser[]> => [];
+
+export const listSessions = async (): Promise<never[]> => [];
+
+export const revokeSession = async (): Promise<void> => {};
+
+export const revokeAllUserSessions = async (): Promise<void> => {};
+
+export const getRoleMapping = async (): Promise<RoleMappingConfig> => ({
+  admin: 'homelab-admins',
+  operator: 'homelab-operators',
+  viewer: 'homelab-viewers',
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ function buildAliases(): Record<string, string> {
     aliases['@/data/proxmox/functions'] = fileURLToPath(new URL('./src/lib/mock/functions/proxmox.functions.ts', import.meta.url))
     aliases['@/data/settings/functions'] = fileURLToPath(new URL('./src/lib/mock/functions/settings.functions.ts', import.meta.url))
     aliases['@/data/stacks/functions'] = fileURLToPath(new URL('./src/lib/mock/functions/stacks.functions.tsx', import.meta.url))
+    aliases['@/data/auth.functions'] = fileURLToPath(new URL('./src/lib/mock/functions/auth.functions.ts', import.meta.url))
   }
   aliases['@'] = fileURLToPath(new URL('./src', import.meta.url))
   return aliases


### PR DESCRIPTION
## Problem

The demo site (https://jaredglaser.github.io/homelab-manager) immediately redirects to a login page, so the demo is unusable.

## Root cause

The demo is a static SPA on GitHub Pages with no backend. `useAuth` calls `getSession`, a TanStack Start server function (`src/data/auth.functions.tsx`). On a static host there is no server-function endpoint, so the call rejects and `useAuth`'s catch handler runs `navigate({ to: '/login' })`.

The Vite demo aliases (`vite.config.ts`) swap the docker/zfs/proxmox/settings/stacks data modules for mocks, but `auth.functions` was never aliased, so this one server call leaked through and failed.

## Fix

Follow the existing demo convention (CLAUDE.md: "swaps server functions via Vite aliases ... Zero changes to routes/hooks/components") rather than adding demo branching to a hook:

- New `src/lib/mock/functions/auth.functions.ts` mock module.
- Alias `@/data/auth.functions` to it in `vite.config.ts` under the demo block.

`getSession` returns the synthetic admin, so `useAuth` takes its existing auth-disabled branch (no redirect, `user: null`), identical to `AUTH_ENABLED=false`. With `user` null the settings page never renders `AuthManagementCard`, so the admin-only mock functions are never called; they exist only to satisfy module resolution. No production hooks/components change.

## Testing

- `bun run typecheck` clean.
- `bun run build:demo` succeeds; verified the mock is bundled (`admin@local` present in the client asset) and no auth server/db code (`loadAuthConfig`, `*-repository`) leaked into the public bundle.
- Full suite + coverage gate pass (functions 94.27% / lines 98.25%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)