### PR TITLE
ci: gate the release jobs on e2e and migration verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
   publish:
     name: Publish Docker Images
     runs-on: ubuntu-latest
-    needs: [build-test, agent, agent-updater]
+    needs: [build-test, agent, agent-updater, e2e]
     if: github.event_name == 'push'
     permissions:
       contents: read
@@ -442,7 +442,7 @@ jobs:
   deploy-demo:
     name: Deploy Demo to GitHub Pages
     runs-on: ubuntu-latest
-    needs: [build-test, agent, agent-updater, demo-build]
+    needs: [build-test, agent, agent-updater, demo-build, e2e]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     concurrency:
       group: pages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
   publish:
     name: Publish Docker Images
     runs-on: ubuntu-latest
-    needs: [build-test, agent, agent-updater, e2e]
+    needs: [build-test, agent, agent-updater, e2e, migrations]
     if: github.event_name == 'push'
     permissions:
       contents: read


### PR DESCRIPTION
Originally "add the e2e job", but that job landed with #293. What is left here is the release gating, kept separate so the policy change is reviewed on its own.

## What it does

Two lines in `.github/workflows/ci.yml`:

- `publish` (Docker images) gains `e2e` and `migrations` in `needs:`.
- `deploy-demo` (GitHub Pages) gains `e2e`.

`deploy-demo` is deliberately **not** gated on `migrations`: it is a static build with no database, so a migration failure says nothing about whether the demo is publishable.

Without this, both release jobs depended only on `build-test`, `agent` and `agent-updater`, so a red e2e run or a broken migration could not stop a publish.

## Why it is worth the latency

Accepted trade-off: releases now wait on the slowest of the two added jobs, and a flaky e2e run can block a publish until it is re-run. The e2e job is bounded at `timeout-minutes: 20` so it cannot hang a release indefinitely.

## Verification

Both job ids referenced in `needs:` exist in the workflow on `main`: `e2e` at `ci.yml:75` and `migrations` at `ci.yml:246`. CI is green on this head, with `publish` and `deploy-demo` correctly reporting as skipped (they run only on `push`, not on pull requests, so the new edges are exercised on merge to `main`).

## History

This branch was originally stacked on #293's branch. #293 was squash-merged, which orphaned it, so it was rebased onto `main` with `restack.sh`; only its own two commits remain.