### PR TITLE
test(hosts): fix ManagedHostsCard edit test for read-only host name

### DIFF
--- a/src/components/settings/__tests__/ManagedHostsCard.test.tsx
+++ b/src/components/settings/__tests__/ManagedHostsCard.test.tsx
@@ -410,14 +410,14 @@ describe('ManagedHostsCard', () => {
       expect(screen.queryByLabelText('Edit Socket Proxy URL')).toBeNull()
     })
 
-    it('calls onUpdate with correct values when Save is clicked', () => {
+    it('calls onUpdate with the unchanged name and edited URL when Save is clicked', () => {
       const onUpdate = mock(() => {})
       const host = makeHost()
       render(<ManagedHostsCardView {...makeProps({ hosts: [host], onUpdate })} />)
       fireEvent.click(screen.getByLabelText('edit host'))
-      fireEvent.change(screen.getByLabelText('Edit Host Name'), { target: { value: 'updated-server' } })
+      fireEvent.change(screen.getByLabelText('Edit Agent URL'), { target: { value: 'http://10.0.0.9:9090' } })
       fireEvent.click(screen.getByRole('button', { name: 'Save' }))
-      expect(onUpdate).toHaveBeenCalledWith(1, 'updated-server', 'http://192.168.1.10:9090')
+      expect(onUpdate).toHaveBeenCalledWith(1, 'server1', 'http://10.0.0.9:9090')
     })
 
     it('does not call onUpdate when Cancel is clicked', () => {


### PR DESCRIPTION
## Summary
- PR #263 made the Edit Host dialog's name field read-only, but the squash merge landed before the matching `ManagedHostsCard.test.tsx` update, leaving `main` with a failing test.
- This updates the `calls onUpdate ...` test to edit the Agent URL (the name field is now read-only) and assert the unchanged name is passed through.

## Test Plan
- [x] `bun test --isolate src/components/settings/__tests__/ManagedHostsCard.test.tsx` (49 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)