### PR TITLE
chore: normalize Node builtin imports to the node: prefix

### DIFF
--- a/.github/scripts/triage-issues.ts
+++ b/.github/scripts/triage-issues.ts
@@ -6,8 +6,8 @@
  *   triage-summary.md: human-readable summary for the PR description
  */
 
-import { readFileSync, writeFileSync } from "fs";
-import { dirname } from "path";
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 
 const MAX_ISSUES = Math.min(Math.max(1, Number(process.env.MAX_ISSUES ?? "10") || 10), 50);
 const INPUT_FILE = process.env.INPUT_FILE ?? "sonar-issues.json";

--- a/agent/src/__tests__/stacks.test.ts
+++ b/agent/src/__tests__/stacks.test.ts
@@ -8,8 +8,8 @@ import {
   handleStackStatus,
   parseContainerNames,
 } from '../routes/stacks';
-import { mkdirSync, rmSync, existsSync, readFileSync, statSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { mkdirSync, rmSync, existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 beforeAll(() => {
   console.error = mock(() => {});

--- a/scripts/download-icons.ts
+++ b/scripts/download-icons.ts
@@ -6,9 +6,9 @@
  *
  * @see https://github.com/homarr-labs/dashboard-icons
  */
-import { mkdir, writeFile, readdir, cp, rm } from 'fs/promises';
-import { existsSync } from 'fs';
-import { execSync } from 'child_process';
+import { mkdir, writeFile, readdir, cp, rm } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
 
 const ICONS_DIR = './public/icons';
 const REPO_URL = 'https://github.com/homarr-labs/dashboard-icons.git';

--- a/src/data/git-tokens.functions.tsx
+++ b/src/data/git-tokens.functions.tsx
@@ -10,7 +10,7 @@ export const createGitToken = createServerFn()
   .handler(async ({ data, context }): Promise<{ token: string }> => {
     requireRole('admin')(context.user);
 
-    const { randomBytes } = await import('crypto');
+    const { randomBytes } = await import('node:crypto');
     const { databaseConnectionManager } = await import('@/lib/clients/database-client');
     const { loadDatabaseConfig } = await import('@/lib/config/database-config');
     const { loadMasterKeyring } = await import('@/lib/crypto/master-key');

--- a/src/lib/auth/__tests__/login-handler.test.ts
+++ b/src/lib/auth/__tests__/login-handler.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, afterEach, beforeEach } from 'bun:test';
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { buildStateCookie, generatePkcePair } from '@/lib/auth/login-handler';
 
 // Module mocks must be registered before importing the handler so its dynamic

--- a/src/lib/auth/__tests__/session-manager.test.ts
+++ b/src/lib/auth/__tests__/session-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { SessionManager, resetSessionManagerState } from '../session-manager';
 import type { SessionManagerDeps } from '../session-manager';
 import type { AuthUser } from '@/lib/auth/types';

--- a/src/lib/auth/login-handler.ts
+++ b/src/lib/auth/login-handler.ts
@@ -1,4 +1,4 @@
-import { createHash, randomBytes } from 'crypto';
+import { createHash, randomBytes } from 'node:crypto';
 
 /**
  * Builds the oidc_state cookie value for the login flow.

--- a/src/lib/auth/logout-handler.ts
+++ b/src/lib/auth/logout-handler.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 
 /** Builds the Set-Cookie header value that clears the session cookie. */
 export function buildClearSessionCookie(isSecure: boolean): string {

--- a/src/lib/config/__tests__/git-config.test.ts
+++ b/src/lib/config/__tests__/git-config.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { join } from 'path';
+import { join } from 'node:path';
 import { loadGitConfig } from '../git-config';
 
 describe('loadGitConfig', () => {

--- a/src/lib/database/__tests__/migrate.test.ts
+++ b/src/lib/database/__tests__/migrate.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { readdirSync } from 'fs';
-import { join } from 'path';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
 import { runMigrations, MIGRATIONS_ADVISORY_LOCK_KEY } from '@/lib/database/migrate';
 import type { DatabaseClient } from '@/lib/clients/database-client';
 

--- a/src/lib/database/migrate.ts
+++ b/src/lib/database/migrate.ts
@@ -1,8 +1,8 @@
 import type { DatabaseClient } from '../clients/database-client';
 import type { PoolClient } from 'pg';
-import { readFileSync, readdirSync } from 'fs';
-import { join, dirname } from 'path';
-import { fileURLToPath } from 'url';
+import { readFileSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 // Get the root directory of the project (3 levels up from this file)
 const currentDir = dirname(fileURLToPath(import.meta.url));

--- a/src/lib/deploy/__tests__/stack-repo-writer.test.ts
+++ b/src/lib/deploy/__tests__/stack-repo-writer.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import { initBareRepo, commitFiles } from '@/lib/git/repo';
 import * as gitConfig from '@/lib/config/git-config';

--- a/src/lib/git/__tests__/editor-operations.test.ts
+++ b/src/lib/git/__tests__/editor-operations.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import { initBareRepo, commitFiles, readFileFromRepo, getLog } from '../repo';
 import { saveAndCommitFile, updateManifest } from '../editor-operations';

--- a/src/lib/git/__tests__/init-repo.test.ts
+++ b/src/lib/git/__tests__/init-repo.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import git from 'isomorphic-git';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import { ensureRepoInitialized } from '../init-repo';

--- a/src/lib/git/__tests__/integration.test.ts
+++ b/src/lib/git/__tests__/integration.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import { initBareRepo, commitFiles, readFileFromRepo, listFilesInRepo, getLog, diffCommits } from '../repo';
 import { parseManifest } from '../manifest';

--- a/src/lib/git/__tests__/post-receive-handler-pipeline.test.ts
+++ b/src/lib/git/__tests__/post-receive-handler-pipeline.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { generateKeyPair } from 'jose';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import { initBareRepo, commitFiles } from '../repo';

--- a/src/lib/git/__tests__/post-receive-handler.test.ts
+++ b/src/lib/git/__tests__/post-receive-handler.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn, mock } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import { initBareRepo, commitFiles } from '../repo';
 import { processPostReceive } from '../post-receive-handler';

--- a/src/lib/git/__tests__/post-receive.test.ts
+++ b/src/lib/git/__tests__/post-receive.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import { initBareRepo, commitFiles } from '../repo';
 import {

--- a/src/lib/git/__tests__/repo-diff.test.ts
+++ b/src/lib/git/__tests__/repo-diff.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync } from 'fs';
-import { join } from 'path';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import { initBareRepo, commitFiles, getLog, diffCommits } from '../repo';
 

--- a/src/lib/git/__tests__/repo.test.ts
+++ b/src/lib/git/__tests__/repo.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import git from 'isomorphic-git';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import yaml from 'js-yaml';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';

--- a/src/lib/parsers/__tests__/text-parser.test.ts
+++ b/src/lib/parsers/__tests__/text-parser.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import type { StreamParser } from '../../streaming/types';
 import { streamTextLines, streamParsedLines } from '../text-parser';
 

--- a/src/lib/parsers/text-parser.ts
+++ b/src/lib/parsers/text-parser.ts
@@ -1,5 +1,5 @@
-import { createInterface } from 'readline';
-import { Readable } from 'stream';
+import { createInterface } from 'node:readline';
+import { Readable } from 'node:stream';
 import type { StreamParser } from '../streaming/types';
 
 /**

--- a/src/lib/stream-utils.ts
+++ b/src/lib/stream-utils.ts
@@ -1,5 +1,5 @@
-import { createInterface } from "readline";
-import { Readable } from "stream";
+import { createInterface } from "node:readline";
+import { Readable } from "node:stream";
 
 /**
  * Converts a Node.js Readable stream to an async iterator

--- a/src/lib/test/__tests__/stream-utils.test.ts
+++ b/src/lib/test/__tests__/stream-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { Readable } from 'stream';
+import { Readable } from 'node:stream';
 import { createMockJSONStream, collectStreamOutput } from '../stream-utils';
 
 describe('stream-utils', () => {

--- a/src/lib/test/stream-utils.ts
+++ b/src/lib/test/stream-utils.ts
@@ -1,4 +1,4 @@
-import { Readable, PassThrough } from 'stream';
+import { Readable, PassThrough } from 'node:stream';
 
 /**
  * Converts objects into a stream of Newline-Delimited JSON (NDJSON)

--- a/src/lib/test/tmp-dir.ts
+++ b/src/lib/test/tmp-dir.ts
@@ -1,5 +1,5 @@
-import { existsSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
 
 const DEV_SHM = '/dev/shm';
 


### PR DESCRIPTION
## What

Adds the `node:` prefix to every bare Node builtin import specifier across 26 files (`crypto`, `fs`, `fs/promises`, `path`, `stream`, `readline`, `child_process`, `url`), plus the dynamic `await import('crypto')` in `git-tokens.functions.tsx`. Specifier strings only, no logic changes (43 insertions / 43 deletions, fully symmetric).

## Why

This started from the question "should we replace `node:` APIs with Bun alternatives?" The conclusion was no: Bun implements `node:*` natively and recommends the prefixed form, and swapping `src/` to `Bun.*` APIs would couple shared code to Bun for negligible benefit. The genuinely useful cleanup was the opposite direction: most of the codebase already uses the `node:` prefix, but ~26 files used bare specifiers. This change makes them consistent.

## Background: the "run dev under Bun" idea was tried and dropped

A second change was scoped to make `bun dev` run under Bun (via `bun --bun vite`) so dev matches the prod/worker runtime. During validation it was found to break the dev server: it boots (`VITE ready`) but returns HTTP 500 on every request because Nitro's Vite dev entry wires websocket support through `crossws`, whose Node adapter rejects the Bun runtime. That isn't a quick/safe fix (disabling websockets would break real features), so the dev-runtime change was reverted and is not part of this PR. Dev stays on Node, prod stays on Bun, and `src/` remains runtime-agnostic, which is exactly why the `node:` builtins (not `Bun.*`) are the right call.

### How to reproduce the dev-under-Bun failure locally

This PR does NOT contain these changes. Apply them yourself to observe the issue:

1. In `package.json`, change the `dev` script:
   ```diff
   -    "dev": "vite dev --port 3000",
   +    "dev": "bun --bun vite dev --port 3000",
   ```
   The `--bun` flag overrides the `vite` binary's `#!/usr/bin/env node` shebang and forces the Bun runtime. Without it, `bun dev` still runs Vite under Node.

2. Make sure deps are installed (`bun run setup`), then start dev:
   ```bash
   bun dev
   ```
   It boots fine:
   ```
   $ bun --bun vite dev --port 3000
     VITE v8.0.16  ready in ~3000 ms
     ➜  Local:   http://localhost:3000/
   ```

3. Hit any route and watch it fail:
   ```bash
   curl -i http://localhost:3000/
   ```
   Returns `HTTP/1.1 500`, and the dev server stdout prints:
   ```
   error: [crossws] Using Node.js adapter in an incompatible environment.
       at nodeAdapter (node_modules/crossws/dist/_chunks/node.mjs:25:17)
       at nitro/dist/runtime/internal/vite/dev-entry.mjs:21:52
   ```

4. Revert the `package.json` change to get a working dev server again.

**Root cause:** `vite.config.ts` enables `nitro({ ..., features: { websocket: true } })`. Nitro's Vite dev entry instantiates the `crossws` Node adapter for websocket support, and that adapter throws when it detects a non-Node runtime (Bun). The web server only runs under Bun in production (`Dockerfile`: `bun .output/server/index.mjs`), where this dev-only Nitro path isn't used, so prod is unaffected.

**Possible paths to actually enable it** (out of scope here, would need investigation): a Nitro Bun/dev preset or a crossws Bun adapter, or gating `features.websocket` per-environment if dev websockets aren't needed.

## Verification

- `bun run typecheck:all` passes.
- `bun run test:all`: identical results before and after (2479 pass / 396 fail), and identical to the base commit. The pre-existing failures are unrelated environment/mock-isolation issues, not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)