### PR TITLE
refactor(stacks): one stack-repo-layout module owning the repo layout

### DIFF
--- a/src/lib/deploy/__tests__/stack-repo-writer.test.ts
+++ b/src/lib/deploy/__tests__/stack-repo-writer.test.ts
@@ -20,10 +20,6 @@ async function seedRepo(repoPath: string, files: Array<{ path: string; content: 
   }));
 }
 
-// Behavior of the underlying remove-stack-from-manifest sequence (idempotency,
-// deleting stack files, missing-manifest errors) is covered once in
-// stack-repo-layout.test.ts. These tests only confirm the StackRepoWriter port
-// wires that shared implementation to the configured repo.
 describe('createStackRepoWriter', () => {
   let testDir: string;
   let repoPath: string;

--- a/src/lib/deploy/__tests__/stack-repo-writer.test.ts
+++ b/src/lib/deploy/__tests__/stack-repo-writer.test.ts
@@ -4,16 +4,7 @@ import { join } from 'path';
 import { getTestTmpDir } from '@/lib/test/tmp-dir';
 import { initBareRepo, commitFiles } from '@/lib/git/repo';
 import * as gitConfig from '@/lib/config/git-config';
-import { createStackRepoWriter } from '../stack-repo-writer';
-
-const MANIFEST_WITH_PLEX_AND_TRAEFIK = `stacks:
-  plex:
-    autoDeploy: true
-    host: homeserver
-  traefik:
-    autoDeploy: false
-    host: homeserver
-`;
+import { createStackRepoWriter } from '@/lib/deploy/stack-repo-writer';
 
 const MANIFEST_WITH_PLEX = `stacks:
   plex:
@@ -29,6 +20,10 @@ async function seedRepo(repoPath: string, files: Array<{ path: string; content: 
   }));
 }
 
+// Behavior of the underlying remove-stack-from-manifest sequence (idempotency,
+// deleting stack files, missing-manifest errors) is covered once in
+// stack-repo-layout.test.ts. These tests only confirm the StackRepoWriter port
+// wires that shared implementation to the configured repo.
 describe('createStackRepoWriter', () => {
   let testDir: string;
   let repoPath: string;
@@ -51,9 +46,9 @@ describe('createStackRepoWriter', () => {
     rmSync(testDir, { recursive: true, force: true });
   });
 
-  it('removes the stack from the manifest and returns a commit SHA', async () => {
+  it('removes the stack from the manifest at the configured repo and returns a commit SHA', async () => {
     await seedRepo(repoPath, [
-      { path: 'manifest.yaml', content: MANIFEST_WITH_PLEX_AND_TRAEFIK },
+      { path: 'manifest.yaml', content: MANIFEST_WITH_PLEX },
       { path: 'plex/docker-compose.yml', content: 'services:\n  plex: {}' },
     ]);
 
@@ -62,45 +57,10 @@ describe('createStackRepoWriter', () => {
 
     expect(typeof result.commitSha).toBe('string');
     expect(result.commitSha.length).toBeGreaterThan(0);
+    expect(loadGitConfigSpy).toHaveBeenCalled();
   });
 
-  it('removes the stack entry and its files from the repo', async () => {
-    await seedRepo(repoPath, [
-      { path: 'manifest.yaml', content: MANIFEST_WITH_PLEX_AND_TRAEFIK },
-      { path: 'plex/docker-compose.yml', content: 'services:\n  plex: {}' },
-      { path: 'plex/.env', content: 'FOO=bar' },
-    ]);
-
-    const writer = createStackRepoWriter();
-    await writer.removeStackFromManifest('plex');
-
-    // Read the updated manifest from the repo via a subsequent commit callback
-    let updatedManifest = '';
-    await commitFiles(repoPath, (existingFiles) => {
-      updatedManifest = existingFiles.get('manifest.yaml') ?? '';
-      const plexCompose = existingFiles.get('plex/docker-compose.yml');
-      expect(plexCompose).toBeUndefined();
-      // Return null to skip an actual commit
-      return null;
-    });
-
-    expect(updatedManifest).not.toContain('plex:');
-    expect(updatedManifest).toContain('traefik:');
-  });
-
-  it('is idempotent when the stack is already absent from the manifest', async () => {
-    await seedRepo(repoPath, [
-      { path: 'manifest.yaml', content: MANIFEST_WITH_PLEX },
-    ]);
-
-    const writer = createStackRepoWriter();
-    // Remove a stack that is not in the manifest: should not throw
-    const result = await writer.removeStackFromManifest('traefik');
-
-    expect(typeof result.commitSha).toBe('string');
-  });
-
-  it('throws when manifest.yaml is missing from the repo', async () => {
+  it('propagates the underlying error when the manifest is missing', async () => {
     await seedRepo(repoPath, [
       { path: 'plex/docker-compose.yml', content: 'services:\n  plex: {}' },
     ]);

--- a/src/lib/deploy/stack-repo-writer.ts
+++ b/src/lib/deploy/stack-repo-writer.ts
@@ -1,11 +1,7 @@
-import yaml from 'js-yaml';
 import type { StackRepoWriter } from '@/lib/deploy/pipeline';
 import { loadGitConfig } from '@/lib/config/git-config';
 import { commitFiles } from '@/lib/git/repo';
-import { parseManifest } from '@/lib/git/manifest';
-
-const MANIFEST_FILENAME = 'manifest.yaml';
-const SYSTEM_AUTHOR = { name: 'homelab-manager', email: 'homelab-manager@localhost' };
+import { removeStackFromManifest as buildRemoveStackFromManifestPlan } from '@/lib/stacks/stack-repo-layout';
 
 /**
  * Create a StackRepoWriter backed by the configured git repo.
@@ -16,39 +12,7 @@ export function createStackRepoWriter(): StackRepoWriter {
   return {
     async removeStackFromManifest(stackName: string): Promise<{ commitSha: string }> {
       const { repoPath } = loadGitConfig();
-      const commitSha = await commitFiles(repoPath, (existingFiles) => {
-        const manifestContent = existingFiles.get(MANIFEST_FILENAME);
-        if (manifestContent === undefined) {
-          throw new Error(`manifest.yaml not found in repo "${repoPath}"`);
-        }
-        const manifest = parseManifest(manifestContent);
-
-        // Idempotent: if the stack is already gone from the manifest, just
-        // remove any lingering stack files.
-        if (manifest.stacks[stackName]) {
-          delete manifest.stacks[stackName];
-        }
-
-        const newManifestContent = yaml.dump(manifest, {
-          indent: 2,
-          lineWidth: -1,
-          noRefs: true,
-          sortKeys: true,
-        });
-
-        const stackDirPrefix = `${stackName}/`;
-        const stackFiles = Array.from(existingFiles.keys()).filter((p) =>
-          p.startsWith(stackDirPrefix),
-        );
-
-        return {
-          files: [{ path: MANIFEST_FILENAME, content: newManifestContent }],
-          filesToDelete: stackFiles,
-          message: `Remove stack: ${stackName}`,
-          author: SYSTEM_AUTHOR,
-        };
-      });
-
+      const commitSha = await commitFiles(repoPath, buildRemoveStackFromManifestPlan(stackName));
       return { commitSha };
     },
   };

--- a/src/lib/git/editor-operations.ts
+++ b/src/lib/git/editor-operations.ts
@@ -1,6 +1,6 @@
-import yaml from 'js-yaml';
 import { commitFiles, FileNotFoundError } from '@/lib/git/repo';
 import { parseManifest } from '@/lib/git/manifest';
+import { MANIFEST, serializeManifest } from '@/lib/stacks/stack-repo-layout';
 
 interface SaveFileOptions {
   filePath: string;
@@ -38,16 +38,16 @@ interface UpdateManifestOptions {
 }
 
 /**
- * Add or update a stack entry in manifest.yaml and commit.
+ * Add or update a stack entry in the manifest and commit.
  */
 export async function updateManifest(
   repoPath: string,
   options: UpdateManifestOptions,
 ): Promise<SaveResult> {
   const commitSha = await commitFiles(repoPath, (existingFiles) => {
-    const manifestContent = existingFiles.get('manifest.yaml');
+    const manifestContent = existingFiles.get(MANIFEST);
     if (manifestContent === undefined) {
-      throw new FileNotFoundError('manifest.yaml');
+      throw new FileNotFoundError(MANIFEST);
     }
     const manifest = parseManifest(manifestContent);
 
@@ -56,15 +56,8 @@ export async function updateManifest(
       autoDeploy: options.autoDeploy,
     };
 
-    const newContent = yaml.dump(manifest, {
-      indent: 2,
-      lineWidth: -1,
-      noRefs: true,
-      sortKeys: true,
-    });
-
     return {
-      files: [{ path: 'manifest.yaml', content: newContent }],
+      files: [{ path: MANIFEST, content: serializeManifest(manifest) }],
       message: `Update manifest: ${options.stackName} on ${options.host}`,
       author: options.author,
     };

--- a/src/lib/git/init-repo.ts
+++ b/src/lib/git/init-repo.ts
@@ -2,6 +2,7 @@ import git from 'isomorphic-git';
 import fs from 'node:fs';
 import { loadGitConfig } from '@/lib/config/git-config';
 import { initBareRepo, commitFiles } from '@/lib/git/repo';
+import { MANIFEST } from '@/lib/stacks/stack-repo-layout';
 
 const DEFAULT_MANIFEST = `stacks: {}
 `;
@@ -21,7 +22,7 @@ export async function ensureRepoInitialized(): Promise<void> {
   await commitFiles(repoPath, (existingFiles) => {
     if (existingFiles.size > 0) return null; // another writer initialized first
     return {
-      files: [{ path: 'manifest.yaml', content: DEFAULT_MANIFEST }],
+      files: [{ path: MANIFEST, content: DEFAULT_MANIFEST }],
       message: 'Initialize stacks repository',
       author: {
         name: 'homelab-manager',

--- a/src/lib/git/manifest.ts
+++ b/src/lib/git/manifest.ts
@@ -14,7 +14,9 @@ export type StackEntry = z.infer<typeof StackEntrySchema>;
 export type StackManifest = z.infer<typeof ManifestSchema>;
 
 /**
- * Parse and validate a manifest.yaml string.
+ * Parse and validate a raw stack manifest YAML string. The manifest's filename
+ * and serialization are owned by stack-repo-layout.ts; this module only knows
+ * the schema.
  *
  * @param content - Raw YAML string
  * @returns Validated StackManifest

--- a/src/lib/git/post-receive-handler.ts
+++ b/src/lib/git/post-receive-handler.ts
@@ -1,6 +1,7 @@
 import { buildDeployRequests } from '@/lib/git/post-receive';
 import { readFileFromRepo } from '@/lib/git/repo';
 import { parseManifest } from '@/lib/git/manifest';
+import { MANIFEST } from '@/lib/stacks/stack-repo-layout';
 import { GitTriggerBuilder } from '@/lib/deploy/builders/git-trigger-builder';
 import type { DeployRepository } from '@/lib/database/repositories/deploy-repository';
 
@@ -9,9 +10,9 @@ import type { DeployRepository } from '@/lib/database/repositories/deploy-reposi
  * Diffs the old and new HEAD, builds deploy requests, and dispatches them
  * to the deploy pipeline.
  *
- * @throws {Error} If manifest.yaml is missing from the repo
- * @throws {YAMLException} If manifest.yaml has invalid YAML syntax
- * @throws {ZodError} If manifest.yaml structure doesn't match schema
+ * @throws {Error} If the manifest is missing from the repo
+ * @throws {YAMLException} If the manifest has invalid YAML syntax
+ * @throws {ZodError} If the manifest structure doesn't match schema
  */
 export async function processPostReceive(
   repoPath: string,
@@ -26,7 +27,7 @@ export async function processPostReceive(
   }
 
   // Read the manifest at newHead to get the authoritative stack config
-  const manifestContent = await readFileFromRepo(repoPath, 'manifest.yaml', newHead);
+  const manifestContent = await readFileFromRepo(repoPath, MANIFEST, newHead);
   const manifest = parseManifest(manifestContent);
 
   // Build a map of stackName -> composeContent for changed stacks.

--- a/src/lib/git/post-receive.ts
+++ b/src/lib/git/post-receive.ts
@@ -1,5 +1,6 @@
 import { diffCommits, readFileFromRepo } from '@/lib/git/repo';
 import { parseManifest } from '@/lib/git/manifest';
+import { MANIFEST, composePath } from '@/lib/stacks/stack-repo-layout';
 
 export interface DeployRequest {
   stack: string;
@@ -44,7 +45,7 @@ export async function buildDeployRequests(
     return [];
   }
 
-  const manifestContent = await readFileFromRepo(repoPath, 'manifest.yaml', toOid);
+  const manifestContent = await readFileFromRepo(repoPath, MANIFEST, toOid);
   const manifest = parseManifest(manifestContent);
 
   const requests: DeployRequest[] = [];
@@ -59,7 +60,7 @@ export async function buildDeployRequests(
     requests.push({
       stack: stackName,
       host: stackConfig.host,
-      composePath: `${stackName}/docker-compose.yml`,
+      composePath: composePath(stackName),
       commitSha: toOid,
       secrets: {},
       action: 'deploy',

--- a/src/lib/server-init.ts
+++ b/src/lib/server-init.ts
@@ -17,6 +17,7 @@ async function startDeployRecovery(): Promise<void> {
   const { loadGitConfig } = await import('@/lib/config/git-config');
   const { readFileFromRepo } = await import('@/lib/git/repo');
   const { parseManifest } = await import('@/lib/git/manifest');
+  const { MANIFEST } = await import('@/lib/stacks/stack-repo-layout');
 
   const dbClient = await dbm.getClient(loadDatabaseConfig());
   const repo = new DeployRepository(dbClient.getPool());
@@ -25,7 +26,7 @@ async function startDeployRecovery(): Promise<void> {
     async listStackNames(): Promise<Set<string>> {
       try {
         const { repoPath } = loadGitConfig();
-        const content = await readFileFromRepo(repoPath, 'manifest.yaml');
+        const content = await readFileFromRepo(repoPath, MANIFEST);
         return new Set(Object.keys(parseManifest(content).stacks));
       } catch {
         // No repo, no manifest, nothing to orphan-sweep against.

--- a/src/lib/stacks/__tests__/stack-repo-layout.test.ts
+++ b/src/lib/stacks/__tests__/stack-repo-layout.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { getTestTmpDir } from '@/lib/test/tmp-dir';
+import { initBareRepo, commitFiles } from '@/lib/git/repo';
+import {
+  MANIFEST,
+  composePath,
+  stackFiles,
+  serializeManifest,
+  removeStackFromManifest,
+} from '@/lib/stacks/stack-repo-layout';
+
+const MANIFEST_WITH_PLEX_AND_TRAEFIK = `stacks:
+  plex:
+    autoDeploy: true
+    host: homeserver
+  traefik:
+    autoDeploy: false
+    host: homeserver
+`;
+
+const MANIFEST_WITH_PLEX = `stacks:
+  plex:
+    autoDeploy: true
+    host: homeserver
+`;
+
+async function seedRepo(repoPath: string, files: Array<{ path: string; content: string }>): Promise<string> {
+  return commitFiles(repoPath, () => ({
+    files,
+    message: 'initial',
+    author: { name: 'test', email: 'test@test.com' },
+  }));
+}
+
+describe('composePath', () => {
+  it('builds the compose file path for a stack', () => {
+    expect(composePath('plex')).toBe('plex/docker-compose.yml');
+  });
+});
+
+describe('stackFiles', () => {
+  it('returns only paths under the stack directory', () => {
+    const paths = ['plex/docker-compose.yml', 'plex/.env', 'traefik/docker-compose.yml', MANIFEST];
+    expect(stackFiles(paths, 'plex')).toEqual(['plex/docker-compose.yml', 'plex/.env']);
+  });
+
+  it('returns an empty array when the stack has no files', () => {
+    expect(stackFiles(['traefik/docker-compose.yml', MANIFEST], 'plex')).toEqual([]);
+  });
+
+  it('does not match a stack name that is a prefix of another stack name', () => {
+    // "plex" must not match files under "plex-backup/", only "plex/".
+    expect(stackFiles(['plex-backup/docker-compose.yml'], 'plex')).toEqual([]);
+  });
+});
+
+describe('serializeManifest', () => {
+  it('sorts keys and produces stable YAML', () => {
+    const yamlContent = serializeManifest({
+      stacks: {
+        traefik: { host: 'homeserver', autoDeploy: false },
+        plex: { host: 'homeserver', autoDeploy: true },
+      },
+    });
+
+    expect(yamlContent).toBe(MANIFEST_WITH_PLEX_AND_TRAEFIK);
+  });
+});
+
+describe('removeStackFromManifest', () => {
+  let testDir: string;
+  let repoPath: string;
+
+  beforeEach(async () => {
+    testDir = mkdtempSync(join(getTestTmpDir(), 'stack-repo-layout-'));
+    repoPath = join(testDir, 'stacks.git');
+    await initBareRepo(repoPath);
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('removes the stack from the manifest and returns a commit SHA', async () => {
+    await seedRepo(repoPath, [
+      { path: MANIFEST, content: MANIFEST_WITH_PLEX_AND_TRAEFIK },
+      { path: 'plex/docker-compose.yml', content: 'services:\n  plex: {}' },
+    ]);
+
+    const commitSha = await commitFiles(repoPath, removeStackFromManifest('plex'));
+
+    expect(typeof commitSha).toBe('string');
+    expect(commitSha.length).toBeGreaterThan(0);
+  });
+
+  it('removes the stack entry and its files from the repo', async () => {
+    await seedRepo(repoPath, [
+      { path: MANIFEST, content: MANIFEST_WITH_PLEX_AND_TRAEFIK },
+      { path: 'plex/docker-compose.yml', content: 'services:\n  plex: {}' },
+      { path: 'plex/.env', content: 'FOO=bar' },
+    ]);
+
+    await commitFiles(repoPath, removeStackFromManifest('plex'));
+
+    // Read the updated manifest from the repo via a subsequent commit callback.
+    let updatedManifest = '';
+    await commitFiles(repoPath, (existingFiles) => {
+      updatedManifest = existingFiles.get(MANIFEST) ?? '';
+      expect(existingFiles.get('plex/docker-compose.yml')).toBeUndefined();
+      expect(existingFiles.get('plex/.env')).toBeUndefined();
+      // Return null to skip an actual commit.
+      return null;
+    });
+
+    expect(updatedManifest).not.toContain('plex:');
+    expect(updatedManifest).toContain('traefik:');
+  });
+
+  it('is idempotent when the stack is already absent from the manifest', async () => {
+    await seedRepo(repoPath, [{ path: MANIFEST, content: MANIFEST_WITH_PLEX }]);
+
+    // Remove a stack that is not in the manifest: should not throw.
+    const commitSha = await commitFiles(repoPath, removeStackFromManifest('traefik'));
+
+    expect(typeof commitSha).toBe('string');
+  });
+
+  it('throws when the manifest is missing from the repo', async () => {
+    await seedRepo(repoPath, [
+      { path: 'plex/docker-compose.yml', content: 'services:\n  plex: {}' },
+    ]);
+
+    await expect(commitFiles(repoPath, removeStackFromManifest('plex'))).rejects.toThrow(
+      'manifest.yaml not found',
+    );
+  });
+});

--- a/src/lib/stacks/stack-repo-layout.ts
+++ b/src/lib/stacks/stack-repo-layout.ts
@@ -1,0 +1,81 @@
+/**
+ * Owns the stack git-repo layout: where a stack's compose file lives, what the
+ * manifest is called, which files belong to a stack, how the manifest is
+ * serialized, and the single implementation of "remove a stack from the
+ * manifest and delete its files". A layout change (renaming the compose file,
+ * moving to nested dirs) should only ever require editing this file.
+ */
+import yaml from 'js-yaml';
+import type { CommitCallback } from '@/lib/git/repo';
+import { parseManifest, type StackManifest } from '@/lib/git/manifest';
+
+/** Manifest filename at the repo root. */
+export const MANIFEST = 'manifest.yaml';
+
+const COMPOSE_FILENAME = 'docker-compose.yml';
+
+const SYSTEM_AUTHOR = { name: 'homelab-manager', email: 'homelab-manager@localhost' };
+
+/** Path to a stack's compose file, relative to the repo root. */
+export function composePath(stackName: string): string {
+  return `${stackName}/${COMPOSE_FILENAME}`;
+}
+
+/** Directory prefix (with trailing slash) that contains all of a stack's files. */
+function stackDirPrefix(stackName: string): string {
+  return `${stackName}/`;
+}
+
+/** Filter a set of repo paths down to the ones that belong to a stack, for deletion. */
+export function stackFiles(existingPaths: Iterable<string>, stackName: string): string[] {
+  const prefix = stackDirPrefix(stackName);
+  return Array.from(existingPaths).filter((path) => path.startsWith(prefix));
+}
+
+/**
+ * The one yaml.dump call for manifest serialization. Sorted keys keep the diff
+ * of a single-stack change to a single line instead of reordering the whole file.
+ */
+export function serializeManifest(manifest: StackManifest): string {
+  return yaml.dump(manifest, {
+    indent: 2,
+    lineWidth: -1,
+    noRefs: true,
+    sortKeys: true,
+  });
+}
+
+/**
+ * Build the commitFiles plan that removes a stack from the manifest and deletes
+ * its files. Returns a {@link CommitCallback}, ready to pass to `commitFiles`.
+ *
+ * Idempotent: if the stack is already absent from the manifest, only lingering
+ * files (if any) are swept, so callers can retry or race safely. This is what
+ * lets the orphaned-manifest-delete sweep in startup-recovery.ts call it
+ * unconditionally for stacks it merely suspects were left behind.
+ *
+ * Used by both the synchronous "unmanage" delete path (stack-service.ts, via
+ * createStackRepoWriter) and the async teardown-then-remove path
+ * (stack-repo-writer.ts's StackRepoWriter port, consumed by DeployPipeline and
+ * by the startup-recovery orphan sweep).
+ */
+export function removeStackFromManifest(stackName: string): CommitCallback {
+  return (existingFiles) => {
+    const manifestContent = existingFiles.get(MANIFEST);
+    if (manifestContent === undefined) {
+      throw new Error(`${MANIFEST} not found in repo`);
+    }
+    const manifest = parseManifest(manifestContent);
+
+    if (manifest.stacks[stackName]) {
+      delete manifest.stacks[stackName];
+    }
+
+    return {
+      files: [{ path: MANIFEST, content: serializeManifest(manifest) }],
+      filesToDelete: stackFiles(existingFiles.keys(), stackName),
+      message: `Remove stack: ${stackName}`,
+      author: SYSTEM_AUTHOR,
+    };
+  };
+}

--- a/src/lib/stacks/stack-service.ts
+++ b/src/lib/stacks/stack-service.ts
@@ -10,7 +10,8 @@ import { loadGitConfig } from '@/lib/config/git-config';
 import { readFileFromRepo, commitFiles, FileNotFoundError } from '@/lib/git/repo';
 import { parseManifest } from '@/lib/git/manifest';
 import { saveAndCommitFile } from '@/lib/git/editor-operations';
-import yaml from 'js-yaml';
+import { MANIFEST, composePath, serializeManifest } from '@/lib/stacks/stack-repo-layout';
+import { createStackRepoWriter } from '@/lib/deploy/stack-repo-writer';
 import {
   manifestEntryToSummary,
   manifestEntryToDetail,
@@ -27,8 +28,6 @@ export const SAFE_PATH_SEGMENT_PATTERN = /^[a-zA-Z0-9_-]+$/;
 export { resolveDeleteStack } from '@/lib/stacks/delete-stack-resolver';
 export type { DeleteStackDeps, DeleteStackResult } from '@/lib/stacks/delete-stack-resolver';
 
-const COMPOSE_FILENAME = 'docker-compose.yml';
-const MANIFEST_FILENAME = 'manifest.yaml';
 const SYSTEM_AUTHOR = { name: 'homelab-manager', email: 'homelab-manager@localhost' };
 
 function getRepoPath(): string {
@@ -41,7 +40,7 @@ export async function getStackSummaries(): Promise<StackSummary[]> {
 
   let manifestContent: string;
   try {
-    manifestContent = await readFileFromRepo(repoPath, MANIFEST_FILENAME);
+    manifestContent = await readFileFromRepo(repoPath, MANIFEST);
   } catch {
     return [];
   }
@@ -88,14 +87,14 @@ export async function getStackDetailByName(
 ): Promise<StackDetail | null> {
   try {
     const repoPath = getRepoPath();
-    const manifestContent = await readFileFromRepo(repoPath, MANIFEST_FILENAME);
+    const manifestContent = await readFileFromRepo(repoPath, MANIFEST);
     const manifest = parseManifest(manifestContent);
     const entry = manifest.stacks[stackName];
     if (!entry) return null;
 
     let composeContent = '';
     try {
-      composeContent = await readFileFromRepo(repoPath, `${stackName}/${COMPOSE_FILENAME}`);
+      composeContent = await readFileFromRepo(repoPath, composePath(stackName));
     } catch (err) {
       if (!(err instanceof FileNotFoundError)) {
         console.error(`[StackService] Unexpected error reading compose file for "${stackName}":`, err);
@@ -134,7 +133,7 @@ export async function triggerStackDeploy(params: {
     const rollbackSha = params.commitSha;
     return handleTriggerDeploy({
       readCompose: (stack) =>
-        readFileFromRepo(repoPath, `${stack}/${COMPOSE_FILENAME}`, rollbackSha),
+        readFileFromRepo(repoPath, composePath(stack), rollbackSha),
       getCommitSha: () => Promise.resolve(rollbackSha),
       buildRequest: (input) =>
         builder.buildRollback({
@@ -148,7 +147,7 @@ export async function triggerStackDeploy(params: {
   }
 
   return handleTriggerDeploy({
-    readCompose: (stack) => readFileFromRepo(repoPath, `${stack}/${COMPOSE_FILENAME}`),
+    readCompose: (stack) => readFileFromRepo(repoPath, composePath(stack)),
     getCommitSha: () => git.resolveRef({ fs, gitdir: repoPath, ref: 'HEAD' }),
     buildRequest: (input) => {
       const req = builder.build(input);
@@ -252,7 +251,7 @@ async function buildRequestFromDeployRecord(
     try {
       composeContent = await readFileFromRepo(
         repoPath,
-        `${deploy.stack}/${COMPOSE_FILENAME}`,
+        composePath(deploy.stack),
         deploy.commitSha,
       );
     } catch (err) {
@@ -278,7 +277,7 @@ export async function getStackDeployHistory(
   const repoPath = getRepoPath();
   if (!repoPath) return [];
 
-  const manifestContent = await readFileFromRepo(repoPath, MANIFEST_FILENAME);
+  const manifestContent = await readFileFromRepo(repoPath, MANIFEST);
   const manifest = parseManifest(manifestContent);
   const entry = manifest.stacks[stackName];
   if (!entry) return [];
@@ -302,10 +301,10 @@ export async function saveStackComposeFile(
   const repoPath = getRepoPath();
 
   return saveAndCommitFile(repoPath, {
-    filePath: `${stackName}/${COMPOSE_FILENAME}`,
+    filePath: composePath(stackName),
     content,
     author: SYSTEM_AUTHOR,
-    message: `Update ${stackName}/${COMPOSE_FILENAME}`,
+    message: `Update ${composePath(stackName)}`,
   });
 }
 
@@ -332,7 +331,7 @@ export async function createStackInRepo(
   if (!managedHost) throw new Error(`Host "${host}" not found in managed_hosts`);
 
   const commitSha = await commitFiles(repoPath, (existingFiles) => {
-    const manifestContent = existingFiles.get(MANIFEST_FILENAME);
+    const manifestContent = existingFiles.get(MANIFEST);
     const manifest = manifestContent ? parseManifest(manifestContent) : { stacks: {} };
 
     if (manifest.stacks[stackName]) {
@@ -340,17 +339,11 @@ export async function createStackInRepo(
     }
 
     manifest.stacks[stackName] = { host, autoDeploy };
-    const newManifestContent = yaml.dump(manifest, {
-      indent: 2,
-      lineWidth: -1,
-      noRefs: true,
-      sortKeys: true,
-    });
 
     return {
       files: [
-        { path: `${stackName}/${COMPOSE_FILENAME}`, content: '' },
-        { path: MANIFEST_FILENAME, content: newManifestContent },
+        { path: composePath(stackName), content: '' },
+        { path: MANIFEST, content: serializeManifest(manifest) },
       ],
       message: `Add stack: ${stackName} on ${host}`,
       author: SYSTEM_AUTHOR,
@@ -366,7 +359,7 @@ export async function deleteStackFromRepo(
 ): Promise<DeleteStackResult> {
   const repoPath = getRepoPath();
 
-  const manifestContent = await readFileFromRepo(repoPath, MANIFEST_FILENAME);
+  const manifestContent = await readFileFromRepo(repoPath, MANIFEST);
   const manifest = parseManifest(manifestContent);
   const entry = manifest.stacks[stackName];
   if (!entry) throw new Error(`Stack "${stackName}" not found in manifest`);
@@ -390,45 +383,10 @@ export async function deleteStackFromRepo(
 
   return resolveDeleteStack(stackName, host, teardown, {
     triggerDeploy: (params) => triggerStackDeploy(params),
-    commitRemoveFromManifest: (sn) => commitRemoveStackFromManifest(repoPath, sn),
+    // Same implementation the async teardown path uses (stack-repo-writer.ts):
+    // one remove-stack-from-manifest sequence for both delete paths.
+    commitRemoveFromManifest: (sn) => createStackRepoWriter().removeStackFromManifest(sn),
   });
-}
-
-async function commitRemoveStackFromManifest(
-  repoPath: string,
-  stackName: string,
-): Promise<{ commitSha: string }> {
-  const commitSha = await commitFiles(repoPath, (existingFiles) => {
-    const freshManifestContent = existingFiles.get(MANIFEST_FILENAME);
-    if (freshManifestContent === undefined) {
-      throw new Error(`Stack "${stackName}" not found in manifest`);
-    }
-    const manifest = parseManifest(freshManifestContent);
-
-    if (!manifest.stacks[stackName]) {
-      throw new Error(`Stack "${stackName}" not found in manifest`);
-    }
-
-    delete manifest.stacks[stackName];
-    const newManifestContent = yaml.dump(manifest, {
-      indent: 2,
-      lineWidth: -1,
-      noRefs: true,
-      sortKeys: true,
-    });
-
-    const stackDirPrefix = `${stackName}/`;
-    const stackFiles = Array.from(existingFiles.keys()).filter((p) => p.startsWith(stackDirPrefix));
-
-    return {
-      files: [{ path: MANIFEST_FILENAME, content: newManifestContent }],
-      filesToDelete: stackFiles,
-      message: `Remove stack: ${stackName}`,
-      author: SYSTEM_AUTHOR,
-    };
-  });
-
-  return { commitSha };
 }
 
 export async function getManagedHostNames(): Promise<string[]> {
@@ -450,7 +408,7 @@ export async function updateStackIconSlug(
   const repoPath = getRepoPath();
   if (!repoPath) return;
 
-  const manifestContent = await readFileFromRepo(repoPath, MANIFEST_FILENAME);
+  const manifestContent = await readFileFromRepo(repoPath, MANIFEST);
   const manifest = parseManifest(manifestContent);
   const entry = manifest.stacks[stackName];
   if (!entry) return;


### PR DESCRIPTION
## What changed

New module `src/lib/stacks/stack-repo-layout.ts` owns the stack git-repo layout that was previously re-derived as string literals across ~8 files: the manifest filename (`MANIFEST`), `composePath(stackName)`, `stackFiles(existingPaths, stackName)`, `serializeManifest` (the single canonical `yaml.dump`), and one `removeStackFromManifest` used by both delete paths. It builds on the existing `src/lib/git/manifest.ts` (imports `parseManifest` / `StackManifest`), and does not duplicate manifest schema or parsing.

## How each acceptance criterion is met

- **Layout literals in one place.** `grep -rn "manifest.yaml" src/lib/` (minus tests) returns only `stack-repo-layout.ts`; same for `docker-compose.yml`.
- **One `yaml.dump`.** Only in `serializeManifest`. The four previous call sites (`stack-service.ts` x2, `deploy/stack-repo-writer.ts`, `git/editor-operations.ts`) route through it.
- **One remove-stack implementation.** `stack-repo-layout.removeStackFromManifest(stackName)` returns a `commitFiles` callback (parse, delete entry, serialize, collect stack files to delete). The `StackRepoWriter` port method delegates to it (kept because `pipeline.ts` depends on the port); `stack-service.ts`'s synchronous delete path now calls the writer's method directly, and its old `commitRemoveStackFromManifest` duplicate is deleted. Both paths go through the same `commitFiles` / `withRepoLock` mutex as before.
- **Duplicate tests folded.** Behavioral cases (idempotency, file deletion, missing-manifest error) live in one suite testing through the layout interface; the writer test is slimmed to wiring checks.
- **`git/repo.ts` untouched**: the layout module sits between it and callers.

## Behavior note for review

Unifying the two remove paths makes `stack-service.ts`'s synchronous delete idempotent (silent no-op if the manifest entry already vanished) where it previously threw `Stack "X" not found in manifest`. The outer existence check in `deleteStackFromRepo` still throws for the normal case; this edge (entry disappears between check and commit callback) was covered by no existing test and now matches the behavior `stack-repo-writer` and `startup-recovery`'s orphan sweep already relied on.

## Verification

- `bun run typecheck:all`: clean.
- Every touched test file passes in isolation (`stack-repo-layout` 9, `stack-service` 39, `post-receive-handler` 7, `post-receive` 8, `editor-operations` 6, `stack-repo-writer` 2, `init-repo` 4). The repo-wide local suite has pre-existing cross-file `--isolate` pollution and an environment-dependent coverage gate (no DB locally); CI is the arbiter per CLAUDE.md.

Closes #332

Part of epic #337.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq)_