### PR TITLE
fix(sse): heartbeat broadcast streams to stop idle-timeout reconnect churn

### DIFF
--- a/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
@@ -93,6 +93,39 @@ describe('createBroadcastSseHandler', () => {
     reader.cancel();
   });
 
+  it('emits comment heartbeats on the interval to keep idle streams warm', async () => {
+    let heartbeatFn: (() => void) | null = null;
+    const intervalSpy = spyOn(globalThis, 'setInterval').mockImplementation(((fn: () => void) => {
+      heartbeatFn = fn;
+      return 123 as unknown as ReturnType<typeof setInterval>;
+    }) as typeof setInterval);
+    const clearSpy = spyOn(globalThis, 'clearInterval').mockImplementation(() => {});
+
+    try {
+      const { handler } = setup();
+      const ac = new AbortController();
+
+      const res = await handler({ request: makeRequest(ac) });
+      const reader = readerOf(res);
+      const decoder = new TextDecoder();
+      await reader.read(); // : ok
+
+      expect(heartbeatFn).not.toBeNull();
+      heartbeatFn!();
+      const frame = await reader.read();
+      expect(decoder.decode(frame.value)).toBe(':\n\n');
+
+      ac.abort();
+      // Aborting tears down the stream, which must stop the heartbeat timer.
+      expect(clearSpy).toHaveBeenCalledWith(123);
+
+      reader.cancel();
+    } finally {
+      intervalSpy.mockRestore();
+      clearSpy.mockRestore();
+    }
+  });
+
   it('uses the caller-provided serializer verbatim', async () => {
     const serialize = mock((e: Event) => `event: custom\ndata: ${e.n}\n\n`);
     const { handler, emit } = setup(serialize);

--- a/src/lib/sse/create-broadcast-sse-handler.ts
+++ b/src/lib/sse/create-broadcast-sse-handler.ts
@@ -11,6 +11,16 @@
  */
 type Unsubscribe = () => void;
 
+// These streams only emit when their broadcast source changes (a settings write,
+// a container state change), so a quiet homelab leaves them silent well past the
+// idle timeout of the runtime (Bun's HTTP default is 10s) and any reverse proxy.
+// Without traffic the socket is dropped, the browser's EventSource reconnects,
+// and the churn of short-lived streams trips Caddy's (Go net/http2) rapid-reset
+// protection, which GOAWAYs the whole HTTP/2 connection: every multiplexed
+// request dies at once. A comment heartbeat keeps the stream warm. 5s stays
+// under typical Bun/proxy idle defaults; mirrors the agent's logs route.
+const HEARTBEAT_INTERVAL_MS = 5_000;
+
 export interface BroadcastSseHandlerOptions<Event> {
   /**
    * Called once per request. Responsible for any dynamic imports of
@@ -53,10 +63,15 @@ export function createBroadcastSseHandler<Event>(
         controller.enqueue(encoder.encode(': ok\n\n'));
 
         let unsubscribe: Unsubscribe = () => {};
+        let heartbeat: ReturnType<typeof setInterval> | null = null;
 
         const teardown = () => {
           if (closed) return;
           closed = true;
+          if (heartbeat !== null) {
+            clearInterval(heartbeat);
+            heartbeat = null;
+          }
           unsubscribe();
           try {
             controller.close();
@@ -99,6 +114,22 @@ export function createBroadcastSseHandler<Event>(
         }
 
         unsubscribe = subscribe(sendEvent);
+
+        heartbeat = setInterval(() => {
+          if (closed) {
+            clearInterval(heartbeat!);
+            heartbeat = null;
+            return;
+          }
+          try {
+            controller.enqueue(encoder.encode(':\n\n'));
+          } catch (err) {
+            if (!isCloseRelatedError(err)) {
+              console.error('Unexpected error during SSE heartbeat:', err);
+            }
+            teardown();
+          }
+        }, HEARTBEAT_INTERVAL_MS);
 
         request.signal.addEventListener('abort', teardown);
         // If the client disconnected during the awaits above, the abort event


### PR DESCRIPTION
## Summary

Adds a 5s comment heartbeat to the browser-facing broadcast SSE factory (`src/lib/sse/create-broadcast-sse-handler.ts`), which serves `/api/settings`, `/api/docker-inventory`, and `/api/stack-status`. This is the web-layer counterpart to the agent-side heartbeat merged in #322.

## Background

Diagnosed from a browser HAR export plus live-session data on a deployment behind Caddy. The tab became sluggish and eventually stopped loading anything after a while, with every request (down to a 4 KB favicon) failing with `ERR_HTTP2_PROTOCOL_ERROR`.

Root cause chain:

1. The broadcast streams only emit when their source changes (a settings write, a container state change). On a quiet homelab they stay silent past the runtime and reverse-proxy idle timeouts (Bun's HTTP default is 10s). The HAR showed `/api/settings` reconnecting on an ~11s cycle.
2. Each idle drop makes the browser's `EventSource` reconnect, producing a steady churn of short-lived HTTP/2 streams on the single multiplexed connection.
3. Caddy (Go `net/http2`) has rapid-reset protection (post CVE-2023-44487). The accumulating aborted streams eventually trip it, and it sends `GOAWAY` and tears down the whole connection. Because every request is multiplexed on that one connection, they all die at once, which presents as "nothing loads."

The stats streams (`/api/docker-stats` etc.) were unaffected because they push data every ~1s and never go idle. Only the change-driven broadcast streams needed the heartbeat.

## Change

- Start a 5s `:\n\n` comment heartbeat once the subscription is established, cleared in `teardown` alongside the existing abort and enqueue-failure paths. Mirrors the pattern already used in the agent logs route and the container-inventory fix (#322).
- Add a test asserting the heartbeat frame is emitted on the interval and the timer is cleared on abort.

## Testing

- `bun run typecheck:all`: clean.
- SSE handler suite: 11/11 pass (including the new heartbeat test).
- Full suite failure count is unchanged versus `main` in this environment (pre-existing, environment-dependent failures unrelated to this change; the affected files pass in isolation).

## Notes for deployers (Caddy)

App-side this is sufficient, but as defense in depth: set `flush_interval -1` on the `reverse_proxy`, and ensure any `encode` directive does not compress `text/event-stream`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ksd1cZa8erB1McyUusH4RJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ksd1cZa8erB1McyUusH4RJ)_