### PR TITLE
fix(self-hosting): make documented deployment actually work

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,6 @@ POSTGRES_POOL_SIZE="10"
 WEB_PORT="3000"
 
 # Background Worker
-WORKER_ENABLED="true"
 WORKER_DOCKER_ENABLED="true"
 WORKER_ZFS_ENABLED="false"
 WORKER_PROXMOX_ENABLED="false"
@@ -41,7 +40,6 @@ WORKER_COLLECTION_INTERVAL_MS="1000"
 
 # Docker Stack Management
 GIT_REPOS_DIR="./data/repos"
-GIT_SERVER_TOKEN="dev-git-token"
 
 # Deploy watchdog: fails deploys stuck in "in_progress" past the threshold.
 # DEPLOY_WATCHDOG_INTERVAL_MS="120000"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -124,7 +124,7 @@ loadSubscribe: async () => {
 }
 ```
 
-Hand-written routes (don't fit the factory shape): `docker-logs.$containerId` (auth + DB lookup + pipe-through from agent) and `git.$` (git HTTP smart protocol, not SSE).
+Hand-written routes (don't fit the factory shape): `docker-logs.$containerId` (auth + DB lookup + pipe-through from agent), `git.$` (git HTTP smart protocol, not SSE), and `health` (unauthenticated DB-reachability probe for Docker healthchecks and uptime monitors, handler in `src/lib/health/`).
 
 ### Shared DataTable (`src/components/ui/datatable/`)
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,8 @@ The fastest path is the pre-built Docker images. Download the compose file and a
 ```bash
 mkdir homelab-manager && cd homelab-manager
 curl -O https://raw.githubusercontent.com/jaredglaser/homelab-manager/main/self-hosting/docker-compose.yml
-# Create a .env with POSTGRES_* and MASTER_KEY (see self-hosting guide)
+# Create a .env with POSTGRES_*, MASTER_KEY, and an auth choice
+# (OIDC or AUTH_DISABLED=true; see the self-hosting guide)
 docker compose up -d
 ```
 
@@ -74,7 +75,7 @@ Full instructions: [Self-Hosting Guide](self-hosting/README.md). For local devel
 - [x] Agent-updater sidecar for automatic container updates
 - [x] Pre-built Docker image on a container registry
 - [x] Live demo deployed to GitHub Pages
-- [~] Authentication (OIDC with Pocket ID support): code landed in `src/lib/auth/`, required by default with `AUTH_DISABLED=true` as the opt-out; integration docs pending
+- [x] Authentication (OIDC with Pocket ID support): required by default with `AUTH_DISABLED=true` as the opt-out; setup documented in the [self-hosting guide](self-hosting/README.md#authentication-oidc)
 - [ ] Return to TanStack Start streaming server functions (pending upstream abort signal fix)
 
 ## AI Disclosure

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -98,7 +98,6 @@ services:
     environment:
       <<: [*postgres-env, *zfs-env, *proxmox-env]
       POSTGRES_POOL_SIZE: ${POSTGRES_POOL_SIZE}
-      WORKER_ENABLED: ${WORKER_ENABLED}
       WORKER_DOCKER_ENABLED: ${WORKER_DOCKER_ENABLED}
       WORKER_ZFS_ENABLED: ${WORKER_ZFS_ENABLED}
       WORKER_PROXMOX_ENABLED: ${WORKER_PROXMOX_ENABLED}

--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,6 @@ POSTGRES_PORT="5432"
 POSTGRES_POOL_SIZE="10"
 
 # Worker: enable Docker collection
-WORKER_ENABLED="true"
 WORKER_DOCKER_ENABLED="true"
 WORKER_COLLECTION_INTERVAL_MS="1000"
 
@@ -48,7 +47,6 @@ WEB_PORT="3000"
 
 # Docker Stack Management / Git stacks repo
 GIT_REPOS_DIR="./data/repos"
-GIT_SERVER_TOKEN="dev-git-token"
 
 # Master encryption key for stack secrets and per-agent keypairs.
 # Generate with: openssl rand -base64 32

--- a/docs/git-stacks-repo.md
+++ b/docs/git-stacks-repo.md
@@ -17,7 +17,7 @@ The repo is accessible via Git HTTP smart protocol at:
 http://localhost:3000/api/git/stacks
 ```
 
-Authentication uses a Bearer token set via `GIT_SERVER_TOKEN` in your `.env`.
+Authentication uses per-user git tokens. Generate one in **Settings → Authentication → Generate Git Token** (visible to admins). The token is stored encrypted (JWE, master keyring) in the `git_tokens` table and shown once at creation; pushes require the token's owner to have the `admin` or `operator` role.
 
 ### Clone
 
@@ -25,10 +25,10 @@ Authentication uses a Bearer token set via `GIT_SERVER_TOKEN` in your `.env`.
 git clone http://localhost:3000/api/git/stacks stacks
 ```
 
-When prompted for credentials, use any username and the `GIT_SERVER_TOKEN` value as the password. Or configure the token in the URL:
+When prompted for credentials, use any username and your git token as the password. Or configure the token in the URL:
 
 ```bash
-git clone http://x:dev-git-token@localhost:3000/api/git/stacks ~/stacks
+git clone http://x:<your-git-token>@localhost:3000/api/git/stacks ~/stacks
 ```
 
 > **Note:** The `x` username is ignored; only the password (token) matters.
@@ -86,9 +86,8 @@ stacks:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `GIT_REPOS_DIR` | `/data/repos` | Directory for bare git repos (inside the container) |
-| `GIT_SERVER_TOKEN` | (none) | Bearer token for git HTTP authentication (required) |
 
-Both must be set in your `.env`.
+Git HTTP authentication does not use an env var: tokens are generated per user in the Settings UI and stored encrypted in the database.
 
 ## Local Development
 
@@ -102,14 +101,11 @@ The repo URL is the same: `http://localhost:3000/api/git/stacks`.
 
 ## Troubleshooting
 
-**"Git server token not configured" (500)**
-Set `GIT_SERVER_TOKEN` in your `.env` and restart the web server.
-
 **"Unauthorized" (401)**
-Check that you're passing the token. With curl: `curl -H "Authorization: Bearer dev-git-token" http://localhost:3000/api/git/stacks/info/refs?service=git-upload-pack`
+Check that you're passing a valid git token generated in **Settings → Authentication**. With curl: `curl -H "Authorization: Bearer <your-git-token>" http://localhost:3000/api/git/stacks/info/refs?service=git-upload-pack`. A 401 also occurs when the token was revoked or its owner lost the `admin`/`operator` role.
 
 **Clone hangs or times out**
-Ensure the web server is running and `GIT_SERVER_TOKEN` is set.
+Ensure the web server is running and reachable.
 
 **Push succeeds but stack doesn't appear**
 Check that the stack is listed in `manifest.yaml` and the `host` value matches a managed host name.

--- a/self-hosting/README.md
+++ b/self-hosting/README.md
@@ -6,7 +6,7 @@ A real-time monitoring dashboard for Docker containers, ZFS pools, and Proxmox V
 > **Stack management and agent functionality are currently unstable and under active development.** Expect breaking changes, incomplete features, and rough edges. Use at your own risk.
 
 > [!WARNING]
-> **Do not expose this dashboard to the public internet.** There is no built-in authentication - anyone who can reach the port can view your infrastructure and change settings. The service is not hardened for untrusted networks. Keep it on your LAN, and ideally isolate it further with a dedicated lab VLAN or a firewall rule that restricts access to specific hosts.
+> **Do not expose this dashboard to the public internet.** The dashboard ships with built-in OIDC authentication (on by default), but the service is not hardened for untrusted networks. Keep it on your LAN, and ideally isolate it further with a dedicated lab VLAN or a firewall rule that restricts access to specific hosts.
 >
 > For remote access, use a VPN tunnel back to your home network rather than port-forwarding. [Tailscale](https://tailscale.com) and [WireGuard](https://www.wireguard.com) are both solid options: install the client on your phone or laptop, connect to your homelab's VPN, and access the dashboard at its local IP as if you were home.
 
@@ -25,7 +25,7 @@ curl -O https://raw.githubusercontent.com/jaredglaser/homelab-manager/main/self-
 
 **2. Create a `.env` file**
 
-Copy the template below into a `.env` file in the same directory and fill in your values:
+Copy the base template below into a `.env` file in the same directory and fill in your values:
 
 ```env
 # PostgreSQL
@@ -38,17 +38,38 @@ POSTGRES_PASSWORD=changeme   # change this
 MASTER_KEY=changeme          # replace with a generated key
 ```
 
-See [Configuration](#configuration) for all available options.
+**3. Choose an authentication path**
 
-**3. Start**
+Authentication is on by default and must be configured before the dashboard is usable. Pick one:
+
+**Path A: OIDC login (recommended).** Set up an OIDC provider and add its values to `.env`:
+
+```env
+OIDC_ISSUER_URL=https://id.example.com
+OIDC_CLIENT_ID=homelab-manager
+OIDC_CLIENT_SECRET=your-client-secret
+OIDC_REDIRECT_URI=http://<your-server-ip>:3000/api/auth/callback
+```
+
+The dashboard is designed and tested with [Pocket ID](https://github.com/pocket-id/pocket-id), a lightweight OIDC/passkey provider built for homelabs, but works with any OIDC issuer. Follow the [Pocket ID setup walkthrough](#setting-up-pocket-id) below before your first login; skipping the group setup locks you out at a "denied" page.
+
+**Path B: no login, trusted network only.** Explicitly opt out of authentication:
+
+```env
+AUTH_DISABLED=true
+```
+
+With auth disabled, anyone who can reach the port can view your infrastructure and change settings. Only use this on an isolated network you trust (see the warning above).
+
+**4. Start**
 
 ```bash
 docker compose up -d
 ```
 
-Open `http://<your-server-ip>:3000` (or whichever port you set via `WEB_PORT`).
+Open `http://<your-server-ip>:3000` (or whichever port you set via `WEB_PORT`). The worker applies database migrations on its first start, so give the stack a few seconds before the first page load.
 
-**4. Stop**
+**5. Stop**
 
 ```bash
 docker compose down
@@ -67,16 +88,23 @@ docker compose down -v
 | Service | Image | Description |
 |---------|-------|-------------|
 | `postgres` | `timescale/timescaledb:latest-pg16` | Time-series database (infinite retention, automatic compression after 7 days). Runs with `synchronous_commit=off` - up to ~200ms of stats can be lost on a hard crash, which is acceptable for monitoring data where transaction latency matters more than durability. |
-| `worker` | `ghcr.io/jaredglaser/homelab-manager-worker` | Background collector - connects to agent sidecars (Docker/ZFS) and polls Proxmox, writes stats to TimescaleDB |
+| `worker` | `ghcr.io/jaredglaser/homelab-manager-worker` | Background collector - connects to agent sidecars (Docker/ZFS) and polls Proxmox, writes stats to TimescaleDB. Also applies database migrations on startup. |
 | `web` | `ghcr.io/jaredglaser/homelab-manager-web` | Dashboard UI and API server. Streams stats from TimescaleDB to connected clients via SSE. |
 
-> **Note:** Images are published to GitHub Container Registry ([web](https://github.com/jaredglaser/homelab-manager/pkgs/container/homelab-manager-web), [worker](https://github.com/jaredglaser/homelab-manager/pkgs/container/homelab-manager-worker)) on every push to `main`. The project is pre-release and not yet versioned - use `latest` for now and watch the changelog for breaking changes before pulling updates.
+Two more images run on **monitored hosts** (not in this compose file). The Add Host wizard generates a compose stack for them during enrollment:
+
+| Image | Description |
+|-------|-------------|
+| `ghcr.io/jaredglaser/homelab-manager-agent` | Agent sidecar deployed on each monitored Docker/ZFS host |
+| `ghcr.io/jaredglaser/homelab-manager-agent-updater` | Optional companion that keeps the agent image up to date |
+
+> **Note:** Images are published to GitHub Container Registry ([web](https://github.com/jaredglaser/homelab-manager/pkgs/container/homelab-manager-web), [worker](https://github.com/jaredglaser/homelab-manager/pkgs/container/homelab-manager-worker), [agent](https://github.com/jaredglaser/homelab-manager/pkgs/container/homelab-manager-agent), [agent-updater](https://github.com/jaredglaser/homelab-manager/pkgs/container/homelab-manager-agent-updater)) on every push to `main`. The project is pre-release and not yet versioned: use `latest`, and review recent commits on `main` for breaking changes before pulling updates.
 
 ---
 
 ## Configuration
 
-All configuration is done via environment variables in your `.env` file.
+All configuration is done via environment variables in your `.env` file. The compose file forwards each documented variable to the container that reads it; if you add variables beyond the ones listed here (for example an extra `MASTER_KEY_<KID>` during key rotation), you must also add them to the matching service's `environment:` block, because Compose does not pass arbitrary `.env` keys through on its own.
 
 ### Required
 
@@ -85,7 +113,7 @@ All configuration is done via environment variables in your `.env` file.
 | `POSTGRES_DB` | Database name |
 | `POSTGRES_USER` | Database user |
 | `POSTGRES_PASSWORD` | Database password |
-| `MASTER_KEY` or `MASTER_KEY_FILE` | Base64-encoded 256-bit key for at-rest encryption of stack secrets and agent keypairs. Set exactly one: `MASTER_KEY` inline, or `MASTER_KEY_FILE` pointing at a file containing the base64 string. Generate with `openssl rand -base64 32`. For key rotation, add `MASTER_KEY_<KID>` (e.g. `MASTER_KEY_v2`) alongside the old key and re-encrypt with `bun run migrate-secrets --from v1 --to v2`. |
+| `MASTER_KEY` or `MASTER_KEY_FILE` | Base64-encoded 256-bit key for at-rest encryption of stack secrets, agent keypairs, and git tokens. Set exactly one. Generate with `openssl rand -base64 32`. `MASTER_KEY_FILE` points at a file *inside the container*, so it also requires adding a matching volume mount to the `worker` and `web` services in the compose file. See [Master Key Rotation](#master-key-rotation) and [Backup and Restore](#backup-and-restore) before you rely on it: losing this key permanently orphans everything encrypted with it. |
 
 ### Web Server
 
@@ -93,22 +121,54 @@ All configuration is done via environment variables in your `.env` file.
 |----------|---------|-------------|
 | `WEB_PORT` | `3000` | Host port for the dashboard |
 
+### Authentication (OIDC)
+
+On by default. Configure an OIDC provider (designed and tested with [Pocket ID](https://github.com/pocket-id/pocket-id), but works with any OIDC issuer), or set `AUTH_DISABLED=true` to opt out on a trusted network. The opt-out is deliberate: an unrecognized `AUTH_DISABLED` value or the removed legacy `AUTH_ENABLED` variable fails startup instead of silently opening the app. With auth disabled, every request runs as a synthetic admin and the dashboard relies on network isolation (see the warning above).
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AUTH_DISABLED` | unset (auth required) | Set to `true` (or `1`/`yes`/`on`) to disable OIDC login for all routes and SSE streams |
+| `OIDC_ISSUER_URL` | - | OIDC issuer URL, used for discovery (e.g. `https://id.example.com`) |
+| `OIDC_CLIENT_ID` | - | OIDC client ID registered with your provider |
+| `OIDC_CLIENT_SECRET` | - | OIDC client secret. Not validated at startup; a missing or wrong secret surfaces as a failed login attempt, so test a login after changing it. |
+| `OIDC_REDIRECT_URI` | - | Callback URL pointing at **this dashboard**, always ending in `/api/auth/callback` (e.g. `https://homelab.example.com/api/auth/callback`). This is not a URL on your OIDC provider. It must exactly match the callback URL registered in the provider. |
+| `SESSION_TTL_HOURS` | `8` | Session cookie lifetime |
+| `OIDC_ROLE_ADMIN` | `homelab-admins` | OIDC group claim that maps to the `admin` role |
+| `OIDC_ROLE_OPERATOR` | `homelab-operators` | OIDC group claim that maps to the `operator` role |
+| `OIDC_ROLE_VIEWER` | `homelab-viewers` | OIDC group claim that maps to the `viewer` role |
+
+Roles come from the provider's `groups` claim (the app requests the `openid profile email groups` scopes and reads groups from both the userinfo endpoint and the ID token). A user whose groups match none of the three role mappings is denied access entirely. There is no bootstrap admin: get the group membership right in the provider before the first login.
+
+#### Setting up Pocket ID
+
+Step-by-step for a working login with [Pocket ID](https://github.com/pocket-id/pocket-id). The same shape applies to other providers.
+
+1. **Create the role groups.** In the Pocket ID admin UI, create user groups matching your role mapping (by default `homelab-admins`, `homelab-operators`, `homelab-viewers`; only the ones you need). Assign your user to the right group, e.g. `homelab-admins` for the admin role.
+2. **Create an OIDC client** for the dashboard. Set its callback URL to your dashboard's callback: `http(s)://<dashboard-host>/api/auth/callback`. This exact value also goes into `OIDC_REDIRECT_URI`. A common mistake is pointing `OIDC_REDIRECT_URI` at the provider (e.g. an `/authorize` URL); it must point at the dashboard.
+3. **Allow your group on the client.** Pocket ID can restrict which user groups may use a client (new clients are restricted by default on recent versions). If your user's group is not allowed on the client, Pocket ID blocks the login with "You're not allowed to access this service." before the dashboard is ever involved. This client-access setting is separate from the role-mapping groups in step 1, even if you use the same group for both.
+4. **Copy the client ID and secret** into `OIDC_CLIENT_ID` and `OIDC_CLIENT_SECRET`.
+5. Set `OIDC_ISSUER_URL` to your Pocket ID base URL (e.g. `https://id.example.com`), then `docker compose up -d` and log in.
+
+If login succeeds at the provider but the dashboard shows "You don't have access to this application", the OIDC handshake worked and the role mapping failed: your user's groups matched none of the `OIDC_ROLE_*` values. Fix the group membership in Pocket ID and log in again.
+
 ### Reverse Proxy
 
-Any reverse proxy works. [Caddy](https://caddyserver.com/docs/) is a popular homelab choice - refer to its docs for setup.
+Any reverse proxy works. [Caddy](https://caddyserver.com/docs/) is a popular homelab choice - refer to its docs for setup. Three dashboard-specific requirements:
+
+- **Serve over HTTPS if you can.** The session cookie is only marked `Secure` when `OIDC_REDIRECT_URI` starts with `https://`, so an https reverse proxy plus an https redirect URI keeps the session cookie off plaintext connections.
+- **Do not buffer SSE.** All real-time updates stream over long-lived `text/event-stream` responses under `/api/`. Disable response buffering for those routes (nginx: `proxy_buffering off;`) and raise the read/idle timeout well above its 60s default, or the dashboard will appear frozen or lose live updates.
+- **Forward client IPs.** The dashboard records `X-Forwarded-For` on login sessions for auditing, so pass it through.
 
 **Keep the dashboard on your LAN.** A reverse proxy does not change the security posture described in the warning above. Do not route this dashboard through a public-facing proxy.
 
-**Authentication layer:** Since the dashboard has no built-in auth, consider placing an auth middleware in front of it. [tinyauth](https://github.com/steveiliop56/tinyauth) paired with [Pocket ID](https://github.com/stonith404/pocket-id) (a lightweight OIDC/passkey provider built for homelabs) is a clean option: Pocket ID manages your identity store, tinyauth enforces login at the proxy layer, and the dashboard itself stays unchanged. Treat this as defense-in-depth on top of network isolation, not a replacement for it.
-
 ### Agent Environment
 
-These variables are set on each **agent** container (not on the dashboard or worker). The Add Host wizard generates a compose snippet for the agent; set `AGENT_HOST_NAME` on that container to the same host name you register in the wizard.
+These variables are set on each **agent** container (not on the dashboard or worker). The Add Host wizard (**Settings → Managed Hosts → Add Host**) generates a ready-to-use compose stack for the agent, including a Docker socket proxy, the agent-updater, and any ZFS device/binary mounts, so you normally never write this by hand. The variables below are for reference when customizing the generated stack.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AGENT_HOST_NAME` | - | **Required.** Must equal the managed host's name as registered in **Settings → Managed Hosts**. Manager-issued JWTs carry this name as the `aud` claim, so a token minted for one host is rejected by another (protects against a reused or copy-pasted keypair). The agent exits at startup if it is unset. |
-| `AGENT_TRUSTED_PUBKEY` or `AGENT_TRUSTED_PUBKEY_FILE` | - | Trusted Ed25519 public JWK the agent verifies request JWTs against. The dashboard hands you this value during the Verify step. Set exactly one. |
+| `AGENT_TRUSTED_PUBKEY` or `AGENT_TRUSTED_PUBKEY_FILE` | - | Trusted Ed25519 public JWK the agent verifies request JWTs against. The dashboard hands you this value during the Verify step. Set one of the two; if both are set, the `_FILE` variant wins. |
 | `AGENT_PORT` | `9090` | Port the agent listens on |
 | `DOCKER_HOST` | - | Docker endpoint (socket proxy recommended, e.g. `tcp://socket-proxy:2375`). Enables the Docker capability. |
 | `TLS_CERT_PATH` / `TLS_KEY_PATH` | - | Optional TLS for the agent's listener. Set both together. |
@@ -123,7 +183,9 @@ Docker monitoring works through agent sidecars. Deploy the agent container on ea
 
 ZFS monitoring works through agent sidecars (the same agents used for Docker management). When you register a managed host with ZFS capability, the worker connects to the agent's `/zfs/stats/stream` SSE endpoint to receive real-time `zpool iostat` data. No SSH configuration is needed.
 
-> **Setup:** Deploy the agent container on a host with ZFS pools, then register the host in **Settings → Managed Hosts** with the `zfs` capability enabled. The agent auto-detects ZFS by checking for the `zpool` binary at startup.
+The agent image does not ship ZFS tooling; the ZFS capability requires bind-mounting the host's binaries and device node into the agent container (`/usr/sbin/zpool` and `/usr/sbin/zfs` read-only, plus `/dev/zfs`), and running the container as a uid/gid with permission on `/dev/zfs`. The Add Host wizard generates all of this when you enable the ZFS capability; if you hand-write the agent compose file and omit the mounts, the agent logs "ZFS capability: disabled" at startup because it cannot find the `zpool` binary.
+
+> **Setup:** Deploy the wizard-generated agent stack on a host with ZFS pools, then register the host in **Settings → Managed Hosts** with the `zfs` capability enabled.
 
 ### Proxmox VE Monitoring
 
@@ -139,15 +201,16 @@ ZFS monitoring works through agent sidecars (the same agents used for Docker man
 
 ### Docker Stack Management
 
-Stack management lets you deploy and manage Docker Compose stacks on your hosts via the dashboard. Authentication uses short-lived JWTs signed by a per-host Ed25519 keypair stored encrypted in the database; no token file is distributed to hosts.
+Stack management lets you deploy and manage Docker Compose stacks on your hosts via the dashboard, either from the UI or by pushing to the built-in git repository at `/api/git/stacks`.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `GIT_SERVER_TOKEN` | - | Token for authenticating git pushes to the built-in git server |
+Two separate credentials are involved, neither of which is an env var:
+
+- **Dashboard-to-agent:** each deploy request carries a short-lived JWT signed by a per-host Ed25519 keypair stored encrypted in the database; no token file is distributed to hosts.
+- **Git pushes:** authenticated with per-user git tokens. Generate one in **Settings → Authentication → Generate Git Token** (admin only; the token is shown once). Use it as the password on `git push`; pushes require the `admin` or `operator` role.
 
 > **How it works:** Each managed Docker host runs a lightweight agent container that the dashboard communicates with for deploy operations. When you enroll a host, the dashboard generates an Ed25519 keypair, encrypts the private key with `MASTER_KEY`, and sends the public JWK to the agent. Each deploy request carries a short-lived signed JWT; the agent verifies it against the trusted public key.
 >
-> **Adding a host:** Use **Settings → Managed Hosts → Add Host** in the dashboard. The wizard generates a compose snippet for the agent and handles key exchange during the Verify step. Set `AGENT_HOST_NAME` on the agent to the host name you enter in the wizard (see [Agent Environment](#agent-environment)). Once connectivity is confirmed, the keypair is stored and the host is ready.
+> **Adding a host:** Use **Settings → Managed Hosts → Add Host** in the dashboard. The wizard generates a compose stack for the agent and handles key exchange during the Verify step. Set `AGENT_HOST_NAME` on the agent to the host name you enter in the wizard (see [Agent Environment](#agent-environment)). Once connectivity is confirmed, the keypair is stored and the host is ready.
 
 ### PostgreSQL Connection
 
@@ -157,25 +220,9 @@ Stack management lets you deploy and manage Docker Compose stacks on your hosts 
 | `POSTGRES_SSL_REJECT_UNAUTHORIZED` | `true` | Verify the server's TLS certificate. Set to `false` only for self-signed certificates. This disables chain validation and exposes the connection to MITM attacks. |
 | `POSTGRES_POOL_SIZE` | `10` | Database connection pool size |
 
-### Authentication (OIDC)
-
-On by default. Configure an OIDC provider (designed and tested with [Pocket ID](https://github.com/stonith404/pocket-id), but works with any OIDC issuer), or set `AUTH_DISABLED=true` to opt out on a trusted network. The opt-out is deliberate: an unrecognized `AUTH_DISABLED` value or the removed legacy `AUTH_ENABLED` variable fails startup instead of silently opening the app. With auth disabled, the dashboard relies on network isolation (see the warning above).
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `AUTH_DISABLED` | unset (auth required) | Set to `true` (or `1`/`yes`/`on`) to disable OIDC login for all routes and SSE streams |
-| `OIDC_ISSUER_URL` | - | OIDC discovery URL (e.g. `https://pocketid.example.com`) |
-| `OIDC_CLIENT_ID` | - | OIDC client ID registered with your provider |
-| `OIDC_CLIENT_SECRET` | - | OIDC client secret |
-| `OIDC_REDIRECT_URI` | - | Public callback URL, e.g. `https://homelab.example.com/api/auth/callback` |
-| `SESSION_TTL_HOURS` | `8` | Session cookie lifetime |
-| `OIDC_ROLE_ADMIN` | `homelab-admins` | OIDC group claim that maps to the `admin` role |
-| `OIDC_ROLE_OPERATOR` | `homelab-operators` | OIDC group claim that maps to the `operator` role |
-| `OIDC_ROLE_VIEWER` | `homelab-viewers` | OIDC group claim that maps to the `viewer` role |
-
-If you prefer to keep auth at the proxy layer instead (tinyauth + Pocket ID), set `AUTH_DISABLED=true`. See the [Authentication layer](#reverse-proxy) note above.
-
 ### Deploy Watchdog (optional)
+
+Runs inside the web container; scans for deploys stuck `in_progress` (e.g. after a crash) and fails them.
 
 | Variable | Default | Description |
 |----------|---------|-------------|
@@ -184,14 +231,52 @@ If you prefer to keep auth at the proxy layer instead (tinyauth + Pocket ID), se
 
 ### Worker Behavior
 
+The worker always runs and applies database migrations on startup; individual collection sources are toggled per source.
+
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `WORKER_ENABLED` | `true` | Enable the background collector |
 | `WORKER_DOCKER_ENABLED` | `true` | Enable Docker stats collection |
 | `WORKER_ZFS_ENABLED` | `false` | Enable ZFS stats collection |
 | `WORKER_PROXMOX_ENABLED` | `false` | Enable Proxmox stats collection |
 | `WORKER_COLLECTION_INTERVAL_MS` | `1000` | Collection interval in milliseconds |
 | `WORKER_LOCALHOST_AGENT` | - | Docker-internal hostname to substitute for `localhost` agent URLs (e.g. `hlm-agent`). Set this when the worker and an agent container run on the same Docker host; without it, `localhost` agent URLs resolve to the worker container itself rather than the agent container. |
+
+---
+
+## Master Key Rotation
+
+Encrypted columns use a versioned keyring so a new master key can be enrolled without breaking existing ciphertext. `MASTER_KEY` is treated as key ID `v1`; additional keys use `MASTER_KEY_<KID>` (e.g. `MASTER_KEY_v2`). The lexicographically last KID encrypts new secrets; all loaded keys decrypt.
+
+1. Generate a new key: `openssl rand -base64 32`
+2. Add `MASTER_KEY_v2=<new-base64>` to `.env` (keep the old `MASTER_KEY` in place), **and** add `MASTER_KEY_v2: ${MASTER_KEY_v2:-}` to the `environment:` blocks of both the `web` and `worker` services in `docker-compose.yml`. Compose only forwards variables that the service block names.
+3. Recreate the containers: `docker compose up -d`
+4. Re-encrypt existing rows inside the web container:
+
+   ```bash
+   docker compose exec web bun run migrate-secrets --from v1 --to v2
+   ```
+
+5. Remove the old key from `.env` (and its compose line if you added one), then `docker compose up -d` again.
+
+The migration exits non-zero on any failure. Partially migrated rows are safe because both keys stay in the keyring during the rotation window.
+
+## Backup and Restore
+
+Three things constitute a full backup:
+
+1. **The database.** Either snapshot the `pgdata` volume while the stack is stopped, or take a live dump: `docker compose exec postgres pg_dump -U $POSTGRES_USER -Fc $POSTGRES_DB > homelab.dump`
+2. **The git repos volume** (`git-repos`), which holds your stack definitions.
+3. **Your `.env`, especially `MASTER_KEY`.**
+
+The master key is not stored in the database. A database backup without the key is incomplete: stack secrets, every managed host's agent keypair, and all git tokens are encrypted with it and cannot be recovered if it is lost. You would have to re-enter all stack secrets, re-enroll every managed host, and regenerate git tokens. Store the key somewhere safe and separate from the database backup.
+
+## Health Monitoring
+
+The web service exposes an unauthenticated `GET /api/health` endpoint that verifies database reachability: `200 {"status":"ok","database":true}` when healthy, `503` otherwise. The compose file uses it for the `web` service's Docker healthcheck, and it is the right target for an external uptime monitor (e.g. Uptime Kuma):
+
+```bash
+curl http://<your-server-ip>:3000/api/health
+```
 
 ---
 
@@ -209,11 +294,25 @@ MASTER_KEY=a-long-base64-string-here
 # Web Server
 # WEB_PORT=3000
 
+# Authentication: pick ONE path.
+# Path A: OIDC login (recommended; see the Pocket ID walkthrough)
+OIDC_ISSUER_URL=https://id.example.com
+OIDC_CLIENT_ID=homelab-manager
+OIDC_CLIENT_SECRET=your-client-secret
+OIDC_REDIRECT_URI=https://homelab.example.com/api/auth/callback
+# SESSION_TTL_HOURS=8
+# OIDC_ROLE_ADMIN=homelab-admins
+# OIDC_ROLE_OPERATOR=homelab-operators
+# OIDC_ROLE_VIEWER=homelab-viewers
+# Path B: no login, trusted network only (comment out the OIDC block above)
+# AUTH_DISABLED=true
+
 # Docker: no env vars needed; register hosts with the Docker capability
 # in Settings → Managed Hosts after deploying an agent sidecar.
 
-# ZFS: no env vars needed; register hosts with ZFS capability
-# in Settings → Managed Hosts after deploying an agent sidecar
+# ZFS: no worker env vars needed; deploy the wizard-generated agent stack
+# (includes the required zpool/zfs/dev mounts) and register the host with
+# the ZFS capability in Settings → Managed Hosts.
 
 # Proxmox VE
 PROXMOX_HOST=192.168.1.100
@@ -221,14 +320,11 @@ PROXMOX_TOKEN_ID=root@pam!monitoring
 PROXMOX_TOKEN_SECRET=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 
 # Worker
-# WORKER_ENABLED=true
 # WORKER_DOCKER_ENABLED=true
 # WORKER_ZFS_ENABLED=false
 WORKER_PROXMOX_ENABLED=true
 # WORKER_COLLECTION_INTERVAL_MS=1000
-
-# Stack management
-# GIT_SERVER_TOKEN=a-random-token-for-git-auth
+# WORKER_LOCALHOST_AGENT=hlm-agent
 ```
 
 ---
@@ -242,7 +338,18 @@ docker compose pull
 docker compose up -d
 ```
 
+The worker applies any pending database migrations when it starts, so it must come up as part of every update. There is no downgrade path: back up before updating (see [Backup and Restore](#backup-and-restore)).
+
 ## Troubleshooting
+
+**Login always fails with `error=login_failed` in the URL**
+- The web container cannot complete the OIDC flow. Check `docker compose logs web` for the reason: usually missing `OIDC_*` variables, an unreachable `OIDC_ISSUER_URL`, or a wrong `OIDC_CLIENT_SECRET` (the secret is only validated at login time, not startup).
+
+**Provider says "You're not allowed to access this service" (Pocket ID)**
+- Your user's group is not allowed on the OIDC client in Pocket ID. Grant the group access on the client itself (or unrestrict the client). See step 3 of the [Pocket ID walkthrough](#setting-up-pocket-id).
+
+**Dashboard says "You don't have access to this application"**
+- The OIDC login worked, but none of your user's groups match `OIDC_ROLE_ADMIN`/`OPERATOR`/`VIEWER`. Fix the group membership in the provider (and confirm the provider includes a `groups` claim), then log in again.
 
 **Dashboard shows no data**
 - Check the worker logs: `docker compose logs -f worker`
@@ -250,6 +357,7 @@ docker compose up -d
 
 **Database connection errors**
 - The web and worker services wait for the database to be healthy before starting, but if the DB is slow to initialize on first run, restart the failed service: `docker compose restart worker web`
+- `docker compose ps` shows the web service's health state; `curl http://<ip>:3000/api/health` checks it from outside.
 
 **Proxmox page shows no data**
 - `WORKER_PROXMOX_ENABLED` defaults to `false`. Set it to `true` in your `.env` along with the `PROXMOX_*` connection vars, then restart the worker.
@@ -257,6 +365,9 @@ docker compose up -d
 **Managed hosts aren't reachable / Stacks page shows no hosts**
 - Verify the agent is running on the target host: `curl http://<agent-ip>:9090/health`
 - Re-enroll the host via the wizard if the keypair is missing (e.g., after a fresh database).
+
+**ZFS host shows no pools**
+- The agent needs the host's `zpool`/`zfs` binaries and `/dev/zfs` mounted into its container (the wizard-generated stack includes these). Check the agent logs for "ZFS capability: disabled".
 
 **Port conflict on 3000**
 - Set `WEB_PORT` to any available port in your `.env`.

--- a/self-hosting/docker-compose.yml
+++ b/self-hosting/docker-compose.yml
@@ -4,7 +4,8 @@ x-postgres-env: &postgres-env
   POSTGRES_DB: ${POSTGRES_DB}
   POSTGRES_USER: ${POSTGRES_USER}
   POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-  POSTGRES_SSL: "false"
+  POSTGRES_SSL: ${POSTGRES_SSL:-false}
+  POSTGRES_SSL_REJECT_UNAUTHORIZED: ${POSTGRES_SSL_REJECT_UNAUTHORIZED:-true}
 
 x-proxmox-env: &proxmox-env
   PROXMOX_HOST: ${PROXMOX_HOST:-}
@@ -12,6 +13,20 @@ x-proxmox-env: &proxmox-env
   PROXMOX_TOKEN_ID: ${PROXMOX_TOKEN_ID:-}
   PROXMOX_TOKEN_SECRET: ${PROXMOX_TOKEN_SECRET:-}
   PROXMOX_ALLOW_SELF_SIGNED: ${PROXMOX_ALLOW_SELF_SIGNED:-true}
+
+# Auth is required by default. Either configure OIDC or set AUTH_DISABLED=true
+# for a trusted network. These keys must be listed here: Compose only forwards
+# .env values into a container when the service's environment block names them.
+x-auth-env: &auth-env
+  AUTH_DISABLED: ${AUTH_DISABLED:-}
+  OIDC_ISSUER_URL: ${OIDC_ISSUER_URL:-}
+  OIDC_CLIENT_ID: ${OIDC_CLIENT_ID:-}
+  OIDC_CLIENT_SECRET: ${OIDC_CLIENT_SECRET:-}
+  OIDC_REDIRECT_URI: ${OIDC_REDIRECT_URI:-}
+  SESSION_TTL_HOURS: ${SESSION_TTL_HOURS:-8}
+  OIDC_ROLE_ADMIN: ${OIDC_ROLE_ADMIN:-homelab-admins}
+  OIDC_ROLE_OPERATOR: ${OIDC_ROLE_OPERATOR:-homelab-operators}
+  OIDC_ROLE_VIEWER: ${OIDC_ROLE_VIEWER:-homelab-viewers}
 
 services:
   # PostgreSQL / TimescaleDB - persistent time-series database
@@ -35,7 +50,9 @@ services:
     networks:
       - homelab-network
 
-  # Background worker - collects stats from Docker/ZFS hosts and writes to DB
+  # Background worker - collects stats from Docker/ZFS hosts and writes to DB.
+  # Also runs database migrations on startup, so it must run at least once per
+  # install or upgrade before the web dashboard has a usable schema.
   worker:
     image: ghcr.io/jaredglaser/homelab-manager-worker:latest
     container_name: homelab-worker
@@ -45,11 +62,11 @@ services:
       MASTER_KEY: ${MASTER_KEY:-}
       MASTER_KEY_FILE: ${MASTER_KEY_FILE:-}
       POSTGRES_POOL_SIZE: ${POSTGRES_POOL_SIZE:-10}
-      WORKER_ENABLED: ${WORKER_ENABLED:-true}
       WORKER_DOCKER_ENABLED: ${WORKER_DOCKER_ENABLED:-true}
       WORKER_ZFS_ENABLED: ${WORKER_ZFS_ENABLED:-false}
       WORKER_PROXMOX_ENABLED: ${WORKER_PROXMOX_ENABLED:-false}
       WORKER_COLLECTION_INTERVAL_MS: ${WORKER_COLLECTION_INTERVAL_MS:-1000}
+      WORKER_LOCALHOST_AGENT: ${WORKER_LOCALHOST_AGENT:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped
@@ -72,14 +89,22 @@ services:
     volumes:
       - git-repos:/data/repos
     environment:
-      <<: *postgres-env
+      <<: [*postgres-env, *auth-env]
       MASTER_KEY: ${MASTER_KEY:-}
       MASTER_KEY_FILE: ${MASTER_KEY_FILE:-}
       NODE_ENV: production
       POSTGRES_POOL_SIZE: ${POSTGRES_POOL_SIZE:-10}
       GIT_REPOS_DIR: "/data/repos"
-      GIT_SERVER_TOKEN: ${GIT_SERVER_TOKEN}
-
+      DEPLOY_WATCHDOG_INTERVAL_MS: ${DEPLOY_WATCHDOG_INTERVAL_MS:-}
+      DEPLOY_WATCHDOG_TIMEOUT_MINUTES: ${DEPLOY_WATCHDOG_TIMEOUT_MINUTES:-}
+    healthcheck:
+      # The image has no curl; bun ships in the base image and can probe the
+      # unauthenticated /api/health endpoint (checks DB reachability too).
+      test: ["CMD", "bun", "-e", "fetch('http://localhost:3000/api/health').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped

--- a/src/lib/config/feature-flags.ts
+++ b/src/lib/config/feature-flags.ts
@@ -1,14 +1,6 @@
 import { isAuthDisabled } from '@/lib/config/auth-config';
 
 /**
- * Check if Docker stack management feature is enabled.
- * Gated behind DOCKER_MANAGEMENT_FEATURE_FLAG=true env var.
- */
-export function isDockerManagementEnabled(): boolean {
-  return process.env.DOCKER_MANAGEMENT_FEATURE_FLAG === 'true';
-}
-
-/**
  * Check if authentication is enabled (server-side only). Auth is required by
  * default; AUTH_DISABLED=true is the explicit opt-out.
  * Auth state reaches the client through the getSession() server function.

--- a/src/lib/config/worker-config.ts
+++ b/src/lib/config/worker-config.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
 
 const WorkerConfigSchema = z.object({
-  enabled: z.boolean(),
   docker: z.object({
     enabled: z.boolean(),
   }),
@@ -29,7 +28,6 @@ export type WorkerConfig = z.infer<typeof WorkerConfigSchema>;
  */
 export function loadWorkerConfig(): WorkerConfig {
   const config = {
-    enabled: process.env.WORKER_ENABLED === 'true',
     docker: {
       enabled: process.env.WORKER_DOCKER_ENABLED === 'true',
     },

--- a/src/lib/health/__tests__/health-handler.test.ts
+++ b/src/lib/health/__tests__/health-handler.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
+import { handleHealth, checkDatabase } from '@/lib/health/health-handler';
+
+describe('handleHealth', () => {
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('returns 200 with ok status when the database check resolves', async () => {
+    const response = await handleHealth(() => Promise.resolve());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ status: 'ok', database: true });
+  });
+
+  it('returns 503 with degraded status when the database check rejects', async () => {
+    const response = await handleHealth(() => Promise.reject(new Error('connection refused')));
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ status: 'degraded', database: false });
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('returns 503 when the database check hangs past the timeout', async () => {
+    const response = await handleHealth(() => new Promise<void>(() => {}), 1);
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ status: 'degraded', database: false });
+  });
+
+  it('reports non-Error rejections without throwing', async () => {
+    const response = await handleHealth(() => Promise.reject('string failure'));
+
+    expect(response.status).toBe(503);
+    expect(errorSpy).toHaveBeenCalledWith('[health] Database check failed:', 'string failure');
+  });
+});
+
+describe('checkDatabase', () => {
+  it('queries SELECT 1 through the connection pool', async () => {
+    const query = mock(() => Promise.resolve({ rows: [] }));
+    const getClient = mock(() => Promise.resolve({ getPool: () => ({ query }) }));
+
+    mock.module('@/lib/clients/database-client', () => ({
+      databaseConnectionManager: { getClient },
+    }));
+    mock.module('@/lib/config/database-config', () => ({
+      loadDatabaseConfig: () => ({ host: 'db', port: 5432 }),
+    }));
+
+    await checkDatabase();
+
+    expect(getClient).toHaveBeenCalledTimes(1);
+    expect(query).toHaveBeenCalledWith('SELECT 1');
+  });
+});

--- a/src/lib/health/health-handler.ts
+++ b/src/lib/health/health-handler.ts
@@ -1,0 +1,41 @@
+const DB_CHECK_TIMEOUT_MS = 5000;
+
+/** Round-trips the connection pool so a wedged database reports as unhealthy, not just a dead TCP target. */
+export async function checkDatabase(): Promise<void> {
+  const { databaseConnectionManager } = await import('@/lib/clients/database-client');
+  const { loadDatabaseConfig } = await import('@/lib/config/database-config');
+  const client = await databaseConnectionManager.getClient(loadDatabaseConfig());
+  await client.getPool().query('SELECT 1');
+}
+
+/**
+ * Liveness/readiness probe for the web container. Unauthenticated by design:
+ * Docker healthchecks and uptime monitors must reach it before any login
+ * exists, so the body carries no version, config, or entity details.
+ *
+ * @returns 200 `{status:'ok',database:true}` when the DB answers within the
+ * timeout, 503 `{status:'degraded',database:false}` otherwise.
+ */
+export async function handleHealth(
+  check: () => Promise<void> = checkDatabase,
+  timeoutMs: number = DB_CHECK_TIMEOUT_MS,
+): Promise<Response> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([
+      check(),
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Database health check timed out after ${timeoutMs}ms`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+    return Response.json({ status: 'ok', database: true });
+  } catch (err) {
+    console.error('[health] Database check failed:', err instanceof Error ? err.message : err);
+    return Response.json({ status: 'degraded', database: false }, { status: 503 });
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -24,6 +24,7 @@ import { Route as ApiZfsStatsRouteImport } from './routes/api/zfs-stats'
 import { Route as ApiStackStatusRouteImport } from './routes/api/stack-status'
 import { Route as ApiSettingsRouteImport } from './routes/api/settings'
 import { Route as ApiProxmoxStatsRouteImport } from './routes/api/proxmox-stats'
+import { Route as ApiHealthRouteImport } from './routes/api/health'
 import { Route as ApiDockerStatsRouteImport } from './routes/api/docker-stats'
 import { Route as ApiDockerInventoryRouteImport } from './routes/api/docker-inventory'
 import { Route as StacksHostHostNameRouteImport } from './routes/stacks/host.$hostName'
@@ -108,6 +109,11 @@ const ApiProxmoxStatsRoute = ApiProxmoxStatsRouteImport.update({
   path: '/api/proxmox-stats',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiHealthRoute = ApiHealthRouteImport.update({
+  id: '/api/health',
+  path: '/api/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiDockerStatsRoute = ApiDockerStatsRouteImport.update({
   id: '/api/docker-stats',
   path: '/api/docker-stats',
@@ -161,6 +167,7 @@ export interface FileRoutesByFullPath {
   '/zfs': typeof ZfsRoute
   '/api/docker-inventory': typeof ApiDockerInventoryRoute
   '/api/docker-stats': typeof ApiDockerStatsRoute
+  '/api/health': typeof ApiHealthRoute
   '/api/proxmox-stats': typeof ApiProxmoxStatsRoute
   '/api/settings': typeof ApiSettingsRoute
   '/api/stack-status': typeof ApiStackStatusRoute
@@ -185,6 +192,7 @@ export interface FileRoutesByTo {
   '/zfs': typeof ZfsRoute
   '/api/docker-inventory': typeof ApiDockerInventoryRoute
   '/api/docker-stats': typeof ApiDockerStatsRoute
+  '/api/health': typeof ApiHealthRoute
   '/api/proxmox-stats': typeof ApiProxmoxStatsRoute
   '/api/settings': typeof ApiSettingsRoute
   '/api/stack-status': typeof ApiStackStatusRoute
@@ -211,6 +219,7 @@ export interface FileRoutesById {
   '/zfs': typeof ZfsRoute
   '/api/docker-inventory': typeof ApiDockerInventoryRoute
   '/api/docker-stats': typeof ApiDockerStatsRoute
+  '/api/health': typeof ApiHealthRoute
   '/api/proxmox-stats': typeof ApiProxmoxStatsRoute
   '/api/settings': typeof ApiSettingsRoute
   '/api/stack-status': typeof ApiStackStatusRoute
@@ -238,6 +247,7 @@ export interface FileRouteTypes {
     | '/zfs'
     | '/api/docker-inventory'
     | '/api/docker-stats'
+    | '/api/health'
     | '/api/proxmox-stats'
     | '/api/settings'
     | '/api/stack-status'
@@ -262,6 +272,7 @@ export interface FileRouteTypes {
     | '/zfs'
     | '/api/docker-inventory'
     | '/api/docker-stats'
+    | '/api/health'
     | '/api/proxmox-stats'
     | '/api/settings'
     | '/api/stack-status'
@@ -287,6 +298,7 @@ export interface FileRouteTypes {
     | '/zfs'
     | '/api/docker-inventory'
     | '/api/docker-stats'
+    | '/api/health'
     | '/api/proxmox-stats'
     | '/api/settings'
     | '/api/stack-status'
@@ -313,6 +325,7 @@ export interface RootRouteChildren {
   ZfsRoute: typeof ZfsRoute
   ApiDockerInventoryRoute: typeof ApiDockerInventoryRoute
   ApiDockerStatsRoute: typeof ApiDockerStatsRoute
+  ApiHealthRoute: typeof ApiHealthRoute
   ApiProxmoxStatsRoute: typeof ApiProxmoxStatsRoute
   ApiSettingsRoute: typeof ApiSettingsRoute
   ApiStackStatusRoute: typeof ApiStackStatusRoute
@@ -431,6 +444,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiProxmoxStatsRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/api/health': {
+      id: '/api/health'
+      path: '/api/health'
+      fullPath: '/api/health'
+      preLoaderRoute: typeof ApiHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/docker-stats': {
       id: '/api/docker-stats'
       path: '/api/docker-stats'
@@ -527,6 +547,7 @@ const rootRouteChildren: RootRouteChildren = {
   ZfsRoute: ZfsRoute,
   ApiDockerInventoryRoute: ApiDockerInventoryRoute,
   ApiDockerStatsRoute: ApiDockerStatsRoute,
+  ApiHealthRoute: ApiHealthRoute,
   ApiProxmoxStatsRoute: ApiProxmoxStatsRoute,
   ApiSettingsRoute: ApiSettingsRoute,
   ApiStackStatusRoute: ApiStackStatusRoute,

--- a/src/routes/api/git.$.ts
+++ b/src/routes/api/git.$.ts
@@ -146,10 +146,6 @@ export const Route = createFileRoute('/api/git/$')({
   server: {
     handlers: {
       GET: async ({ request }) => {
-        if (process.env.DOCKER_MANAGEMENT_FEATURE_FLAG !== 'true') {
-          return new Response('Not Found', { status: 404 });
-        }
-
         const authResult = await authenticateRequest(request);
         if (authResult instanceof Response) return authResult;
 
@@ -188,10 +184,6 @@ export const Route = createFileRoute('/api/git/$')({
       },
 
       POST: async ({ request }) => {
-        if (process.env.DOCKER_MANAGEMENT_FEATURE_FLAG !== 'true') {
-          return new Response('Not Found', { status: 404 });
-        }
-
         const authResult = await authenticateRequest(request);
         if (authResult instanceof Response) return authResult;
 

--- a/src/routes/api/health.ts
+++ b/src/routes/api/health.ts
@@ -1,0 +1,10 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { handleHealth } from '@/lib/health/health-handler';
+
+export const Route = createFileRoute('/api/health')({
+  server: {
+    handlers: {
+      GET: () => handleHealth(),
+    },
+  },
+});

--- a/src/worker/__tests__/collector-factory.test.ts
+++ b/src/worker/__tests__/collector-factory.test.ts
@@ -27,7 +27,6 @@ function getMockInfoCalls(): unknown[] {
 
 function createWorkerConfig(overrides?: Partial<WorkerConfig>): WorkerConfig {
   return {
-    enabled: true,
     docker: { enabled: false },
     zfs: { enabled: false },
     proxmox: { enabled: false },

--- a/src/worker/__tests__/host-collector-manager.test.ts
+++ b/src/worker/__tests__/host-collector-manager.test.ts
@@ -14,7 +14,6 @@ const originalConsoleLog = console.log;
 
 function makeWorkerConfig(overrides?: Partial<WorkerConfig>): WorkerConfig {
   const base: WorkerConfig = {
-    enabled: true,
     docker: { enabled: true },
     zfs: { enabled: true },
     proxmox: { enabled: false },

--- a/src/worker/collector.ts
+++ b/src/worker/collector.ts
@@ -45,11 +45,6 @@ async function main() {
     const dbConfig = loadDatabaseConfig();
     const workerConfig = loadWorkerConfig();
 
-    if (!workerConfig.enabled) {
-      console.info('[Worker] Worker disabled via WORKER_ENABLED=false, exiting');
-      process.exit(0);
-    }
-
     console.info('[Worker] Configuration loaded:', {
       database: `${dbConfig.host}:${dbConfig.port}/${dbConfig.database}`,
       docker: workerConfig.docker.enabled,

--- a/src/worker/collectors/__tests__/agent-stats-collector.test.ts
+++ b/src/worker/collectors/__tests__/agent-stats-collector.test.ts
@@ -32,7 +32,6 @@ function createMockDb() {
 }
 
 const defaultConfig = {
-  enabled: true,
   docker: { enabled: true },
   zfs: { enabled: false },
   proxmox: { enabled: false },

--- a/src/worker/collectors/__tests__/base-collector.test.ts
+++ b/src/worker/collectors/__tests__/base-collector.test.ts
@@ -17,8 +17,7 @@ function createMockDb() {
 
 function createMockConfig(overrides?: Partial<any>) {
   return {
-    enabled: true,
-    docker: { enabled: true },
+      docker: { enabled: true },
     zfs: { enabled: true },
     proxmox: { enabled: false },
     collection: { interval: 1000 },

--- a/src/worker/collectors/__tests__/proxmox-collector.test.ts
+++ b/src/worker/collectors/__tests__/proxmox-collector.test.ts
@@ -21,8 +21,7 @@ function createMockDb() {
 
 function createMockConfig(): WorkerConfig {
   return {
-    enabled: true,
-    docker: { enabled: false },
+      docker: { enabled: false },
     zfs: { enabled: false },
     proxmox: { enabled: true },
     collection: { interval: 1000 },

--- a/src/worker/collectors/__tests__/zfs-collector.test.ts
+++ b/src/worker/collectors/__tests__/zfs-collector.test.ts
@@ -26,7 +26,6 @@ function createMockDb() {
 }
 
 const defaultConfig = {
-  enabled: true,
   docker: { enabled: false },
   zfs: { enabled: true },
   proxmox: { enabled: false },


### PR DESCRIPTION
## Summary

A fleet review of the self-hosting documentation traced every claim against the code (38 raw findings, 23 confirmed after adversarial verification, 0 refuted). The headline: a user following `self-hosting/README.md` as written could not get a working deployment, because the compose file never forwarded the documented env vars into the containers. This PR fixes the wiring, removes dead configuration, adds a health endpoint, and rewrites the docs so every claim matches the code.

## Compose wiring fixes (`self-hosting/docker-compose.yml`)

The compose file forwards an explicit allowlist of env vars and had no `env_file:`, so documented `.env` keys silently never reached the containers:

- **Auth was unreachable**: `AUTH_DISABLED`, `OIDC_ISSUER_URL/CLIENT_ID/CLIENT_SECRET/REDIRECT_URI`, `SESSION_TTL_HOURS`, and `OIDC_ROLE_*` were never passed to the web container. With auth on by default, every fresh install dead-ended in a `/login?error=login_failed` loop with no escape hatch. Now forwarded via an `x-auth-env` anchor.
- `POSTGRES_SSL` was hardcoded to `"false"` in the shared anchor, so TLS to Postgres could never be enabled. Now `${POSTGRES_SSL:-false}`, plus `POSTGRES_SSL_REJECT_UNAUTHORIZED` forwarding.
- `WORKER_LOCALHOST_AGENT` (worker) and `DEPLOY_WATCHDOG_*` (web) were documented but not forwarded.
- Added a `healthcheck:` block for the web service against the new `/api/health` endpoint (via `bun -e fetch`, the image has no curl).

## Dead configuration removed

- **`DOCKER_MANAGEMENT_FEATURE_FLAG`**: the git routes (`src/routes/api/git.$.ts`) returned 404 unless this undocumented flag was set, so the documented stack-management flow never worked. The gate is removed; the flag no longer exists. `feature-flags.ts` stays for future flags.
- **`GIT_SERVER_TOKEN`**: documented as the git-push auth mechanism, but no code reads it. Real auth is per-user tokens generated in Settings (encrypted at rest, timing-safe compare, admin/operator role required), now documented in `docs/git-stacks-repo.md` and the self-hosting guide.
- **`WORKER_ENABLED`**: removed. The worker owns database migrations, so the documented `WORKER_ENABLED=false` option left a fresh install with no schema. The code default was also effectively `false` (exit-on-boot when unset); only the compose default made it appear to be `true`.

## New: `/api/health`

Unauthenticated `GET /api/health` on the web server checks DB reachability (200 ok / 503 degraded, 5s timeout). Handler in `src/lib/health/` with tests, following the thin-route/lib-handler pattern used by the auth routes. Used by the compose healthcheck and documented as the target for uptime monitors.

## Documentation rewrite (`self-hosting/README.md`)

- **Two-path Quick Start**: configure OIDC (Path A) or explicitly opt out with `AUTH_DISABLED=true` for trusted networks (Path B). The old Quick Start left auth on and unconfigured.
- **Pocket ID walkthrough** covering the real lockout pitfalls: the client's group access restriction (distinct from role-mapping groups), `OIDC_REDIRECT_URI` must point at the app's `/api/auth/callback` (not the provider), groups-claim-to-role mapping, and the fact that there is no bootstrap admin.
- Rewrote the stale "There is no built-in authentication" warning that contradicted the OIDC section.
- Documented the agent and agent-updater GHCR images, ZFS bind-mount requirements (`zpool`/`zfs` binaries + `/dev/zfs`), the `MASTER_KEY_FILE` volume-mount caveat, key rotation runnable from containers (`docker compose exec web bun run migrate-secrets`), backup/restore including what is unrecoverable if `MASTER_KEY` is lost, and SSE-specific reverse proxy requirements (buffering off, longer read timeouts, Secure cookie tied to https redirect URI).
- Fixed stale `stonith404/pocket-id` links (project moved to the `pocket-id` org) and removed the reference to a changelog that does not exist. Root README's roadmap now checks off the auth entry and links to the new docs.

## Testing

- `bun run typecheck:all` passes.
- New health-handler tests pass (5 tests). Targeted worker/config suites pass.
- `bun run test:all` shows 396 failures/15 errors both on this branch **and** on the clean base commit in this container (environment-dependent tests); this branch adds exactly the 5 new passing tests and changes no failure. Verify with CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SqhAUuqwmbAqTwPsUtYjng

---
_Generated by [Claude Code](https://claude.ai/code/session_01SqhAUuqwmbAqTwPsUtYjng)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an unauthenticated `/api/health` endpoint that reports database availability and degraded status when checks fail or time out.
  * Git operations now support per-user tokens created in Settings.

* **Documentation**
  * Expanded self-hosting guidance for OIDC, authentication, health monitoring, ZFS setup, credentials, backups, and deployment watchdogs.
  * Updated quick-start and development configuration examples.

* **Improvements**
  * Simplified worker configuration with separate Docker, ZFS, and Proxmox controls.
  * Removed obsolete server-wide Git token and generic worker-enable settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->