### PR TITLE
test(e2e): real-server auth lane for the session cookie contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,89 @@ jobs:
           path: playwright-report/
           retention-days: 14
 
+  e2e-auth:
+    name: E2E Auth (Playwright + Pocket ID)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+
+    # Real-server lane: runs the actual Nitro build against a real Pocket ID and
+    # Postgres so the session cookie (Max-Age, __Host-/Secure, single-name read)
+    # is verified in a real browser. The MSW lane above cannot: it mocks the
+    # backend and cannot emit HttpOnly Set-Cookie.
+    services:
+      postgres:
+        image: timescale/timescaledb:latest-pg16
+        env:
+          POSTGRES_DB: homelab_test
+          POSTGRES_USER: homelab
+          POSTGRES_PASSWORD: homelab
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U homelab"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+      pocket-id:
+        image: ghcr.io/pocket-id/pocket-id:v2
+        env:
+          APP_URL: http://localhost:1411
+          # Throwaway values for an ephemeral CI instance; not real secrets.
+          ENCRYPTION_KEY: e2e-pocket-id-encryption-key-not-a-secret
+          STATIC_API_KEY: e2e-pocket-id-static-api-key-not-a-secret
+          DISABLE_RATE_LIMITING: "true"
+          ANALYTICS_DISABLED: "true"
+        ports:
+          - 1411:1411
+        options: >-
+          --health-cmd "wget --spider -q http://localhost:1411/healthz || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+          --health-start-period 20s
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Install Playwright browser
+        run: bunx playwright install --with-deps chromium
+
+      - name: Generate a throwaway master key
+        run: echo "MASTER_KEY=$(openssl rand -base64 32)" >> "$GITHUB_ENV"
+
+      - name: Run auth e2e tests
+        run: bun run test:e2e:auth
+        env:
+          CI: '1'
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: '5432'
+          POSTGRES_DB: homelab_test
+          POSTGRES_USER: homelab
+          POSTGRES_PASSWORD: homelab
+          POSTGRES_SSL: 'false'
+          POCKET_ID_URL: http://localhost:1411
+          POCKET_ID_API_KEY: e2e-pocket-id-static-api-key-not-a-secret
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-auth
+          path: playwright-report/
+          retention-days: 14
+
   agent:
     name: Agent Test & License Check
     runs-on: ubuntu-latest
@@ -332,7 +415,7 @@ jobs:
   publish:
     name: Publish Docker Images
     runs-on: ubuntu-latest
-    needs: [build-test, agent, agent-updater, e2e, migrations]
+    needs: [build-test, agent, agent-updater, e2e, e2e-auth, migrations]
     if: github.event_name == 'push'
     permissions:
       contents: read

--- a/e2e/auth.authhttp.e2e.ts
+++ b/e2e/auth.authhttp.e2e.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+import { login, setCookieValues } from './auth/login';
+
+/**
+ * http deployment: the app issues the plain `session` cookie (no __Host-, no
+ * Secure). Asserts the real Set-Cookie header and the browser's stored cookie,
+ * then proves persistence (the cookie is sent back and validated) and that
+ * logout clears it. baseURL is http://localhost:3201 (auth-http project).
+ */
+const BASE = 'http://localhost:3201';
+
+test('login issues a plain session cookie with Max-Age and HttpOnly, no Secure', async ({
+  page,
+  context,
+}) => {
+  const callback = await login(page, BASE);
+
+  const session = (await setCookieValues(callback)).find((c) => c.startsWith('session='));
+  expect(session, 'callback should set a session cookie').toBeTruthy();
+  expect(session).not.toContain('__Host-');
+  expect(session).toMatch(/Max-Age=\d+/);
+  expect(session).toContain('HttpOnly');
+  expect(session).toContain('SameSite=Lax');
+  expect(session).toContain('Path=/');
+  expect(session).not.toContain('Secure');
+
+  const stored = (await context.cookies()).find((c) => c.name === 'session');
+  expect(stored?.httpOnly).toBe(true);
+  expect(stored?.secure).toBe(false);
+  // Max-Age set => a real expiry (not a -1 browser-session cookie).
+  expect(stored?.expires).toBeGreaterThan(0);
+});
+
+test('the session persists into a fresh context (cookie is sent back and validated)', async ({
+  page,
+  context,
+  browser,
+}) => {
+  await login(page, BASE);
+
+  const fresh = await browser.newContext({ storageState: await context.storageState() });
+  const freshPage = await fresh.newPage();
+  await freshPage.goto(`${BASE}/`);
+  // Authenticated requests stay on the app; an invalid/missing session bounces to /login.
+  await expect(freshPage).not.toHaveURL(/\/login/);
+  await fresh.close();
+});
+
+test('logout clears the session cookie', async ({ page, context }) => {
+  await login(page, BASE);
+
+  const logout = await page.goto(`${BASE}/api/auth/logout`);
+  const cleared = (await setCookieValues(logout!)).find((c) => c.startsWith('session='));
+  expect(cleared).toContain('Max-Age=0');
+
+  expect((await context.cookies()).find((c) => c.name === 'session')).toBeUndefined();
+});

--- a/e2e/auth.authhttps.e2e.ts
+++ b/e2e/auth.authhttps.e2e.ts
@@ -1,0 +1,52 @@
+import { test, expect } from '@playwright/test';
+import { login, setCookieValues } from './auth/login';
+
+/**
+ * https deployment: the app issues `__Host-session` + Secure. https://localhost
+ * is a secure context in Chromium, so the browser accepts the prefixed/Secure
+ * cookie (a malformed __Host- cookie would be silently dropped, so its presence
+ * in the jar is the acceptance proof). Also asserts the single-name read: on
+ * https a planted plain `session` cookie must not authenticate. baseURL is
+ * https://localhost:3202 (auth-https project).
+ */
+const BASE = 'https://localhost:3202';
+
+test('login issues a __Host-session cookie with Secure and Max-Age', async ({ page, context }) => {
+  const callback = await login(page, BASE);
+
+  const cookie = (await setCookieValues(callback)).find((c) => c.startsWith('__Host-session='));
+  expect(cookie, 'callback should set a __Host-session cookie').toBeTruthy();
+  expect(cookie).toContain('Secure');
+  expect(cookie).toContain('HttpOnly');
+  expect(cookie).toContain('SameSite=Lax');
+  expect(cookie).toContain('Path=/');
+  expect(cookie).toMatch(/Max-Age=\d+/);
+
+  const stored = (await context.cookies()).find((c) => c.name === '__Host-session');
+  expect(stored, '__Host- cookie must be accepted and stored by the browser').toBeTruthy();
+  expect(stored?.secure).toBe(true);
+  expect(stored?.httpOnly).toBe(true);
+  // The plain name must not be present on https.
+  expect((await context.cookies()).find((c) => c.name === 'session')).toBeUndefined();
+});
+
+test('a planted plain session cookie does not authenticate on https', async ({ page, context }) => {
+  // No login: forge a plain `session` cookie (the kind a subdomain could plant).
+  await context.addCookies([
+    { name: 'session', value: 'forged-token', domain: 'localhost', path: '/' },
+  ]);
+
+  await page.goto(`${BASE}/`);
+  // The app reads only __Host-session on https, so this request is unauthenticated.
+  await expect(page).toHaveURL(/\/login/);
+});
+
+test('logout clears the __Host-session cookie', async ({ page, context }) => {
+  await login(page, BASE);
+
+  const logout = await page.goto(`${BASE}/api/auth/logout`);
+  const cleared = (await setCookieValues(logout!)).find((c) => c.startsWith('__Host-session='));
+  expect(cleared).toContain('Max-Age=0');
+
+  expect((await context.cookies()).find((c) => c.name === '__Host-session')).toBeUndefined();
+});

--- a/e2e/auth/login.ts
+++ b/e2e/auth/login.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { type Page, type Response } from '@playwright/test';
+
+/**
+ * Helpers for the real-server auth lane. They drive a genuine OIDC login against
+ * Pocket ID and return the real callback response so specs can assert the actual
+ * Set-Cookie the browser received (the thing Happy-DOM cannot test).
+ *
+ * Login uses Pocket ID's one-time access token (`/lc/<token>`), minted fresh per
+ * call via the admin API, so each browser context gets its own provider session
+ * without passkey automation and without exhausting a single-use token.
+ */
+interface OidcInfo {
+  clientId: string;
+  issuerUrl: string;
+  email: string;
+  userId: string;
+}
+
+export function readOidc(): OidcInfo {
+  return JSON.parse(readFileSync(path.resolve('e2e-build/auth/oidc.json'), 'utf8'));
+}
+
+function apiKey(): string {
+  const key = process.env.POCKET_ID_API_KEY;
+  if (!key) throw new Error('POCKET_ID_API_KEY must be set for the auth e2e lane');
+  return key;
+}
+
+async function mintOneTimeToken(oidc: OidcInfo): Promise<string> {
+  const res = await fetch(`${oidc.issuerUrl}/api/users/${oidc.userId}/one-time-access-token`, {
+    method: 'POST',
+    headers: { 'X-API-Key': apiKey(), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ ttl: '1h' }),
+  });
+  if (!res.ok) throw new Error(`mint one-time token failed: HTTP ${res.status} ${await res.text()}`);
+  return (await res.json()).token;
+}
+
+/** Returns the Set-Cookie header values from a response (one entry per cookie). */
+export async function setCookieValues(response: Response): Promise<string[]> {
+  return (await response.headersArray())
+    .filter((h) => h.name.toLowerCase() === 'set-cookie')
+    .map((h) => h.value);
+}
+
+/**
+ * Establishes a Pocket ID session via a one-time token, then runs the app's OIDC
+ * login. Returns the `/api/auth/callback` response (the one that sets the session
+ * cookie). `baseURL` is the app origin (http or https project).
+ */
+export async function login(page: Page, baseURL: string): Promise<Response> {
+  const oidc = readOidc();
+  const token = await mintOneTimeToken(oidc);
+
+  // Consume the one-time token: this logs the browser into Pocket ID.
+  await page.goto(`${oidc.issuerUrl}/lc/${token}`);
+
+  const callbackPromise = page.waitForResponse((r) => r.url().includes('/api/auth/callback'));
+  await page.goto(`${baseURL}/api/auth/login`);
+
+  // First authorize for this user+client may show a consent screen; later ones are
+  // remembered server-side. Click through if present, otherwise proceed.
+  const consent = page.getByRole('button', { name: /authorize|allow|continue|consent/i });
+  await consent.click({ timeout: 3000 }).catch(() => {});
+
+  const callback = await callbackPromise;
+  await page.waitForURL(`${baseURL}/`);
+  return callback;
+}

--- a/package.json
+++ b/package.json
@@ -45,7 +45,10 @@
     "test:e2e": "bun run e2e:build && playwright test",
     "test:e2e:run": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "test:e2e:report": "playwright show-report"
+    "test:e2e:report": "playwright show-report",
+    "e2e:build:realapp": "bun run e2e:clean && vite build && rm -rf e2e-build/realapp && mkdir -p e2e-build && cp -r .output e2e-build/realapp",
+    "test:e2e:auth": "bun run e2e:build:realapp && bun scripts/e2e-gen-cert.ts && bun scripts/e2e-auth-seed.ts && playwright test --config=playwright.auth.config.ts",
+    "test:e2e:auth:run": "playwright test --config=playwright.auth.config.ts"
   },
   "dependencies": {
     "@base-ui/react": "1.6.0",

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -1,0 +1,62 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Auth lane: a SEPARATE config from playwright.config.ts because this lane runs
+ * the real Nitro server against a real Pocket ID + Postgres, not the static MSW
+ * builds. Keeping it separate means the MSW lane never tries to start these
+ * servers (and vice versa).
+ *
+ * The seed + build run BEFORE `playwright test` (see the `test:e2e:auth` script),
+ * so e2e-build/auth/oidc.env exists when these webServers start. Pocket ID and
+ * Postgres must already be reachable (CI service containers, or local Docker).
+ *
+ * - `auth-http`  (3201): OIDC_REDIRECT_URI=http  -> asserts the plain `session` cookie.
+ * - `auth-https` (3202): OIDC_REDIRECT_URI=https -> asserts `__Host-session` + Secure
+ *   and the single-name read. https://localhost is a secure context in Chromium,
+ *   so the prefixed/Secure cookie is accepted; `ignoreHTTPSErrors` allows the
+ *   self-signed cert.
+ */
+const isCI = !!process.env.CI;
+const HTTP_PORT = 3201;
+const HTTPS_PORT = 3202;
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false, // one Pocket ID user / one-time token; keep the flow serial
+  forbidOnly: isCI,
+  retries: isCI ? 2 : 0,
+  workers: 1,
+  reporter: isCI ? [['list'], ['html', { open: 'never' }]] : [['list']],
+  use: { trace: 'on-first-retry' },
+  projects: [
+    {
+      name: 'auth-http',
+      testMatch: /.*\.authhttp\.e2e\.ts$/,
+      use: { ...devices['Desktop Chrome'], baseURL: `http://localhost:${HTTP_PORT}` },
+    },
+    {
+      name: 'auth-https',
+      testMatch: /.*\.authhttps\.e2e\.ts$/,
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: `https://localhost:${HTTPS_PORT}`,
+        ignoreHTTPSErrors: true,
+      },
+    },
+  ],
+  webServer: [
+    {
+      command: 'bun scripts/e2e-auth-server.ts http',
+      port: HTTP_PORT,
+      reuseExistingServer: !isCI,
+      timeout: 120_000,
+    },
+    {
+      command: 'bun scripts/e2e-auth-server.ts https',
+      url: `https://localhost:${HTTPS_PORT}/`,
+      ignoreHTTPSErrors: true,
+      reuseExistingServer: !isCI,
+      timeout: 120_000,
+    },
+  ],
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,7 +23,9 @@ export default defineConfig({
     {
       name: 'app',
       testMatch: /.*\.e2e\.ts$/,
-      testIgnore: /.*\.demo\.e2e\.ts$/,
+      // Auth specs run only via playwright.auth.config.ts against the real Nitro
+      // server, never against this MSW build.
+      testIgnore: /.*\.(demo|authhttp|authhttps)\.e2e\.ts$/,
       use: { ...devices['Desktop Chrome'], baseURL: `http://localhost:${APP_PORT}` },
     },
     {

--- a/scripts/e2e-auth-seed.ts
+++ b/scripts/e2e-auth-seed.ts
@@ -1,0 +1,151 @@
+/**
+ * Seeds a running Pocket ID instance for the auth e2e lane and prepares the test
+ * database. Mirrors scripts/dev/seed-pocketid.sh (admin API via STATIC_API_KEY)
+ * but is tailored for the e2e run:
+ *
+ * 1. waits for Pocket ID health,
+ * 2. runs DB migrations (the web server does not auto-migrate),
+ * 3. creates the homelab-admins group + an e2e-admin user,
+ * 4. registers an OIDC client whose callback/logout URLs cover BOTH the http and
+ *    https app servers (3201 / 3202), and rotates its secret,
+ * 5. mints a one-time access token (Pocket ID's /lc/<token> login, so no passkey
+ *    automation is needed).
+ *
+ * Outputs (gitignored, under e2e-build/auth/):
+ * - oidc.env  : OIDC_CLIENT_ID / OIDC_CLIENT_SECRET, sourced by the app servers.
+ * - oidc.json : { clientId, issuerUrl, email, oneTimeLoginUrl }, read by the specs.
+ *
+ * Env: POCKET_ID_URL (default http://localhost:1411), POCKET_ID_API_KEY,
+ *      plus POSTGRES_* for migrations.
+ *
+ * Usage: bun scripts/e2e-auth-seed.ts
+ */
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+const POCKET_ID_URL = (process.env.POCKET_ID_URL ?? 'http://localhost:1411').replace(/\/$/, '');
+const API_KEY = process.env.POCKET_ID_API_KEY;
+const CLIENT_ID = 'homelab-manager-e2e';
+const CALLBACK_URLS = [
+  'http://localhost:3201/api/auth/callback',
+  'https://localhost:3202/api/auth/callback',
+];
+const LOGOUT_URLS = ['http://localhost:3201/login', 'https://localhost:3202/login'];
+
+if (!API_KEY) {
+  console.error('[e2e-auth-seed] POCKET_ID_API_KEY is required');
+  process.exit(1);
+}
+
+const api = `${POCKET_ID_URL}/api`;
+const headers = { 'X-API-Key': API_KEY, 'Content-Type': 'application/json' };
+
+async function req(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${api}${path}`, {
+    method,
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  if (!res.ok) {
+    throw new Error(`${method} ${path} -> HTTP ${res.status}: ${await res.text()}`);
+  }
+  const text = await res.text();
+  return text ? JSON.parse(text) : null;
+}
+
+/** Pocket ID list endpoints wrap rows in { data: [...] }; tolerate a bare array too. */
+function rows(resp: any): any[] {
+  if (Array.isArray(resp)) return resp;
+  if (Array.isArray(resp?.data)) return resp.data;
+  return [];
+}
+
+async function waitForHealth(timeoutMs = 60_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    try {
+      const res = await fetch(`${POCKET_ID_URL}/healthz`);
+      if (res.ok) return;
+    } catch {
+      // not up yet
+    }
+    if (Date.now() > deadline) throw new Error('Pocket ID did not become healthy in time');
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+}
+
+async function ensureGroup(name: string, friendlyName: string): Promise<string> {
+  const found = rows(await req('GET', `/user-groups?search=${name}`)).find((g) => g.name === name);
+  if (found) return found.id;
+  return (await req('POST', '/user-groups', { name, friendlyName })).id;
+}
+
+async function ensureUser(username: string, groupId: string): Promise<string> {
+  const found = rows(await req('GET', `/users?search=${username}`)).find(
+    (u) => u.username === username,
+  );
+  if (found) return found.id;
+  return (
+    await req('POST', '/users', {
+      username,
+      firstName: 'E2E',
+      lastName: 'Admin',
+      email: `${username}@example.com`,
+      isAdmin: true,
+      userGroupIds: [groupId],
+    })
+  ).id;
+}
+
+async function ensureClient(): Promise<string> {
+  const payload = {
+    name: 'Homelab Manager (e2e)',
+    callbackURLs: CALLBACK_URLS,
+    logoutCallbackURLs: LOGOUT_URLS,
+    isPublic: false,
+  };
+  const exists = rows(await req('GET', '/oidc/clients')).some((c) => c.id === CLIENT_ID);
+  if (exists) {
+    await req('PUT', `/oidc/clients/${CLIENT_ID}`, payload);
+  } else {
+    await req('POST', '/oidc/clients', { id: CLIENT_ID, ...payload });
+  }
+  return (await req('POST', `/oidc/clients/${CLIENT_ID}/secret`, {})).secret;
+}
+
+await waitForHealth();
+
+// Migrations: import lazily so a Pocket-ID-only failure surfaces before DB work.
+const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+const { runMigrations } = await import('@/lib/database/migrate');
+const db = await databaseConnectionManager.getClient(loadDatabaseConfig());
+try {
+  await runMigrations(db);
+} finally {
+  await databaseConnectionManager.closeAll();
+}
+
+const groupId = await ensureGroup('homelab-admins', 'Homelab Admins');
+const userId = await ensureUser('e2e-admin', groupId);
+const clientSecret = await ensureClient();
+
+const outDir = path.resolve('e2e-build/auth');
+mkdirSync(outDir, { recursive: true });
+writeFileSync(
+  path.join(outDir, 'oidc.env'),
+  `OIDC_CLIENT_ID=${CLIENT_ID}\nOIDC_CLIENT_SECRET=${clientSecret}\n`,
+);
+// userId lets the specs mint a fresh one-time login token per test (the /lc/<token>
+// login is single-use), so each browser context can establish its own Pocket ID
+// session without re-seeding.
+writeFileSync(
+  path.join(outDir, 'oidc.json'),
+  JSON.stringify(
+    { clientId: CLIENT_ID, issuerUrl: POCKET_ID_URL, email: 'e2e-admin@example.com', userId },
+    null,
+    2,
+  ),
+);
+
+console.info(`[e2e-auth-seed] seeded client ${CLIENT_ID}; wrote e2e-build/auth/oidc.{env,json}`);

--- a/scripts/e2e-auth-server.ts
+++ b/scripts/e2e-auth-server.ts
@@ -1,0 +1,80 @@
+/**
+ * Boots the real (non-MSW) Nitro build for the auth e2e lane, in one of two
+ * modes. Auth is required (AUTH_DISABLED unset); OIDC points at the seeded Pocket
+ * ID client (e2e-build/auth/oidc.env). The cookie name is derived from
+ * OIDC_REDIRECT_URI, so the two modes exercise the http vs https cookie contract:
+ *
+ * - http:  PORT 3201, OIDC_REDIRECT_URI=http://localhost:3201/...  -> plain `session`.
+ * - https: Nitro on an internal http port + a TLS proxy on 3202,
+ *          OIDC_REDIRECT_URI=https://localhost:3202/...            -> `__Host-session` + Secure.
+ *
+ * Usage: bun scripts/e2e-auth-server.ts <http|https>
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const mode = process.argv[2];
+if (mode !== 'http' && mode !== 'https') {
+  console.error('Usage: bun scripts/e2e-auth-server.ts <http|https>');
+  process.exit(1);
+}
+
+const serverEntry = path.resolve('e2e-build/realapp/server/index.mjs');
+
+// Client id/secret produced by e2e-auth-seed.ts.
+const oidcEnv = Object.fromEntries(
+  readFileSync(path.resolve('e2e-build/auth/oidc.env'), 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      const idx = line.indexOf('=');
+      return [line.slice(0, idx), line.slice(idx + 1)];
+    }),
+);
+
+const issuerUrl = (process.env.POCKET_ID_URL ?? 'http://localhost:1411').replace(/\/$/, '');
+
+const commonEnv: Record<string, string> = {
+  ...(process.env as Record<string, string>),
+  ...oidcEnv,
+  OIDC_ISSUER_URL: issuerUrl,
+  OIDC_ROLE_ADMIN: 'homelab-admins',
+  OIDC_ROLE_OPERATOR: 'homelab-operators',
+  OIDC_ROLE_VIEWER: 'homelab-viewers',
+  SESSION_TTL_HOURS: process.env.SESSION_TTL_HOURS ?? '8',
+};
+delete commonEnv.AUTH_DISABLED; // auth required
+
+const children: import('bun').Subprocess[] = [];
+function startNitro(port: number, redirectUri: string) {
+  children.push(
+    Bun.spawn(['node', serverEntry], {
+      env: { ...commonEnv, PORT: String(port), OIDC_REDIRECT_URI: redirectUri },
+      stdout: 'inherit',
+      stderr: 'inherit',
+    }),
+  );
+}
+
+if (mode === 'http') {
+  startNitro(3201, 'http://localhost:3201/api/auth/callback');
+} else {
+  const internalPort = 3212;
+  startNitro(internalPort, 'https://localhost:3202/api/auth/callback');
+  children.push(
+    Bun.spawn(['bun', path.resolve('scripts/e2e-tls-proxy.ts'), '3202', String(internalPort)], {
+      stdout: 'inherit',
+      stderr: 'inherit',
+    }),
+  );
+}
+
+const shutdown = () => {
+  for (const c of children) c.kill();
+  process.exit(0);
+};
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);
+
+await Promise.race(children.map((c) => c.exited));
+shutdown();

--- a/scripts/e2e-gen-cert.ts
+++ b/scripts/e2e-gen-cert.ts
@@ -1,0 +1,44 @@
+/**
+ * Generates a self-signed localhost certificate for the auth e2e lane's https
+ * server. Chromium treats https://localhost as a secure context, so the app
+ * issues the __Host-/Secure cookie and the browser accepts it; Playwright runs
+ * with `ignoreHTTPSErrors` so the self-signed cert is fine.
+ *
+ * Output: e2e-build/auth/certs/{cert.pem,key.pem} (gitignored). Idempotent;
+ * regenerates on each run so an expired cert never lingers.
+ *
+ * Usage: bun scripts/e2e-gen-cert.ts
+ */
+import { execFileSync } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import path from 'node:path';
+
+const outDir = path.resolve('e2e-build/auth/certs');
+mkdirSync(outDir, { recursive: true });
+
+const keyPath = path.join(outDir, 'key.pem');
+const certPath = path.join(outDir, 'cert.pem');
+
+execFileSync(
+  'openssl',
+  [
+    'req',
+    '-x509',
+    '-newkey',
+    'rsa:2048',
+    '-nodes',
+    '-keyout',
+    keyPath,
+    '-out',
+    certPath,
+    '-days',
+    '7',
+    '-subj',
+    '/CN=localhost',
+    '-addext',
+    'subjectAltName=DNS:localhost,IP:127.0.0.1',
+  ],
+  { stdio: 'inherit' },
+);
+
+console.info(`[e2e-gen-cert] wrote ${certPath} and ${keyPath}`);

--- a/scripts/e2e-tls-proxy.ts
+++ b/scripts/e2e-tls-proxy.ts
@@ -1,0 +1,44 @@
+/**
+ * Minimal TLS terminator for the auth e2e lane's https target. Fronts a plain
+ * http Nitro instance so the app is reachable over https://localhost:<port>,
+ * which is what makes the browser accept the __Host-/Secure session cookie.
+ * Streams requests and responses through unchanged (method, headers, body).
+ *
+ * Usage: bun scripts/e2e-tls-proxy.ts <listenPort> <targetHttpPort>
+ * Reads the cert from e2e-build/auth/certs (see e2e-gen-cert.ts).
+ */
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const listenPort = Number(process.argv[2]);
+const targetPort = Number(process.argv[3]);
+
+if (!listenPort || !targetPort) {
+  console.error('Usage: bun scripts/e2e-tls-proxy.ts <listenPort> <targetHttpPort>');
+  process.exit(1);
+}
+
+const certDir = path.resolve('e2e-build/auth/certs');
+const cert = readFileSync(path.join(certDir, 'cert.pem'));
+const key = readFileSync(path.join(certDir, 'key.pem'));
+
+Bun.serve({
+  port: listenPort,
+  tls: { cert, key },
+  async fetch(req) {
+    const url = new URL(req.url);
+    const target = `http://localhost:${targetPort}${url.pathname}${url.search}`;
+    // Redirect must not auto-follow: the app's 302s (login/callback) are the
+    // behavior under test, so the browser has to see them, not the proxy.
+    return fetch(target, {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+      redirect: 'manual',
+      // @ts-expect-error Bun supports duplex streaming bodies
+      duplex: 'half',
+    });
+  },
+});
+
+console.info(`[e2e-tls-proxy] https://localhost:${listenPort} -> http://localhost:${targetPort}`);

--- a/scripts/run-migrations.ts
+++ b/scripts/run-migrations.ts
@@ -1,0 +1,18 @@
+/**
+ * Runs database migrations against the configured Postgres (POSTGRES_* env), then
+ * exits. The web server does not auto-migrate (only the worker does), so the auth
+ * e2e lane uses this to prepare the throwaway test database before the app starts.
+ *
+ * Usage: bun scripts/run-migrations.ts
+ */
+import { databaseConnectionManager } from '@/lib/clients/database-client';
+import { loadDatabaseConfig } from '@/lib/config/database-config';
+import { runMigrations } from '@/lib/database/migrate';
+
+const db = await databaseConnectionManager.getClient(loadDatabaseConfig());
+try {
+  await runMigrations(db);
+  console.info('[run-migrations] migrations applied');
+} finally {
+  await databaseConnectionManager.closeAll();
+}


### PR DESCRIPTION
Re-cut onto `main` on 2026-07-27. Previously stacked behind #293, #295 and #281; all three have merged, so this is now a single commit against `main` with no stack.

Adds the end-to-end lane that proves the OIDC session cookie contract in a real browser.

## Why a separate lane

The MSW harness (#293) cannot test the session cookie. It serves static builds with an in-browser mock backend, a service worker cannot emit an `HttpOnly` `Set-Cookie`, and auth there is faked through a `getSession` override. The cookie attributes are equally out of reach for Happy-DOM unit tests, since `Set-Cookie` is a forbidden response header. They need a real server and a real browser.

## What it does

- `playwright.auth.config.ts` defines two projects: `auth-http` (3201) and `auth-https` (3202, self-signed TLS with `ignoreHTTPSErrors`). The MSW `app` project ignores the auth specs, so the lanes never cross.
- Boots the real, non-MSW Nitro build against a real **Pocket ID** and a throwaway **Timescale** database. The cookie name is driven by `OIDC_REDIRECT_URI`, so the two servers exercise the `session` and `__Host-session` modes.
- Login uses Pocket ID's one-time access token, minted per test through the admin API, so there is no passkey or WebAuthn automation.
- https is reached through a small Bun TLS proxy in front of an internal Nitro instance, because `https://localhost` is a secure context in Chromium and is therefore required for `__Host-` and `Secure` to be accepted at all.

## Assertions

- **http**: the real callback `Set-Cookie` carries `Max-Age`, `HttpOnly`, `SameSite=Lax`, `Path=/` and no `Secure`; the browser stores it with a real expiry; the session survives into a fresh context; logout clears it.
- **https**: `__Host-session` with `Secure` is accepted and stored, which is itself the proof, since a malformed `__Host-` cookie would be silently dropped. A planted plain `session` cookie does **not** authenticate, covering the single-name read. Logout clears it.

## CI

New `e2e-auth` job with `timescale/timescaledb` and `ghcr.io/pocket-id/pocket-id:v2` service containers, running `bun run test:e2e:auth`.

`publish` now requires `e2e-auth` alongside the `e2e` and `migrations` gates added by #295. `deploy-demo` deliberately does **not**: it is a static build with no database and no OIDC, so a Pocket ID container failing says nothing about whether the demo is publishable. That is the same reasoning that kept `migrations` off `deploy-demo`.

The job is bounded at `timeout-minutes: 20`, matching `e2e`. It gates `publish`, and an unbounded job that boots two service containers can block a release indefinitely.

## What the re-cut changed

The branch carried three commits that have since merged in evolved form, so only the auth-lane commit was replayed. The cookie contract these tests assert (`__Host-session`, `Max-Age`, `buildClearSessionCookie`) was confirmed present on `main` before the superseded commit was dropped.

Specs were renamed from `*.authhttp.spec.ts` to `*.authhttp.e2e.ts`, with the matchers and ignores updated. This branch predates the rename #293 made: `bun test` collects `*.spec.ts` and dies on Playwright's `test()` with no failing assertion, so keeping the old suffix would have reintroduced that. `docs/playwright-test-plan.md` was deleted on `main`; the lane's description belongs in the flow inventory (#384) rather than resurrecting the file.

## Verification

Docker is not available in the environment this was re-cut in, so the full Pocket ID and Postgres flow is verified by the `e2e-auth` job in CI. Verified locally: `bun run typecheck` clean; `bun test` collects no e2e specs; the MSW lane still lists 21 tests in 9 files with the auth specs correctly excluded; the auth lane lists 6 tests across both projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end authentication coverage for HTTP and HTTPS deployments.
  * Verified secure session cookie behavior, persistence, logout, and rejection of forged cookies.
  * Added automated setup for authentication services and test databases.

* **Tests**
  * Added dedicated Playwright authentication test projects and CI execution.
  * Authentication test reports are now uploaded as build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->