### PR TITLE
refactor(sse): deepen SSE transport into one wire-protocol primitive

### DIFF
--- a/src/lib/database/__tests__/subscription-service.test.ts
+++ b/src/lib/database/__tests__/subscription-service.test.ts
@@ -1,7 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { databaseConnectionManager } from '@/lib/clients/database-client';
-import { StatsRepository } from '@/lib/database/repositories/stats-repository';
-import { statsPollService } from '../subscription-service';
+import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { StatsPollService, type StatsSource } from '../subscription-service';
 
 interface IntervalHandle {
   cb: () => Promise<void> | void;
@@ -33,141 +31,128 @@ function createIntervalHarness() {
   };
 }
 
-/** Minimal pg.Pool stand-in that records which pool instance received queries. */
-function createMockPool(label: string) {
-  const queries: { sql: string; params: unknown[] }[] = [];
-  return {
-    label,
-    queries,
-    pool: {
-      query: async (sql: string, params: unknown[] = []) => {
-        queries.push({ sql, params });
-        return { rows: [] };
-      },
-    } as unknown as import('pg').Pool,
-  };
-}
-
-/** Build a fake DatabaseClient whose getPool() returns the provided pool. */
-function createMockDbClient(pool: import('pg').Pool) {
-  return {
-    id: 'mock-db',
-    isConnected: () => true,
-    getPool: () => pool,
-  } as unknown as import('@/lib/clients/database-client').DatabaseClient;
+function statsRow(time: string) {
+  return { time };
 }
 
 describe('StatsPollService', () => {
   let harness: ReturnType<typeof createIntervalHarness>;
-  let getClientSpy: ReturnType<typeof spyOn>;
   let errorSpy: ReturnType<typeof spyOn>;
+  let loadRows: ReturnType<typeof mock>;
+  let service: StatsPollService;
 
   beforeEach(() => {
     harness = createIntervalHarness();
     errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+    loadRows = mock(async (_source: StatsSource, _since: Date) => []);
+    service = new StatsPollService({ loadRows });
   });
 
   afterEach(async () => {
-    // Ensure polling state is fully reset between tests. The service is a
-    // module-level singleton, so lingering subscribers would leak across cases.
-    await statsPollService.stop();
-    getClientSpy?.mockRestore();
+    await service.stop();
     errorSpy.mockRestore();
     harness.restore();
   });
 
-  it('rebuilds the repo per tick and queries the current pool after reconnect', async () => {
-    const firstPool = createMockPool('pool-1');
-    const secondPool = createMockPool('pool-2');
-
-    const firstClient = createMockDbClient(firstPool.pool);
-    const secondClient = createMockDbClient(secondPool.pool);
-
-    // Spy on getPool so we can verify which client was used each tick.
-    const firstGetPool = spyOn(firstClient, 'getPool');
-    const secondGetPool = spyOn(secondClient, 'getPool');
-
-    getClientSpy = spyOn(databaseConnectionManager, 'getClient')
-      .mockResolvedValueOnce(firstClient as never)
-      .mockResolvedValueOnce(secondClient as never);
-
-    const querySpy = spyOn(StatsRepository.prototype, 'getDockerStatsSince').mockResolvedValue([]);
-
-    statsPollService.subscribe('docker', () => {});
-
-    expect(harness.intervals).toHaveLength(1);
+  it('calls the injected loadRows with the source and a 200ms lookback cursor', async () => {
+    service.subscribe('docker', () => {});
     const tick = harness.intervals[0].cb;
 
     await tick();
-    expect(firstGetPool).toHaveBeenCalledTimes(1);
-    expect(secondGetPool).toHaveBeenCalledTimes(0);
 
-    await tick();
-    expect(firstGetPool).toHaveBeenCalledTimes(1);
-    expect(secondGetPool).toHaveBeenCalledTimes(1);
-
-    expect(getClientSpy).toHaveBeenCalledTimes(2);
-
-    querySpy.mockRestore();
+    expect(loadRows).toHaveBeenCalledTimes(1);
+    const [source, since] = loadRows.mock.calls[0] as [StatsSource, Date];
+    expect(source).toBe('docker');
+    // subscribe() seeds lastPollTime to "now", so the first tick's since
+    // cursor sits 200ms behind that seed.
+    expect(since.getTime()).toBeLessThan(Date.now());
   });
 
   it('skips a tick while the previous poll for the source is still in flight', async () => {
-    const pool = createMockPool('pool-inflight');
-    const client = createMockDbClient(pool.pool);
-
-    getClientSpy = spyOn(databaseConnectionManager, 'getClient').mockResolvedValue(client as never);
-
-    // First poll's query hangs so the source stays "in flight" across ticks.
+    // First poll's loadRows call hangs so the source stays "in flight" across ticks.
     let resolveQuery: (rows: never[]) => void = () => {};
-    const querySpy = spyOn(StatsRepository.prototype, 'getDockerStatsSince').mockImplementation(
+    loadRows.mockImplementation(
       () => new Promise<never[]>((resolve) => { resolveQuery = resolve; }),
     );
 
-    statsPollService.subscribe('docker', () => {});
+    service.subscribe('docker', () => {});
     const tick = harness.intervals[0].cb;
 
     const first = tick();
-    // Let the first tick reach its awaited (hanging) query.
+    // Let the first tick reach its awaited (hanging) loadRows call.
     await new Promise((r) => setTimeout(r, 0));
 
     // Second tick must early-return without starting another poll.
     await tick();
-    expect(getClientSpy).toHaveBeenCalledTimes(1);
-    expect(querySpy).toHaveBeenCalledTimes(1);
+    expect(loadRows).toHaveBeenCalledTimes(1);
 
     resolveQuery([]);
     await first;
-
-    querySpy.mockRestore();
   });
 
-  it('does not throw on the healthy path when getClient returns the same client twice', async () => {
-    const pool = createMockPool('pool-healthy');
-    const client = createMockDbClient(pool.pool);
+  it('broadcasts all polled rows (including the 200ms overlap) to every subscriber', async () => {
+    loadRows.mockResolvedValue([statsRow(new Date(Date.now() + 60_000).toISOString())]);
+    const received: unknown[][] = [];
 
-    getClientSpy = spyOn(databaseConnectionManager, 'getClient').mockResolvedValue(client as never);
+    service.subscribe('docker', (rows) => received.push(rows));
+    const tick = harness.intervals[0].cb;
 
-    const querySpy = spyOn(StatsRepository.prototype, 'getDockerStatsSince').mockResolvedValue([]);
+    await tick();
 
-    statsPollService.subscribe('docker', () => {});
+    expect(received).toHaveLength(1);
+    expect(received[0]).toHaveLength(1);
+  });
+
+  it('does not broadcast when loadRows returns no rows newer than the cursor', async () => {
+    // Captured before subscribe() seeds lastPollTime, so this row is not
+    // "newer than" the cursor once the poll runs.
+    const beforeSubscribe = new Date();
+    loadRows.mockResolvedValue([statsRow(beforeSubscribe.toISOString())]);
+    const received: unknown[][] = [];
+
+    service.subscribe('docker', (rows) => received.push(rows));
+    const tick = harness.intervals[0].cb;
+
+    await tick();
+
+    expect(received).toHaveLength(0);
+  });
+
+  it('advances the cursor to the max row time observed, not wall-clock time', async () => {
+    const farFuture = new Date(Date.now() + 5 * 60_000).toISOString();
+    loadRows.mockResolvedValueOnce([statsRow(farFuture)]);
+    loadRows.mockResolvedValueOnce([]);
+
+    service.subscribe('docker', () => {});
+    const tick = harness.intervals[0].cb;
+
+    await tick();
+    await tick();
+
+    const secondCallSince = loadRows.mock.calls[1][1] as Date;
+    // The cursor advanced past "now" to the max row time seen on the first
+    // poll (minus the fixed 200ms lookback), not to wall-clock time.
+    expect(secondCallSince.getTime()).toBeGreaterThan(Date.now());
+  });
+
+  it('does not throw on the healthy path when polling repeatedly', async () => {
+    loadRows.mockResolvedValue([]);
+
+    service.subscribe('docker', () => {});
     const tick = harness.intervals[0].cb;
 
     await expect(tick()).resolves.toBeUndefined();
     await expect(tick()).resolves.toBeUndefined();
 
-    expect(querySpy).toHaveBeenCalledTimes(2);
+    expect(loadRows).toHaveBeenCalledTimes(2);
     expect(errorSpy).not.toHaveBeenCalled();
-
-    querySpy.mockRestore();
   });
 
-  it('increments consecutiveFailures and fires onError at the threshold when getClient throws', async () => {
-    getClientSpy = spyOn(databaseConnectionManager, 'getClient').mockRejectedValue(
-      new Error('db down'),
-    );
+  it('increments consecutiveFailures and fires onError at the threshold when loadRows rejects', async () => {
+    loadRows.mockRejectedValue(new Error('db down'));
 
     let errorFired = 0;
-    statsPollService.subscribe(
+    service.subscribe(
       'docker',
       () => {},
       () => {
@@ -180,15 +165,15 @@ describe('StatsPollService', () => {
     // Threshold is 3 consecutive failures: first two polls stay silent, the
     // third trips the onError callback exactly once. Backoff skips ticks
     // between polls, so advance until each poll actually runs.
-    await ticksUntilNextPoll(tick, getClientSpy);
+    await ticksUntilNextPoll(tick, loadRows);
     expect(errorFired).toBe(0);
-    await ticksUntilNextPoll(tick, getClientSpy);
+    await ticksUntilNextPoll(tick, loadRows);
     expect(errorFired).toBe(0);
-    await ticksUntilNextPoll(tick, getClientSpy);
+    await ticksUntilNextPoll(tick, loadRows);
     expect(errorFired).toBe(1);
 
     // Subsequent failures don't re-fire within the same failure episode.
-    await ticksUntilNextPoll(tick, getClientSpy);
+    await ticksUntilNextPoll(tick, loadRows);
     expect(errorFired).toBe(1);
 
     // And each failing poll logs via console.error, preserving existing behavior.
@@ -196,56 +181,48 @@ describe('StatsPollService', () => {
   });
 
   it('skips ticks with doubling backoff after failures and resets on success', async () => {
-    const pool = createMockPool('pool-recover');
-    const client = createMockDbClient(pool.pool);
-
-    getClientSpy = spyOn(databaseConnectionManager, 'getClient')
+    loadRows
       .mockRejectedValueOnce(new Error('db down'))
       .mockRejectedValueOnce(new Error('db down'))
-      .mockResolvedValue(client as never);
-    const querySpy = spyOn(StatsRepository.prototype, 'getDockerStatsSince').mockResolvedValue([]);
+      .mockResolvedValue([]);
 
-    statsPollService.subscribe('docker', () => {});
+    service.subscribe('docker', () => {});
     const tick = harness.intervals[0].cb;
 
     // Failure 1: effective spacing doubles to 2s, so 1 tick is skipped.
     await tick();
-    expect(getClientSpy).toHaveBeenCalledTimes(1);
+    expect(loadRows).toHaveBeenCalledTimes(1);
     await tick();
-    expect(getClientSpy).toHaveBeenCalledTimes(1);
+    expect(loadRows).toHaveBeenCalledTimes(1);
 
     // Failure 2: spacing doubles to 4s, so 3 ticks are skipped.
     await tick();
-    expect(getClientSpy).toHaveBeenCalledTimes(2);
+    expect(loadRows).toHaveBeenCalledTimes(2);
     await tick();
     await tick();
     await tick();
-    expect(getClientSpy).toHaveBeenCalledTimes(2);
+    expect(loadRows).toHaveBeenCalledTimes(2);
 
     // Next poll succeeds and resets the backoff.
     await tick();
-    expect(getClientSpy).toHaveBeenCalledTimes(3);
+    expect(loadRows).toHaveBeenCalledTimes(3);
 
     // Healthy again: every tick polls.
     await tick();
-    expect(getClientSpy).toHaveBeenCalledTimes(4);
+    expect(loadRows).toHaveBeenCalledTimes(4);
     await tick();
-    expect(getClientSpy).toHaveBeenCalledTimes(5);
-
-    querySpy.mockRestore();
+    expect(loadRows).toHaveBeenCalledTimes(5);
   });
 
-  it('caps the effective poll spacing at 10 ticks while the database stays down', async () => {
-    getClientSpy = spyOn(databaseConnectionManager, 'getClient').mockRejectedValue(
-      new Error('db down'),
-    );
+  it('caps the effective poll spacing at 10 ticks while loadRows keeps rejecting', async () => {
+    loadRows.mockRejectedValue(new Error('db down'));
 
-    statsPollService.subscribe('docker', () => {});
+    service.subscribe('docker', () => {});
     const tick = harness.intervals[0].cb;
 
     const skips: number[] = [];
     for (let poll = 0; poll < 6; poll++) {
-      skips.push(await ticksUntilNextPoll(tick, getClientSpy));
+      skips.push(await ticksUntilNextPoll(tick, loadRows));
     }
 
     // First poll runs immediately; spacing then doubles (2s, 4s, 8s) and caps
@@ -255,19 +232,19 @@ describe('StatsPollService', () => {
 });
 
 /**
- * Advance the polling tick until getClient is invoked again, returning how
+ * Advance the polling tick until loadRows is invoked again, returning how
  * many ticks were skipped by the backoff before the poll ran.
  */
 async function ticksUntilNextPoll(
   tick: () => Promise<void> | void,
-  getClientSpy: ReturnType<typeof spyOn>,
+  loadRows: ReturnType<typeof mock>,
 ): Promise<number> {
-  const before = getClientSpy.mock.calls.length;
+  const before = loadRows.mock.calls.length;
   let skipped = 0;
-  while (getClientSpy.mock.calls.length === before) {
+  while (loadRows.mock.calls.length === before) {
     if (skipped > 20) throw new Error('no poll ran within 20 ticks');
     await tick();
-    if (getClientSpy.mock.calls.length === before) skipped += 1;
+    if (loadRows.mock.calls.length === before) skipped += 1;
   }
   return skipped;
 }

--- a/src/lib/database/__tests__/subscription-service.test.ts
+++ b/src/lib/database/__tests__/subscription-service.test.ts
@@ -7,10 +7,7 @@ interface IntervalHandle {
   cleared: boolean;
 }
 
-/**
- * Replace setInterval/clearInterval so each registered interval becomes a
- * callback we can invoke deterministically from tests (no real timers run).
- */
+/** Replaces setInterval/clearInterval so each interval is a callback tests can invoke deterministically. */
 function createIntervalHarness() {
   const intervals: IntervalHandle[] = [];
   const setSpy = spyOn(globalThis, 'setInterval').mockImplementation(((cb: () => void, ms: number) => {
@@ -63,8 +60,7 @@ describe('StatsPollService', () => {
     expect(loadRows).toHaveBeenCalledTimes(1);
     const [source, since] = loadRows.mock.calls[0] as [StatsSource, Date];
     expect(source).toBe('docker');
-    // subscribe() seeds lastPollTime to "now", so the first tick's since
-    // cursor sits 200ms behind that seed.
+    // subscribe() seeds lastPollTime to "now", so since sits 200ms behind that.
     expect(since.getTime()).toBeLessThan(Date.now());
   });
 
@@ -104,8 +100,7 @@ describe('StatsPollService', () => {
   });
 
   it('does not broadcast when loadRows returns no rows newer than the cursor', async () => {
-    // Captured before subscribe() seeds lastPollTime, so this row is not
-    // "newer than" the cursor once the poll runs.
+    // Captured before subscribe() seeds lastPollTime, so this row isn't "newer than" the cursor.
     const beforeSubscribe = new Date();
     loadRows.mockResolvedValue([statsRow(beforeSubscribe.toISOString())]);
     const received: unknown[][] = [];
@@ -130,8 +125,7 @@ describe('StatsPollService', () => {
     await tick();
 
     const secondCallSince = loadRows.mock.calls[1][1] as Date;
-    // The cursor advanced past "now" to the max row time seen on the first
-    // poll (minus the fixed 200ms lookback), not to wall-clock time.
+    // Cursor advanced to the max row time seen on the first poll, not wall-clock time.
     expect(secondCallSince.getTime()).toBeGreaterThan(Date.now());
   });
 
@@ -162,9 +156,7 @@ describe('StatsPollService', () => {
 
     const tick = harness.intervals[0].cb;
 
-    // Threshold is 3 consecutive failures: first two polls stay silent, the
-    // third trips the onError callback exactly once. Backoff skips ticks
-    // between polls, so advance until each poll actually runs.
+    // Threshold is 3 consecutive failures; backoff skips ticks, so advance until each poll actually runs.
     await ticksUntilNextPoll(tick, loadRows);
     expect(errorFired).toBe(0);
     await ticksUntilNextPoll(tick, loadRows);
@@ -172,11 +164,10 @@ describe('StatsPollService', () => {
     await ticksUntilNextPoll(tick, loadRows);
     expect(errorFired).toBe(1);
 
-    // Subsequent failures don't re-fire within the same failure episode.
+    // Subsequent failures don't re-fire within the same episode.
     await ticksUntilNextPoll(tick, loadRows);
     expect(errorFired).toBe(1);
 
-    // And each failing poll logs via console.error, preserving existing behavior.
     expect(errorSpy).toHaveBeenCalled();
   });
 
@@ -225,16 +216,12 @@ describe('StatsPollService', () => {
       skips.push(await ticksUntilNextPoll(tick, loadRows));
     }
 
-    // First poll runs immediately; spacing then doubles (2s, 4s, 8s) and caps
-    // at 10s, which means at most 9 skipped ticks between polls.
+    // Spacing doubles (2s, 4s, 8s) and caps at 10s: at most 9 skipped ticks between polls.
     expect(skips).toEqual([0, 1, 3, 7, 9, 9]);
   });
 });
 
-/**
- * Advance the polling tick until loadRows is invoked again, returning how
- * many ticks were skipped by the backoff before the poll ran.
- */
+/** Advances ticks until loadRows is invoked again, returning how many ticks were skipped. */
 async function ticksUntilNextPoll(
   tick: () => Promise<void> | void,
   loadRows: ReturnType<typeof mock>,

--- a/src/lib/database/subscription-service.ts
+++ b/src/lib/database/subscription-service.ts
@@ -4,8 +4,13 @@ import { StatsRepository } from '@/lib/database/repositories/stats-repository';
 import { backoffDelayMs } from '@/lib/utils/backoff';
 
 export type StatsSource = 'docker' | 'zfs' | 'proxmox';
+/** Minimal shape the poll loop needs; docker/zfs/proxmox rows all satisfy this. */
+interface StatsRow {
+  time: string | Date;
+}
 type StatsCallback = (rows: unknown[]) => void;
 type StatsErrorCallback = () => void;
+type LoadRowsFn = (source: StatsSource, since: Date) => Promise<StatsRow[]>;
 
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 5000;
@@ -17,13 +22,36 @@ const FAILURE_THRESHOLD = 3;
 const MAX_BACKOFF_MS = 10_000;
 
 /**
+ * Rebuilds the repo on every call (not cached) so a reconnect inside
+ * DatabaseConnectionManager is picked up on the next tick instead of
+ * pinning a stale pg.Pool. getClient() is cached on the healthy path,
+ * so this costs one Map lookup plus a no-op constructor per poll.
+ */
+async function defaultLoadRows(source: StatsSource, since: Date): Promise<StatsRow[]> {
+  const dbClient = await databaseConnectionManager.getClient(loadDatabaseConfig());
+  const repo = new StatsRepository(dbClient.getPool());
+  switch (source) {
+    case 'docker':
+      return repo.getDockerStatsSince(since);
+    case 'zfs':
+      return repo.getZFSStatsSince(since);
+    case 'proxmox':
+      return repo.getProxmoxStatsSince(since);
+  }
+}
+
+export interface StatsPollServiceDeps {
+  loadRows?: LoadRowsFn;
+}
+
+/**
  * Shared poll service that runs one setInterval per source (docker, zfs)
  * and broadcasts results to all subscribed SSE clients.
  *
  * Auto-starts polling when the first subscriber joins for a source,
  * auto-stops when the last subscriber leaves.
  */
-class StatsPollService {
+export class StatsPollService {
   private subscribers = new Map<StatsSource, Set<StatsCallback>>();
   private errorCallbacks = new Map<StatsSource, Set<StatsErrorCallback>>();
   private intervals = new Map<StatsSource, ReturnType<typeof setInterval>>();
@@ -38,7 +66,11 @@ class StatsPollService {
   // timeout) stacks several concurrent queries, each holding a pool
   // connection. The guard sheds to one poll at a time instead.
   private inFlight = new Set<StatsSource>();
-  private readonly dbConfig = loadDatabaseConfig();
+  private readonly loadRows: LoadRowsFn;
+
+  constructor(deps: StatsPollServiceDeps = {}) {
+    this.loadRows = deps.loadRows ?? defaultLoadRows;
+  }
 
   subscribe(source: StatsSource, callback: StatsCallback, onError?: StatsErrorCallback): () => void {
     let subs = this.subscribers.get(source);
@@ -91,19 +123,10 @@ class StatsPollService {
 
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
       try {
-        // Rebuild the repo each tick so we pick up a fresh pg.Pool after any
-        // reconnect in DatabaseConnectionManager. getClient() is cached on the
-        // healthy path, so this costs one Map lookup + a no-op constructor.
-        const dbClient = await databaseConnectionManager.getClient(this.dbConfig);
-        const repo = new StatsRepository(dbClient.getPool());
         const last = this.lastPollTime.get(source) ?? new Date();
         const since = new Date(last.getTime() - 200); // 200ms lookback for late-committing rows
 
-        const rowsPromise = source === 'docker'
-          ? repo.getDockerStatsSince(since)
-          : source === 'zfs'
-            ? repo.getZFSStatsSince(since)
-            : repo.getProxmoxStatsSince(since);
+        const rowsPromise = this.loadRows(source, since);
 
         const timeoutPromise = new Promise<never>((_, reject) => {
           timeoutId = setTimeout(() => reject(new Error('Poll timeout')), POLL_TIMEOUT_MS);
@@ -119,12 +142,12 @@ class StatsPollService {
         // Only broadcast rows newer than last poll - prevents broadcasting stale data
         // when the worker is down (which would break the 30s stale detection in the frontend)
         const toMs = (value: string | Date) => new Date(value).getTime();
-        const newRows = rows.filter(r => toMs(r.time as string | Date) > last.getTime());
+        const newRows = rows.filter(r => toMs(r.time) > last.getTime());
 
         if (newRows.length > 0) {
           // Advance cursor to max observed row time (not wall-clock) to avoid skipping late-committing rows
           const maxSeenTime = rows.reduce(
-            (max, r) => Math.max(max, toMs(r.time as string | Date)),
+            (max, r) => Math.max(max, toMs(r.time)),
             last.getTime()
           );
           this.lastPollTime.set(source, new Date(maxSeenTime));

--- a/src/lib/database/subscription-service.ts
+++ b/src/lib/database/subscription-service.ts
@@ -15,18 +15,10 @@ type LoadRowsFn = (source: StatsSource, since: Date) => Promise<StatsRow[]>;
 const POLL_INTERVAL_MS = 1000;
 const POLL_TIMEOUT_MS = 5000;
 const FAILURE_THRESHOLD = 3;
-// While the database is down every poll still pays the full 5s query timeout,
-// so retrying each 1s tick keeps a failing connection pinned. Consecutive
-// failures stretch the effective spacing by skipping ticks (2s, 4s, 8s, then
-// capped at 10s) until one successful poll resets it.
+// Failures double the effective spacing (2s, 4s, 8s, capped at 10s) until a poll succeeds.
 const MAX_BACKOFF_MS = 10_000;
 
-/**
- * Rebuilds the repo on every call (not cached) so a reconnect inside
- * DatabaseConnectionManager is picked up on the next tick instead of
- * pinning a stale pg.Pool. getClient() is cached on the healthy path,
- * so this costs one Map lookup plus a no-op constructor per poll.
- */
+/** Rebuilds the repo per call (not cached) so a DatabaseConnectionManager reconnect is picked up next tick. */
 async function defaultLoadRows(source: StatsSource, since: Date): Promise<StatsRow[]> {
   const dbClient = await databaseConnectionManager.getClient(loadDatabaseConfig());
   const repo = new StatsRepository(dbClient.getPool());
@@ -45,11 +37,8 @@ export interface StatsPollServiceDeps {
 }
 
 /**
- * Shared poll service that runs one setInterval per source (docker, zfs)
- * and broadcasts results to all subscribed SSE clients.
- *
- * Auto-starts polling when the first subscriber joins for a source,
- * auto-stops when the last subscriber leaves.
+ * Shared poll service: one setInterval per source (docker, zfs), broadcasting to subscribed SSE clients.
+ * Auto-starts on first subscriber per source, auto-stops when the last leaves.
  */
 export class StatsPollService {
   private subscribers = new Map<StatsSource, Set<StatsCallback>>();
@@ -60,11 +49,7 @@ export class StatsPollService {
   private skipTicks = new Map<StatsSource, number>();
   private errorSignalled = new Set<StatsSource>();
   private stoppedSources = new Set<StatsSource>();
-  // Sources with a poll still in flight. The interval fires every second
-  // regardless of how long the previous poll took, so without this guard a
-  // run of slow-but-succeeding polls (2-4s under DB load, still under the
-  // timeout) stacks several concurrent queries, each holding a pool
-  // connection. The guard sheds to one poll at a time instead.
+  // Sources with a poll still in flight, so a run of slow polls can't stack concurrent queries.
   private inFlight = new Set<StatsSource>();
   private readonly loadRows: LoadRowsFn;
 
@@ -117,7 +102,6 @@ export class StatsPollService {
         return;
       }
 
-      // Skip this tick if the previous poll for this source hasn't finished.
       if (this.inFlight.has(source)) return;
       this.inFlight.add(source);
 
@@ -134,38 +118,34 @@ export class StatsPollService {
 
         const rows = await Promise.race([rowsPromise, timeoutPromise]);
 
-        // Success - reset failure tracking and backoff
         this.consecutiveFailures.set(source, 0);
         this.skipTicks.delete(source);
         this.errorSignalled.delete(source);
 
-        // Only broadcast rows newer than last poll - prevents broadcasting stale data
-        // when the worker is down (which would break the 30s stale detection in the frontend)
+        // Only rows newer than the last poll: avoids rebroadcasting stale data (breaks the frontend's 30s stale detection).
         const toMs = (value: string | Date) => new Date(value).getTime();
         const newRows = rows.filter(r => toMs(r.time) > last.getTime());
 
         if (newRows.length > 0) {
-          // Advance cursor to max observed row time (not wall-clock) to avoid skipping late-committing rows
+          // Cursor advances to the max row time seen, not wall-clock, so late-committing rows aren't skipped.
           const maxSeenTime = rows.reduce(
             (max, r) => Math.max(max, toMs(r.time)),
             last.getTime()
           );
           this.lastPollTime.set(source, new Date(maxSeenTime));
           for (const cb of subs) {
-            cb(rows); // send all rows including 200ms overlap - frontend Map deduplicates
+            cb(rows); // includes the 200ms overlap; frontend Map deduplicates
           }
         }
       } catch (err) {
         console.error(`[StatsPollService] Poll failed for source "${source}":`, err);
-        // Track consecutive failures
         const failures = (this.consecutiveFailures.get(source) ?? 0) + 1;
         this.consecutiveFailures.set(source, failures);
 
         const backoffMs = backoffDelayMs(failures, { baseMs: POLL_INTERVAL_MS, capMs: MAX_BACKOFF_MS });
-        // -1 because the current (failing) tick already consumed one interval.
+        // -1: the current (failing) tick already consumed one interval.
         this.skipTicks.set(source, backoffMs / POLL_INTERVAL_MS - 1);
 
-        // Signal error once per failure episode after hitting the threshold
         if (failures >= FAILURE_THRESHOLD && !this.errorSignalled.has(source)) {
           this.errorSignalled.add(source);
           const errCbs = this.errorCallbacks.get(source);
@@ -174,8 +154,7 @@ export class StatsPollService {
           }
         }
       } finally {
-        // Clear the timeout timer whenever the query wins the race, otherwise a
-        // pending 5s timer leaks per successful tick and delays clean shutdown.
+        // Clears the race's other timer so it doesn't leak past a successful poll.
         clearTimeout(timeoutId);
         this.inFlight.delete(source);
       }

--- a/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
@@ -34,7 +34,7 @@ function makeRequest(ac: AbortController): Request {
 }
 
 /** Macrotask flush so onStart's loadSubscribe/subscribe chain settles before asserting its side effects. */
-function flushMicrotasks(): Promise<void> {
+function flushMacrotask(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
@@ -157,9 +157,9 @@ describe('createBroadcastSseHandler', () => {
     const ac = new AbortController();
 
     await handler({ request: makeRequest(ac) });
-    await flushMicrotasks();
+    await flushMacrotask();
     ac.abort();
-    await flushMicrotasks();
+    await flushMacrotask();
 
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
@@ -169,9 +169,9 @@ describe('createBroadcastSseHandler', () => {
     const ac = new AbortController();
 
     await handler({ request: makeRequest(ac) });
-    await flushMicrotasks();
+    await flushMacrotask();
     ac.abort();
-    await flushMicrotasks();
+    await flushMacrotask();
 
     expect(() => emit({ n: 99 })).not.toThrow();
   });

--- a/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
@@ -9,9 +9,17 @@ type Event = { n: number };
 
 function setup(serialize: (e: Event) => string = (e) => `data: ${JSON.stringify(e)}\n\n`) {
   let captured: ((event: Event) => void) | null = null;
-  const unsubscribe = mock(() => {});
+  let markSubscribed = () => {};
+  let markUnsubscribed = () => {};
+  // createSseStream runs onStart (loadSubscribe + subscribe) inside the stream's async
+  // start(), so tests wait on these instead of a timer to know when the subscription is
+  // live and when abort teardown has called unsubscribe.
+  const subscribed = new Promise<void>((resolve) => { markSubscribed = resolve; });
+  const unsubscribed = new Promise<void>((resolve) => { markUnsubscribed = resolve; });
+  const unsubscribe = mock(() => markUnsubscribed());
   const subscribe = mock((cb: (event: Event) => void) => {
     captured = cb;
+    markSubscribed();
     return unsubscribe;
   });
 
@@ -25,17 +33,14 @@ function setup(serialize: (e: Event) => string = (e) => `data: ${JSON.stringify(
     handler,
     subscribe,
     unsubscribe,
+    subscribed,
+    unsubscribed,
     emit: (e: Event) => captured?.(e),
   };
 }
 
 function makeRequest(ac: AbortController): Request {
   return new Request('http://localhost/', { signal: ac.signal });
-}
-
-/** Macrotask flush so onStart's loadSubscribe/subscribe chain settles before asserting its side effects. */
-function flushMacrotask(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function readerOf(res: Response): ReadableStreamDefaultReader<Uint8Array> {
@@ -153,25 +158,25 @@ describe('createBroadcastSseHandler', () => {
   });
 
   it('unsubscribes when the request aborts', async () => {
-    const { handler, unsubscribe } = setup();
+    const { handler, unsubscribe, subscribed, unsubscribed } = setup();
     const ac = new AbortController();
 
     await handler({ request: makeRequest(ac) });
-    await flushMacrotask();
+    await subscribed;
     ac.abort();
-    await flushMacrotask();
+    await unsubscribed;
 
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
 
   it('drops events emitted after abort without throwing', async () => {
-    const { handler, emit } = setup();
+    const { handler, emit, subscribed, unsubscribed } = setup();
     const ac = new AbortController();
 
     await handler({ request: makeRequest(ac) });
-    await flushMacrotask();
+    await subscribed;
     ac.abort();
-    await flushMacrotask();
+    await unsubscribed;
 
     expect(() => emit({ n: 99 })).not.toThrow();
   });

--- a/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
@@ -33,6 +33,16 @@ function makeRequest(ac: AbortController): Request {
   return new Request('http://localhost/', { signal: ac.signal });
 }
 
+/**
+ * createSseStream awaits the caller's onStart (loadSubscribe + subscribe)
+ * before registering its cleanup, one microtask hop deeper than a bare
+ * `await handler(...)` unwinds. Flush a macrotask so that chain settles
+ * before asserting on its side effects (unsubscribe calls, etc.).
+ */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 function readerOf(res: Response): ReadableStreamDefaultReader<Uint8Array> {
   if (!res.body) throw new Error('Response had no body');
   return res.body.getReader();
@@ -93,10 +103,11 @@ describe('createBroadcastSseHandler', () => {
     reader.cancel();
   });
 
-  it('emits comment heartbeats on the interval to keep idle streams warm', async () => {
+  it('emits comment heartbeats on the shared 5s cadence to keep idle streams warm', async () => {
     let heartbeatFn: (() => void) | null = null;
-    const intervalSpy = spyOn(globalThis, 'setInterval').mockImplementation(((fn: () => void) => {
+    const intervalSpy = spyOn(globalThis, 'setInterval').mockImplementation(((fn: () => void, ms: number) => {
       heartbeatFn = fn;
+      expect(ms).toBe(5000); // the cadence now comes only from createSseStream's default
       return 123 as unknown as ReturnType<typeof setInterval>;
     }) as typeof setInterval);
     const clearSpy = spyOn(globalThis, 'clearInterval').mockImplementation(() => {});
@@ -151,7 +162,9 @@ describe('createBroadcastSseHandler', () => {
     const ac = new AbortController();
 
     await handler({ request: makeRequest(ac) });
+    await flushMicrotasks();
     ac.abort();
+    await flushMicrotasks();
 
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });
@@ -161,7 +174,9 @@ describe('createBroadcastSseHandler', () => {
     const ac = new AbortController();
 
     await handler({ request: makeRequest(ac) });
+    await flushMicrotasks();
     ac.abort();
+    await flushMicrotasks();
 
     expect(() => emit({ n: 99 })).not.toThrow();
   });

--- a/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-broadcast-sse-handler.test.ts
@@ -33,12 +33,7 @@ function makeRequest(ac: AbortController): Request {
   return new Request('http://localhost/', { signal: ac.signal });
 }
 
-/**
- * createSseStream awaits the caller's onStart (loadSubscribe + subscribe)
- * before registering its cleanup, one microtask hop deeper than a bare
- * `await handler(...)` unwinds. Flush a macrotask so that chain settles
- * before asserting on its side effects (unsubscribe calls, etc.).
- */
+/** Macrotask flush so onStart's loadSubscribe/subscribe chain settles before asserting its side effects. */
 function flushMicrotasks(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }

--- a/src/lib/sse/__tests__/create-sse-stream.test.ts
+++ b/src/lib/sse/__tests__/create-sse-stream.test.ts
@@ -7,11 +7,7 @@ interface IntervalHandle {
   cleared: boolean;
 }
 
-/**
- * Replace setInterval/clearInterval so the heartbeat becomes a callback we
- * can fire deterministically from tests instead of waiting on wall-clock
- * time (per CLAUDE.md: spy on the timer, don't sleep).
- */
+/** Replaces setInterval/clearInterval so the heartbeat is a callback tests can fire deterministically. */
 function createIntervalHarness() {
   const intervals: IntervalHandle[] = [];
   const setSpy = spyOn(globalThis, 'setInterval').mockImplementation(((cb: () => void, ms: number) => {
@@ -47,13 +43,7 @@ async function readFrame(reader: ReadableStreamDefaultReader<Uint8Array>): Promi
   return new TextDecoder().decode(value);
 }
 
-/**
- * createSseStream's `await onStart(...)` still takes at least one microtask
- * hop even for a synchronous onStart, and more for an async one. A macrotask
- * flush drains all of them deterministically instead of guessing a tick
- * count, so tests that assert on the cleanup wiring (set only once onStart
- * resolves) aren't racing it.
- */
+/** Macrotask flush so tests don't race the microtask hops in `await onStart(...)`. */
 function flushMicrotasks(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
@@ -225,7 +215,7 @@ describe('createSseStream', () => {
     await flushMicrotasks(); // let onStart resolve and register cleanup first
 
     ac.abort();
-    ac.abort(); // AbortController.abort() is itself idempotent, but guard the assertion anyway
+    ac.abort(); // idempotent; guards the assertion anyway
 
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
@@ -237,8 +227,7 @@ describe('createSseStream', () => {
 
     const res = createSseStream(makeRequest(ac), {
       onStart: async () => {
-        // Simulate slow setup (e.g. a dynamic import + subscribe call) that
-        // hasn't returned its cleanup by the time the client disconnects.
+        // Simulates slow setup that hasn't returned its cleanup by the time the client disconnects.
         await new Promise<void>((resolve) => {
           releaseOnStart = resolve;
         });
@@ -289,10 +278,7 @@ describe('createSseStream', () => {
     const reader = readerOf(res);
     await readFrame(reader);
 
-    // A payload whose serialization throws a close-shaped TypeError, same
-    // as what Web Streams throws for enqueue-after-close: exercises the
-    // isCloseRelatedError(err) === true branch of write()'s catch, distinct
-    // from the `closed` flag's own early-return guard.
+    // Serialization throws a close-shaped TypeError, exercising write()'s isCloseRelatedError branch.
     const payload = {
       toJSON() {
         throw new TypeError('The stream is closed');

--- a/src/lib/sse/__tests__/create-sse-stream.test.ts
+++ b/src/lib/sse/__tests__/create-sse-stream.test.ts
@@ -43,10 +43,6 @@ async function readFrame(reader: ReadableStreamDefaultReader<Uint8Array>): Promi
   return new TextDecoder().decode(value);
 }
 
-/** Macrotask flush so tests don't race the microtask hops in `await onStart(...)`. */
-function flushMicrotasks(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
 
 async function readAll(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
   const decoder = new TextDecoder();
@@ -210,18 +206,22 @@ describe('createSseStream', () => {
   });
 
   it('runs the onStart-returned cleanup exactly once on abort', async () => {
-    const cleanup = mock(() => {});
+    let markCleanup = () => {};
+    const cleanupDone = new Promise<void>((resolve) => { markCleanup = resolve; });
+    const cleanup = mock(() => markCleanup());
     const { ac } = setup({ cleanup });
-    await flushMicrotasks(); // let onStart resolve and register cleanup first
 
     ac.abort();
     ac.abort(); // idempotent; guards the assertion anyway
+    await cleanupDone;
 
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
   it('runs cleanup once even when onStart resolves after the abort already tore the stream down', async () => {
-    const cleanup = mock(() => {});
+    let markCleanup = () => {};
+    const cleanupDone = new Promise<void>((resolve) => { markCleanup = resolve; });
+    const cleanup = mock(() => markCleanup());
     const ac = new AbortController();
     let releaseOnStart: (() => void) | null = null;
 
@@ -241,7 +241,7 @@ describe('createSseStream', () => {
     expect(cleanup).not.toHaveBeenCalled();
 
     releaseOnStart!();
-    await flushMicrotasks();
+    await cleanupDone;
 
     expect(cleanup).toHaveBeenCalledTimes(1);
 

--- a/src/lib/sse/__tests__/create-sse-stream.test.ts
+++ b/src/lib/sse/__tests__/create-sse-stream.test.ts
@@ -1,0 +1,351 @@
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
+import { createSseStream, isCloseRelatedError, type SseEmitter } from '../create-sse-stream';
+
+interface IntervalHandle {
+  cb: () => void;
+  ms: number;
+  cleared: boolean;
+}
+
+/**
+ * Replace setInterval/clearInterval so the heartbeat becomes a callback we
+ * can fire deterministically from tests instead of waiting on wall-clock
+ * time (per CLAUDE.md: spy on the timer, don't sleep).
+ */
+function createIntervalHarness() {
+  const intervals: IntervalHandle[] = [];
+  const setSpy = spyOn(globalThis, 'setInterval').mockImplementation(((cb: () => void, ms: number) => {
+    const handle: IntervalHandle = { cb, ms, cleared: false };
+    intervals.push(handle);
+    return handle as unknown as ReturnType<typeof setInterval>;
+  }) as typeof setInterval);
+  const clearSpy = spyOn(globalThis, 'clearInterval').mockImplementation(((h: unknown) => {
+    const handle = h as IntervalHandle;
+    if (handle) handle.cleared = true;
+  }) as typeof clearInterval);
+  return {
+    intervals,
+    restore() {
+      setSpy.mockRestore();
+      clearSpy.mockRestore();
+    },
+  };
+}
+
+function makeRequest(ac: AbortController): Request {
+  return new Request('http://localhost/', { signal: ac.signal });
+}
+
+function readerOf(res: Response): ReadableStreamDefaultReader<Uint8Array> {
+  if (!res.body) throw new Error('Response had no body');
+  return res.body.getReader();
+}
+
+async function readFrame(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
+  const { value, done } = await reader.read();
+  if (done) return '';
+  return new TextDecoder().decode(value);
+}
+
+/**
+ * createSseStream's `await onStart(...)` still takes at least one microtask
+ * hop even for a synchronous onStart, and more for an async one. A macrotask
+ * flush drains all of them deterministically instead of guessing a tick
+ * count, so tests that assert on the cleanup wiring (set only once onStart
+ * resolves) aren't racing it.
+ */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+async function readAll(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
+  const decoder = new TextDecoder();
+  let out = '';
+  for (;;) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    out += decoder.decode(value);
+  }
+  return out;
+}
+
+/** Sets up a stream whose onStart hands the test direct access to `emit`/`signal`. */
+function setup(opts: { heartbeatMs?: number; cleanup?: () => void } = {}) {
+  let capturedEmit: SseEmitter | null = null;
+  let capturedSignal: AbortSignal | null = null;
+  const cleanup = opts.cleanup ?? mock(() => {});
+
+  const ac = new AbortController();
+  const res = createSseStream(makeRequest(ac), {
+    heartbeatMs: opts.heartbeatMs,
+    onStart: (emit, signal) => {
+      capturedEmit = emit;
+      capturedSignal = signal;
+      return cleanup;
+    },
+  });
+
+  return {
+    res,
+    ac,
+    cleanup,
+    getEmit: () => capturedEmit!,
+    getSignal: () => capturedSignal!,
+  };
+}
+
+describe('createSseStream', () => {
+  let harness: ReturnType<typeof createIntervalHarness>;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    harness = createIntervalHarness();
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+    harness.restore();
+  });
+
+  it('returns the standard SSE response headers', () => {
+    const { res, ac } = setup();
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(res.headers.get('Cache-Control')).toBe('no-cache');
+    expect(res.headers.get('Connection')).toBe('keep-alive');
+
+    ac.abort();
+  });
+
+  it('flushes ": ok\\n\\n" as the first frame', async () => {
+    const { res, ac } = setup();
+    const reader = readerOf(res);
+
+    expect(await readFrame(reader)).toBe(': ok\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('arms exactly one heartbeat timer at the default 5000ms cadence', () => {
+    const { ac } = setup();
+
+    expect(harness.intervals).toHaveLength(1);
+    expect(harness.intervals[0].ms).toBe(5000);
+
+    ac.abort();
+  });
+
+  it('respects a caller-supplied heartbeatMs', () => {
+    const { ac } = setup({ heartbeatMs: 1234 });
+
+    expect(harness.intervals[0].ms).toBe(1234);
+
+    ac.abort();
+  });
+
+  it('writes a bare ":\\n\\n" comment on each heartbeat tick', async () => {
+    const { res, ac } = setup();
+    const reader = readerOf(res);
+    await readFrame(reader); // ": ok\n\n"
+
+    harness.intervals[0].cb();
+    expect(await readFrame(reader)).toBe(':\n\n');
+
+    harness.intervals[0].cb();
+    expect(await readFrame(reader)).toBe(':\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('clears the heartbeat timer on abort so no further ticks are written', async () => {
+    const { ac } = setup();
+
+    ac.abort();
+
+    expect(harness.intervals[0].cleared).toBe(true);
+  });
+
+  it('emit.data writes a "data: <JSON>\\n\\n" frame', async () => {
+    const { res, ac, getEmit } = setup();
+    const reader = readerOf(res);
+    await readFrame(reader); // flush comment
+
+    getEmit().data({ n: 1 });
+    expect(await readFrame(reader)).toBe('data: {"n":1}\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('emit.event writes an "event: <name>\\ndata: <JSON>\\n\\n" frame', async () => {
+    const { res, ac, getEmit } = setup();
+    const reader = readerOf(res);
+    await readFrame(reader);
+
+    getEmit().event('stats_error', { message: 'db down' });
+    expect(await readFrame(reader)).toBe('event: stats_error\ndata: {"message":"db down"}\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('emit.raw writes a pre-formatted string frame verbatim', async () => {
+    const { res, ac, getEmit } = setup();
+    const reader = readerOf(res);
+    await readFrame(reader);
+
+    getEmit().raw('event: custom\ndata: 42\n\n');
+    expect(await readFrame(reader)).toBe('event: custom\ndata: 42\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('emit.raw writes bytes verbatim without re-encoding', async () => {
+    const { res, ac, getEmit } = setup();
+    const reader = readerOf(res);
+    await readFrame(reader);
+
+    const bytes = new TextEncoder().encode('data: raw-bytes\n\n');
+    getEmit().raw(bytes);
+    const frame = await reader.read();
+    expect(new TextDecoder().decode(frame.value)).toBe('data: raw-bytes\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('runs the onStart-returned cleanup exactly once on abort', async () => {
+    const cleanup = mock(() => {});
+    const { ac } = setup({ cleanup });
+    await flushMicrotasks(); // let onStart resolve and register cleanup first
+
+    ac.abort();
+    ac.abort(); // AbortController.abort() is itself idempotent, but guard the assertion anyway
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('runs cleanup once even when onStart resolves after the abort already tore the stream down', async () => {
+    const cleanup = mock(() => {});
+    const ac = new AbortController();
+    let releaseOnStart: (() => void) | null = null;
+
+    const res = createSseStream(makeRequest(ac), {
+      onStart: async () => {
+        // Simulate slow setup (e.g. a dynamic import + subscribe call) that
+        // hasn't returned its cleanup by the time the client disconnects.
+        await new Promise<void>((resolve) => {
+          releaseOnStart = resolve;
+        });
+        return cleanup;
+      },
+    });
+    const reader = readerOf(res);
+    await readFrame(reader); // ": ok\n\n"
+
+    ac.abort();
+    expect(cleanup).not.toHaveBeenCalled();
+
+    releaseOnStart!();
+    await flushMicrotasks();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    reader.cancel();
+  });
+
+  it('emit.close() ends the stream immediately: clears the heartbeat and runs cleanup', async () => {
+    const cleanup = mock(() => {});
+    const { res, ac, getEmit } = setup({ cleanup });
+    const reader = readerOf(res);
+    await readFrame(reader);
+
+    getEmit().close();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(harness.intervals[0].cleared).toBe(true);
+
+    const { done } = await reader.read();
+    expect(done).toBe(true);
+
+    ac.abort();
+  });
+
+  it('drops writes issued after teardown without throwing', async () => {
+    const { ac, getEmit } = setup();
+    ac.abort();
+
+    expect(() => getEmit().data({ n: 1 })).not.toThrow();
+  });
+
+  it('classifies a close-related write failure without logging, but still tears down', async () => {
+    const cleanup = mock(() => {});
+    const { res, ac, getEmit } = setup({ cleanup });
+    const reader = readerOf(res);
+    await readFrame(reader);
+
+    // A payload whose serialization throws a close-shaped TypeError, same
+    // as what Web Streams throws for enqueue-after-close: exercises the
+    // isCloseRelatedError(err) === true branch of write()'s catch, distinct
+    // from the `closed` flag's own early-return guard.
+    const payload = {
+      toJSON() {
+        throw new TypeError('The stream is closed');
+      },
+    };
+
+    getEmit().data(payload);
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('isCloseRelatedError classifies TypeErrors mentioning "closed" and nothing else', () => {
+    expect(isCloseRelatedError(new TypeError('The stream is closed'))).toBe(true);
+    expect(isCloseRelatedError(new TypeError('Invalid state: Controller is already closed'))).toBe(true);
+    expect(isCloseRelatedError(new TypeError('something unrelated'))).toBe(false);
+    expect(isCloseRelatedError(new Error('closed'))).toBe(false);
+    expect(isCloseRelatedError('not an error')).toBe(false);
+  });
+
+  it('logs and tears down on an unexpected (non-close) write failure', async () => {
+    const cleanup = mock(() => {});
+    const { res, ac, getEmit } = setup({ cleanup });
+    const reader = readerOf(res);
+    await readFrame(reader);
+
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    getEmit().data(circular);
+
+    expect(errorSpy).toHaveBeenCalledWith('Unexpected error during SSE enqueue:', expect.any(Error));
+    expect(cleanup).toHaveBeenCalledTimes(1);
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('logs but does not crash the stream when onStart itself rejects', async () => {
+    const ac = new AbortController();
+    const res = createSseStream(makeRequest(ac), {
+      onStart: async () => {
+        throw new Error('setup failed');
+      },
+    });
+    const reader = readerOf(res);
+
+    const body = await readAll(reader);
+
+    expect(body).toBe(': ok\n\n');
+    expect(errorSpy).toHaveBeenCalledWith('Unexpected error in SSE onStart handler:', expect.any(Error));
+  });
+});

--- a/src/lib/sse/__tests__/create-stats-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-stats-sse-handler.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
+import { createStatsSseHandler } from '../create-stats-sse-handler';
+
+mock.module('@/lib/auth/sse-auth', () => ({
+  authenticateSSE: mock(async () => ({ id: 1, role: 'admin' })),
+}));
+
+// Real server-init runs deploy recovery and DB shutdown hooks on import;
+// this handler only needs the dynamic import to resolve to a no-op.
+mock.module('@/lib/server-init', () => ({}));
+
+type StatsCallback = (rows: unknown[]) => void;
+type StatsErrorCallback = () => void;
+
+function setupStatsPollService() {
+  let capturedSendData: StatsCallback | null = null;
+  let capturedSendError: StatsErrorCallback | null = null;
+  const unsubscribe = mock(() => {});
+  const subscribe = mock((_source: string, sendData: StatsCallback, sendError?: StatsErrorCallback) => {
+    capturedSendData = sendData;
+    capturedSendError = sendError ?? null;
+    return unsubscribe;
+  });
+
+  mock.module('@/lib/database/subscription-service', () => ({
+    statsPollService: { subscribe },
+  }));
+
+  return {
+    subscribe,
+    unsubscribe,
+    sendRows: (rows: unknown[]) => capturedSendData?.(rows),
+    sendError: () => capturedSendError?.(),
+  };
+}
+
+function makeRequest(ac: AbortController): Request {
+  return new Request('http://localhost/', { signal: ac.signal });
+}
+
+function readerOf(res: Response): ReadableStreamDefaultReader<Uint8Array> {
+  if (!res.body) throw new Error('Response had no body');
+  return res.body.getReader();
+}
+
+async function readFrame(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
+  const { value, done } = await reader.read();
+  if (done) return '';
+  return new TextDecoder().decode(value);
+}
+
+/** Matches the macrotask flush used in create-sse-stream.test.ts: onStart's
+ * subscribe() call needs to resolve (and register cleanup) before an abort
+ * assertion can rely on it having happened. */
+function flushMicrotasks(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('createStatsSseHandler', () => {
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it('returns 401 when authenticateSSE returns null', async () => {
+    const { authenticateSSE } = require('@/lib/auth/sse-auth') as { authenticateSSE: ReturnType<typeof mock> };
+    authenticateSSE.mockImplementationOnce(async () => null);
+
+    const handler = createStatsSseHandler('docker');
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+
+    expect(res.status).toBe(401);
+    ac.abort();
+  });
+
+  it('subscribes to the given source and forwards rows as a data frame', async () => {
+    const { sendRows } = setupStatsPollService();
+    const handler = createStatsSseHandler('docker');
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+    expect(await readFrame(reader)).toBe(': ok\n\n');
+
+    sendRows([{ host: 'h1', time: '2026-01-01T00:00:00Z' }]);
+    expect(await readFrame(reader)).toBe('data: [{"host":"h1","time":"2026-01-01T00:00:00Z"}]\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('subscribes with the exact source string for each stats endpoint', async () => {
+    const { subscribe } = setupStatsPollService();
+    for (const source of ['docker', 'zfs', 'proxmox'] as const) {
+      const handler = createStatsSseHandler(source);
+      const ac = new AbortController();
+      await handler({ request: makeRequest(ac) });
+      ac.abort();
+    }
+
+    expect(subscribe.mock.calls.map((call) => call[0])).toEqual(['docker', 'zfs', 'proxmox']);
+  });
+
+  it('forwards the poll error callback as an "event: stats_error" frame with an empty payload', async () => {
+    const { sendError } = setupStatsPollService();
+    const handler = createStatsSseHandler('zfs');
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+    await readFrame(reader); // ": ok\n\n"
+
+    sendError();
+    expect(await readFrame(reader)).toBe('event: stats_error\ndata: {}\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('unsubscribes from the poll service when the request aborts', async () => {
+    const { unsubscribe } = setupStatsPollService();
+    const handler = createStatsSseHandler('docker');
+    const ac = new AbortController();
+
+    await handler({ request: makeRequest(ac) });
+    await flushMicrotasks();
+    ac.abort();
+    await flushMicrotasks();
+
+    expect(unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits the same stats_error frame and ends the stream when subscribe() throws synchronously', async () => {
+    const subscribe = mock(() => {
+      throw new Error('poll service unavailable');
+    });
+    mock.module('@/lib/database/subscription-service', () => ({
+      statsPollService: { subscribe },
+    }));
+
+    const handler = createStatsSseHandler('docker');
+    const ac = new AbortController();
+
+    const res = await handler({ request: makeRequest(ac) });
+    const reader = readerOf(res);
+
+    const decoder = new TextDecoder();
+    let body = '';
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      body += decoder.decode(value);
+    }
+
+    expect(body).toBe(': ok\n\nevent: stats_error\ndata: {}\n\n');
+
+    ac.abort();
+  });
+
+  it('carries the shared heartbeat cadence: a comment frame follows the initial flush on an idle stream', async () => {
+    const setSpy = spyOn(globalThis, 'setInterval');
+    setupStatsPollService();
+    const handler = createStatsSseHandler('docker');
+    const ac = new AbortController();
+
+    await handler({ request: makeRequest(ac) });
+
+    // StatsPollService only calls sendData when new rows exist, so before
+    // this handler routed through the shared primitive, an idle stream
+    // (worker down, no new rows) emitted nothing after ": ok\n\n" and hit
+    // the idle-timeout reconnect churn #323 was written to stop.
+    expect(setSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
+
+    setSpy.mockRestore();
+    ac.abort();
+  });
+});

--- a/src/lib/sse/__tests__/create-stats-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-stats-sse-handler.test.ts
@@ -5,8 +5,7 @@ mock.module('@/lib/auth/sse-auth', () => ({
   authenticateSSE: mock(async () => ({ id: 1, role: 'admin' })),
 }));
 
-// Real server-init runs deploy recovery and DB shutdown hooks on import;
-// this handler only needs the dynamic import to resolve to a no-op.
+// Real server-init runs deploy recovery and DB shutdown hooks on import; stub it to a no-op.
 mock.module('@/lib/server-init', () => ({}));
 
 type StatsCallback = (rows: unknown[]) => void;
@@ -49,9 +48,7 @@ async function readFrame(reader: ReadableStreamDefaultReader<Uint8Array>): Promi
   return new TextDecoder().decode(value);
 }
 
-/** Matches the macrotask flush used in create-sse-stream.test.ts: onStart's
- * subscribe() call needs to resolve (and register cleanup) before an abort
- * assertion can rely on it having happened. */
+/** Macrotask flush so onStart's subscribe() call resolves before an abort assertion relies on it. */
 function flushMicrotasks(): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, 0));
 }
@@ -172,10 +169,7 @@ describe('createStatsSseHandler', () => {
 
     await handler({ request: makeRequest(ac) });
 
-    // StatsPollService only calls sendData when new rows exist, so before
-    // this handler routed through the shared primitive, an idle stream
-    // (worker down, no new rows) emitted nothing after ": ok\n\n" and hit
-    // the idle-timeout reconnect churn #323 was written to stop.
+    // StatsPollService only calls sendData on new rows, so idle streams need the shared heartbeat.
     expect(setSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
 
     setSpy.mockRestore();

--- a/src/lib/sse/__tests__/create-stats-sse-handler.test.ts
+++ b/src/lib/sse/__tests__/create-stats-sse-handler.test.ts
@@ -14,10 +14,17 @@ type StatsErrorCallback = () => void;
 function setupStatsPollService() {
   let capturedSendData: StatsCallback | null = null;
   let capturedSendError: StatsErrorCallback | null = null;
-  const unsubscribe = mock(() => {});
+  let markSubscribed = () => {};
+  let markUnsubscribed = () => {};
+  // createStatsSseHandler subscribes inside the stream's async start(); tests wait on these
+  // to know when the subscription is live and when abort teardown has unsubscribed.
+  const subscribed = new Promise<void>((resolve) => { markSubscribed = resolve; });
+  const unsubscribed = new Promise<void>((resolve) => { markUnsubscribed = resolve; });
+  const unsubscribe = mock(() => markUnsubscribed());
   const subscribe = mock((_source: string, sendData: StatsCallback, sendError?: StatsErrorCallback) => {
     capturedSendData = sendData;
     capturedSendError = sendError ?? null;
+    markSubscribed();
     return unsubscribe;
   });
 
@@ -28,6 +35,8 @@ function setupStatsPollService() {
   return {
     subscribe,
     unsubscribe,
+    subscribed,
+    unsubscribed,
     sendRows: (rows: unknown[]) => capturedSendData?.(rows),
     sendError: () => capturedSendError?.(),
   };
@@ -46,11 +55,6 @@ async function readFrame(reader: ReadableStreamDefaultReader<Uint8Array>): Promi
   const { value, done } = await reader.read();
   if (done) return '';
   return new TextDecoder().decode(value);
-}
-
-/** Macrotask flush so onStart's subscribe() call resolves before an abort assertion relies on it. */
-function flushMicrotasks(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 describe('createStatsSseHandler', () => {
@@ -122,14 +126,14 @@ describe('createStatsSseHandler', () => {
   });
 
   it('unsubscribes from the poll service when the request aborts', async () => {
-    const { unsubscribe } = setupStatsPollService();
+    const { unsubscribe, subscribed, unsubscribed } = setupStatsPollService();
     const handler = createStatsSseHandler('docker');
     const ac = new AbortController();
 
     await handler({ request: makeRequest(ac) });
-    await flushMicrotasks();
+    await subscribed;
     ac.abort();
-    await flushMicrotasks();
+    await unsubscribed;
 
     expect(unsubscribe).toHaveBeenCalledTimes(1);
   });

--- a/src/lib/sse/create-broadcast-sse-handler.ts
+++ b/src/lib/sse/create-broadcast-sse-handler.ts
@@ -1,32 +1,17 @@
 import { createSseStream, isCloseRelatedError } from '@/lib/sse/create-sse-stream';
 
 /**
- * Factory for subscribe-based SSE route handlers.
- *
- * Covers the shape shared by `/api/docker-inventory`, `/api/stack-status`,
- * and `/api/settings`: authenticate, subscribe to a broadcast service, and
- * forward each event via a caller-provided serializer. Wire mechanics
- * (headers, flush, heartbeat, abort teardown) live in `createSseStream`.
+ * Factory for subscribe-based SSE route handlers (`/api/docker-inventory`,
+ * `/api/stack-status`, `/api/settings`). Wire mechanics live in `createSseStream`.
  */
 type Unsubscribe = () => void;
 
 export interface BroadcastSseHandlerOptions<Event> {
-  /**
-   * Called once per request. Responsible for any dynamic imports of
-   * server-only modules and for returning a subscribe function already
-   * bound to its broadcast service.
-   */
+  /** Called once per request; owns any dynamic imports and returns a subscribe fn bound to its broadcast service. */
   loadSubscribe: () => Promise<(cb: (event: Event) => void) => Unsubscribe>;
-  /**
-   * Produce the complete SSE frame, including any `data:` / `event:` prefixes
-   * and the trailing `\n\n`. Letting callers own the full frame lets them
-   * emit named SSE events when they need to.
-   */
+  /** Produces the complete SSE frame (including `data:`/`event:` prefixes and trailing `\n\n`). */
   serialize: (event: Event) => string;
-  /**
-   * Named SSE event emitted when `loadSubscribe()` rejects, so clients can
-   * surface the failure instead of silently stalling on an empty stream.
-   */
+  /** Named SSE event emitted when `loadSubscribe()` rejects. */
   errorEvent: string;
 }
 
@@ -52,17 +37,12 @@ export function createBroadcastSseHandler<Event>(
           );
           const message = err instanceof Error ? err.message : String(err);
           emit.event(options.errorEvent, { message });
-          // Subscribe is unrecoverable for this request: end the stream
-          // now rather than leaving it open with nothing left to send.
           emit.close();
           return;
         }
 
         return subscribe((event) => {
-          // `serialize` is caller-supplied and runs outside createSseStream's
-          // own enqueue try/catch (it produces the frame text, it doesn't
-          // enqueue it), so a throw here needs the same treatment an enqueue
-          // failure gets: swallow close races, log and tear down otherwise.
+          // serialize() runs outside createSseStream's enqueue try/catch, so mirror its error handling here.
           try {
             emit.raw(options.serialize(event));
           } catch (err) {

--- a/src/lib/sse/create-broadcast-sse-handler.ts
+++ b/src/lib/sse/create-broadcast-sse-handler.ts
@@ -1,25 +1,14 @@
+import { createSseStream, isCloseRelatedError } from '@/lib/sse/create-sse-stream';
+
 /**
  * Factory for subscribe-based SSE route handlers.
  *
  * Covers the shape shared by `/api/docker-inventory`, `/api/stack-status`,
- * and `/api/settings`: open a stream, emit a heartbeat comment, subscribe to
- * a broadcast service, forward each event via a caller-provided serializer,
- * and tear down on request abort or enqueue failure.
- *
- * The heartbeat (`: ok\n\n`) forces Nitro to flush response headers
- * immediately so clients don't stall waiting for the first byte.
+ * and `/api/settings`: authenticate, subscribe to a broadcast service, and
+ * forward each event via a caller-provided serializer. Wire mechanics
+ * (headers, flush, heartbeat, abort teardown) live in `createSseStream`.
  */
 type Unsubscribe = () => void;
-
-// These streams only emit when their broadcast source changes (a settings write,
-// a container state change), so a quiet homelab leaves them silent well past the
-// idle timeout of the runtime (Bun's HTTP default is 10s) and any reverse proxy.
-// Without traffic the socket is dropped, the browser's EventSource reconnects,
-// and the churn of short-lived streams trips Caddy's (Go net/http2) rapid-reset
-// protection, which GOAWAYs the whole HTTP/2 connection: every multiplexed
-// request dies at once. A comment heartbeat keeps the stream warm. 5s stays
-// under typical Bun/proxy idle defaults; mirrors the agent's logs route.
-const HEARTBEAT_INTERVAL_MS = 5_000;
 
 export interface BroadcastSseHandlerOptions<Event> {
   /**
@@ -41,10 +30,6 @@ export interface BroadcastSseHandlerOptions<Event> {
   errorEvent: string;
 }
 
-function isCloseRelatedError(err: unknown): boolean {
-  return err instanceof TypeError && /closed/i.test(err.message);
-}
-
 export function createBroadcastSseHandler<Event>(
   options: BroadcastSseHandlerOptions<Event>,
 ) {
@@ -55,41 +40,8 @@ export function createBroadcastSseHandler<Event>(
       return new Response('Unauthorized', { status: 401 });
     }
 
-    const encoder = new TextEncoder();
-    let closed = false;
-
-    const stream = new ReadableStream({
-      async start(controller) {
-        controller.enqueue(encoder.encode(': ok\n\n'));
-
-        let unsubscribe: Unsubscribe = () => {};
-        let heartbeat: ReturnType<typeof setInterval> | null = null;
-
-        const teardown = () => {
-          if (closed) return;
-          closed = true;
-          if (heartbeat !== null) {
-            clearInterval(heartbeat);
-            heartbeat = null;
-          }
-          unsubscribe();
-          try {
-            controller.close();
-          } catch {}
-        };
-
-        const sendEvent = (event: Event) => {
-          if (closed) return;
-          try {
-            controller.enqueue(encoder.encode(options.serialize(event)));
-          } catch (err) {
-            if (!isCloseRelatedError(err)) {
-              console.error('Unexpected error during SSE enqueue:', err);
-            }
-            teardown();
-          }
-        };
-
+    return createSseStream(request, {
+      onStart: async (emit) => {
         let subscribe: (cb: (event: Event) => void) => Unsubscribe;
         try {
           subscribe = await options.loadSubscribe();
@@ -99,51 +51,27 @@ export function createBroadcastSseHandler<Event>(
             err,
           );
           const message = err instanceof Error ? err.message : String(err);
-          try {
-            controller.enqueue(
-              encoder.encode(
-                `event: ${options.errorEvent}\ndata: ${JSON.stringify({ message })}\n\n`,
-              ),
-            );
-          } catch {}
-          closed = true;
-          try {
-            controller.close();
-          } catch {}
+          emit.event(options.errorEvent, { message });
+          // Subscribe is unrecoverable for this request: end the stream
+          // now rather than leaving it open with nothing left to send.
+          emit.close();
           return;
         }
 
-        unsubscribe = subscribe(sendEvent);
-
-        heartbeat = setInterval(() => {
-          if (closed) {
-            clearInterval(heartbeat!);
-            heartbeat = null;
-            return;
-          }
+        return subscribe((event) => {
+          // `serialize` is caller-supplied and runs outside createSseStream's
+          // own enqueue try/catch (it produces the frame text, it doesn't
+          // enqueue it), so a throw here needs the same treatment an enqueue
+          // failure gets: swallow close races, log and tear down otherwise.
           try {
-            controller.enqueue(encoder.encode(':\n\n'));
+            emit.raw(options.serialize(event));
           } catch (err) {
             if (!isCloseRelatedError(err)) {
-              console.error('Unexpected error during SSE heartbeat:', err);
+              console.error('Unexpected error during SSE enqueue:', err);
             }
-            teardown();
+            emit.close();
           }
-        }, HEARTBEAT_INTERVAL_MS);
-
-        request.signal.addEventListener('abort', teardown);
-        // If the client disconnected during the awaits above, the abort event
-        // already fired and the listener will never run; tear down now so the
-        // subscription doesn't leak.
-        if (request.signal.aborted) teardown();
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        Connection: 'keep-alive',
+        });
       },
     });
   };

--- a/src/lib/sse/create-sse-stream.ts
+++ b/src/lib/sse/create-sse-stream.ts
@@ -1,0 +1,168 @@
+/**
+ * Single owner of the SSE wire protocol: response headers, the initial
+ * flush comment, heartbeat cadence, `data:`/`event:` frame grammar, and
+ * abort/enqueue-failure teardown. Every SSE route (stats polling,
+ * broadcast subscriptions, the docker-logs proxy) builds its `Response`
+ * through this primitive so those wire facts exist in exactly one place
+ * instead of being re-derived per adapter.
+ *
+ * This module only touches Web Streams / Fetch APIs, so it is safe to
+ * import statically from route files; server-only work (auth, DB, agent
+ * fetches) stays in the caller's `onStart`.
+ */
+
+// A quiet stream (no rows, no broadcast event) stays silent past the idle
+// timeout of the runtime (Bun's HTTP default is 10s) and any reverse proxy.
+// Without traffic the socket drops, the browser's EventSource reconnects,
+// and the resulting churn of short-lived streams can trip a proxy's
+// rapid-reset protection (e.g. Caddy/Go net/http2, post CVE-2023-44487),
+// which GOAWAYs the whole HTTP/2 connection: every multiplexed request on
+// it dies at once. A `:\n\n` comment every 5s keeps every stream this
+// primitive builds under typical idle defaults, regardless of whether the
+// underlying source (poll, broadcast, agent proxy) ever emits real data.
+const DEFAULT_HEARTBEAT_MS = 5000;
+
+/** Frame-writing surface handed to `onStart`; no caller writes `\n\n` or `data: ` by hand. */
+export interface SseEmitter {
+  /** Writes a `data: <JSON>\n\n` frame. */
+  data(payload: unknown): void;
+  /** Writes an `event: <name>\ndata: <JSON>\n\n` frame. */
+  event(name: string, payload: unknown): void;
+  /**
+   * Writes a chunk verbatim, bypassing JSON encoding. Covers two cases
+   * that don't fit `data`/`event`: a caller-owned pre-formatted frame
+   * string (a serializer that already returns the full `data: ...\n\n`
+   * text), and raw bytes piped through from an upstream SSE source (the
+   * docker-logs proxy forwards the agent's already-framed stream as-is).
+   */
+  raw(chunk: string | Uint8Array): void;
+  /**
+   * Ends the stream immediately (clears the heartbeat, runs any
+   * `onStart` cleanup, closes the controller). Use when a stream can't
+   * recover from a setup failure and should not sit open heartbeating
+   * with nothing left to deliver, e.g. broadcast subscribe failing.
+   */
+  close(): void;
+}
+
+export type SseCleanup = () => void;
+
+export type SseOnStart = (
+  emit: SseEmitter,
+  signal: AbortSignal,
+) => void | SseCleanup | Promise<void | SseCleanup>;
+
+export interface CreateSseStreamOptions {
+  /**
+   * Called once per request after the initial flush and heartbeat are
+   * armed. May return (or resolve to) a cleanup function; it runs
+   * exactly once, whenever the stream tears down, regardless of whether
+   * that happens before or after `onStart` itself resolves.
+   */
+  onStart: SseOnStart;
+  /** Heartbeat cadence in ms. Defaults to 5000, matching the broadcast idle-timeout fix (#323). */
+  heartbeatMs?: number;
+}
+
+/**
+ * True for the TypeError Web Streams throws when enqueue/close race a
+ * teardown that already closed the controller. Exported so adapters that
+ * do their own work inside a subscribe callback (running a caller-supplied
+ * serializer, say) can apply the same "don't log, just tear down" rule to
+ * errors that never reach the primitive's own enqueue path.
+ */
+export function isCloseRelatedError(err: unknown): boolean {
+  return err instanceof TypeError && /closed/i.test(err.message);
+}
+
+export function createSseStream(request: Request, opts: CreateSseStreamOptions): Response {
+  const { onStart, heartbeatMs = DEFAULT_HEARTBEAT_MS } = opts;
+  const encoder = new TextEncoder();
+  let closed = false;
+  let cleanup: SseCleanup | undefined;
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      let heartbeatTimer: ReturnType<typeof setInterval> | undefined;
+
+      const teardown = () => {
+        if (closed) return;
+        closed = true;
+        if (heartbeatTimer) clearInterval(heartbeatTimer);
+        cleanup?.();
+        try {
+          controller.close();
+        } catch {
+          // Already closed.
+        }
+      };
+
+      // `build` is deferred (not a plain string) so that a payload which
+      // fails to JSON.stringify (circular reference, BigInt) is caught by
+      // the same try/catch as an enqueue failure, instead of throwing
+      // synchronously out of `emit.data`/`emit.event` before this runs.
+      const write = (build: () => string | Uint8Array) => {
+        if (closed) return;
+        try {
+          const value = build();
+          controller.enqueue(typeof value === 'string' ? encoder.encode(value) : value);
+        } catch (err) {
+          if (!isCloseRelatedError(err)) {
+            console.error('Unexpected error during SSE enqueue:', err);
+          }
+          teardown();
+        }
+      };
+
+      const emit: SseEmitter = {
+        data: (payload) => write(() => `data: ${JSON.stringify(payload)}\n\n`),
+        event: (name, payload) => write(() => `event: ${name}\ndata: ${JSON.stringify(payload)}\n\n`),
+        raw: (chunk) => write(() => chunk),
+        close: teardown,
+      };
+
+      // Forces the runtime to flush response headers immediately so
+      // clients don't stall waiting for the first byte.
+      write(() => ': ok\n\n');
+      heartbeatTimer = setInterval(() => write(() => ':\n\n'), heartbeatMs);
+
+      // Registered before `onStart` runs so an abort during its (possibly
+      // slow, dynamic-import-laden) setup tears the stream down right
+      // away instead of waiting on setup to finish first.
+      request.signal.addEventListener('abort', teardown);
+
+      let result: void | SseCleanup = undefined;
+      try {
+        result = await onStart(emit, request.signal);
+      } catch (err) {
+        console.error('Unexpected error in SSE onStart handler:', err);
+        // Setup itself failed: nothing will ever call emit again, so leaving
+        // the stream open would just heartbeat forever with no payload
+        // ever following. End it now instead.
+        teardown();
+      }
+
+      if (closed) {
+        // Teardown already ran while onStart was still setting up (abort,
+        // or onStart called emit.close() itself); run its cleanup now
+        // since the teardown that already fired couldn't have known
+        // about it yet.
+        result?.();
+      } else {
+        cleanup = result ?? undefined;
+        // onStart can resolve after the request aborted mid-setup;
+        // recheck so that race doesn't leak a subscription past
+        // client disconnect.
+        if (request.signal.aborted) teardown();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    },
+  });
+}

--- a/src/lib/sse/create-sse-stream.ts
+++ b/src/lib/sse/create-sse-stream.ts
@@ -1,25 +1,15 @@
 /**
- * Single owner of the SSE wire protocol: response headers, the initial
- * flush comment, heartbeat cadence, `data:`/`event:` frame grammar, and
- * abort/enqueue-failure teardown. Every SSE route (stats polling,
- * broadcast subscriptions, the docker-logs proxy) builds its `Response`
- * through this primitive so those wire facts exist in exactly one place
- * instead of being re-derived per adapter.
+ * Single owner of the SSE wire protocol: headers, initial flush, heartbeat,
+ * `data:`/`event:` frame grammar, and abort/enqueue-failure teardown. Every
+ * SSE route builds its `Response` through this so those facts live in one
+ * place instead of being re-derived per adapter.
  *
- * This module only touches Web Streams / Fetch APIs, so it is safe to
- * import statically from route files; server-only work (auth, DB, agent
- * fetches) stays in the caller's `onStart`.
+ * Import-safe for route files (Web Streams/Fetch only); server-only work
+ * (auth, DB, agent fetches) stays in the caller's `onStart`.
  */
 
-// A quiet stream (no rows, no broadcast event) stays silent past the idle
-// timeout of the runtime (Bun's HTTP default is 10s) and any reverse proxy.
-// Without traffic the socket drops, the browser's EventSource reconnects,
-// and the resulting churn of short-lived streams can trip a proxy's
-// rapid-reset protection (e.g. Caddy/Go net/http2, post CVE-2023-44487),
-// which GOAWAYs the whole HTTP/2 connection: every multiplexed request on
-// it dies at once. A `:\n\n` comment every 5s keeps every stream this
-// primitive builds under typical idle defaults, regardless of whether the
-// underlying source (poll, broadcast, agent proxy) ever emits real data.
+// Quiet streams go silent past idle timeouts (runtime, reverse proxy),
+// causing EventSource reconnect churn; a periodic comment keeps them warm.
 const DEFAULT_HEARTBEAT_MS = 5000;
 
 /** Frame-writing surface handed to `onStart`; no caller writes `\n\n` or `data: ` by hand. */
@@ -28,20 +18,9 @@ export interface SseEmitter {
   data(payload: unknown): void;
   /** Writes an `event: <name>\ndata: <JSON>\n\n` frame. */
   event(name: string, payload: unknown): void;
-  /**
-   * Writes a chunk verbatim, bypassing JSON encoding. Covers two cases
-   * that don't fit `data`/`event`: a caller-owned pre-formatted frame
-   * string (a serializer that already returns the full `data: ...\n\n`
-   * text), and raw bytes piped through from an upstream SSE source (the
-   * docker-logs proxy forwards the agent's already-framed stream as-is).
-   */
+  /** Writes a chunk verbatim (a pre-formatted frame string, or raw bytes piped from an upstream SSE source). */
   raw(chunk: string | Uint8Array): void;
-  /**
-   * Ends the stream immediately (clears the heartbeat, runs any
-   * `onStart` cleanup, closes the controller). Use when a stream can't
-   * recover from a setup failure and should not sit open heartbeating
-   * with nothing left to deliver, e.g. broadcast subscribe failing.
-   */
+  /** Ends the stream now (clears heartbeat, runs `onStart` cleanup, closes controller). */
   close(): void;
 }
 
@@ -53,24 +32,13 @@ export type SseOnStart = (
 ) => void | SseCleanup | Promise<void | SseCleanup>;
 
 export interface CreateSseStreamOptions {
-  /**
-   * Called once per request after the initial flush and heartbeat are
-   * armed. May return (or resolve to) a cleanup function; it runs
-   * exactly once, whenever the stream tears down, regardless of whether
-   * that happens before or after `onStart` itself resolves.
-   */
+  /** Called once per request after the flush and heartbeat are armed. May return a cleanup, run once at teardown. */
   onStart: SseOnStart;
-  /** Heartbeat cadence in ms. Defaults to 5000, matching the broadcast idle-timeout fix (#323). */
+  /** Heartbeat cadence in ms. Defaults to 5000. */
   heartbeatMs?: number;
 }
 
-/**
- * True for the TypeError Web Streams throws when enqueue/close race a
- * teardown that already closed the controller. Exported so adapters that
- * do their own work inside a subscribe callback (running a caller-supplied
- * serializer, say) can apply the same "don't log, just tear down" rule to
- * errors that never reach the primitive's own enqueue path.
- */
+/** True for the TypeError Web Streams throws on enqueue/close after the controller already closed. */
 export function isCloseRelatedError(err: unknown): boolean {
   return err instanceof TypeError && /closed/i.test(err.message);
 }
@@ -92,15 +60,10 @@ export function createSseStream(request: Request, opts: CreateSseStreamOptions):
         cleanup?.();
         try {
           controller.close();
-        } catch {
-          // Already closed.
-        }
+        } catch {}
       };
 
-      // `build` is deferred (not a plain string) so that a payload which
-      // fails to JSON.stringify (circular reference, BigInt) is caught by
-      // the same try/catch as an enqueue failure, instead of throwing
-      // synchronously out of `emit.data`/`emit.event` before this runs.
+      // Deferred build lets a JSON.stringify failure (circular ref, BigInt) hit the same catch as an enqueue failure.
       const write = (build: () => string | Uint8Array) => {
         if (closed) return;
         try {
@@ -121,14 +84,11 @@ export function createSseStream(request: Request, opts: CreateSseStreamOptions):
         close: teardown,
       };
 
-      // Forces the runtime to flush response headers immediately so
-      // clients don't stall waiting for the first byte.
+      // Flushes response headers immediately so clients don't stall on the first byte.
       write(() => ': ok\n\n');
       heartbeatTimer = setInterval(() => write(() => ':\n\n'), heartbeatMs);
 
-      // Registered before `onStart` runs so an abort during its (possibly
-      // slow, dynamic-import-laden) setup tears the stream down right
-      // away instead of waiting on setup to finish first.
+      // Registered before onStart so an abort mid-setup tears down right away.
       request.signal.addEventListener('abort', teardown);
 
       let result: void | SseCleanup = undefined;
@@ -136,23 +96,15 @@ export function createSseStream(request: Request, opts: CreateSseStreamOptions):
         result = await onStart(emit, request.signal);
       } catch (err) {
         console.error('Unexpected error in SSE onStart handler:', err);
-        // Setup itself failed: nothing will ever call emit again, so leaving
-        // the stream open would just heartbeat forever with no payload
-        // ever following. End it now instead.
         teardown();
       }
 
       if (closed) {
-        // Teardown already ran while onStart was still setting up (abort,
-        // or onStart called emit.close() itself); run its cleanup now
-        // since the teardown that already fired couldn't have known
-        // about it yet.
+        // Teardown already ran mid-setup (abort, or onStart called emit.close()); run its cleanup now.
         result?.();
       } else {
         cleanup = result ?? undefined;
-        // onStart can resolve after the request aborted mid-setup;
-        // recheck so that race doesn't leak a subscription past
-        // client disconnect.
+        // onStart can resolve after an abort mid-setup; recheck so a subscription doesn't leak past disconnect.
         if (request.signal.aborted) teardown();
       }
     },

--- a/src/lib/sse/create-stats-sse-handler.ts
+++ b/src/lib/sse/create-stats-sse-handler.ts
@@ -2,13 +2,9 @@ import { createSseStream } from '@/lib/sse/create-sse-stream';
 import type { StatsSource } from '@/lib/database/subscription-service';
 
 /**
- * Factory for stats SSE route handlers.
- * All three stats endpoints (docker, zfs, proxmox) share identical logic;
- * only the source string differs. Wire mechanics (headers, flush,
- * heartbeat, abort teardown) live in `createSseStream`; StatsPollService
- * only pushes rows when it has new ones, so before the shared heartbeat
- * this stream stayed silent (past idle timeouts) whenever the worker was
- * down.
+ * Factory for stats SSE route handlers (docker, zfs, proxmox share this; only the source differs).
+ * StatsPollService only pushes on new rows, so the shared `createSseStream` heartbeat is what
+ * keeps this stream alive when the worker is down and nothing new ever arrives.
  */
 export function createStatsSseHandler(source: StatsSource) {
   return async ({ request }: { request: Request }) => {
@@ -32,8 +28,6 @@ export function createStatsSseHandler(source: StatsSource) {
             () => emit.event('stats_error', {}),
           );
         } catch {
-          // Subscribe is unrecoverable for this request: end the stream
-          // now rather than leaving it open with nothing left to send.
           emit.event('stats_error', {});
           emit.close();
         }

--- a/src/lib/sse/create-stats-sse-handler.ts
+++ b/src/lib/sse/create-stats-sse-handler.ts
@@ -1,9 +1,14 @@
+import { createSseStream } from '@/lib/sse/create-sse-stream';
 import type { StatsSource } from '@/lib/database/subscription-service';
 
 /**
  * Factory for stats SSE route handlers.
  * All three stats endpoints (docker, zfs, proxmox) share identical logic;
- * only the source string differs.
+ * only the source string differs. Wire mechanics (headers, flush,
+ * heartbeat, abort teardown) live in `createSseStream`; StatsPollService
+ * only pushes rows when it has new ones, so before the shared heartbeat
+ * this stream stayed silent (past idle timeouts) whenever the worker was
+ * down.
  */
 export function createStatsSseHandler(source: StatsSource) {
   return async ({ request }: { request: Request }) => {
@@ -18,70 +23,20 @@ export function createStatsSseHandler(source: StatsSource) {
       '@/lib/database/subscription-service'
     );
 
-    const encoder = new TextEncoder();
-    let closed = false;
-
-    const stream = new ReadableStream({
-      start(controller) {
-        // SSE heartbeat forces Nitro to flush response headers immediately
-        controller.enqueue(encoder.encode(': ok\n\n'));
-
-        let unsubscribe: () => void = () => {};
-
-        // Tear down polling + close the stream once the consumer is gone
-        // (either via request abort, or because controller.enqueue threw).
-        const teardown = () => {
-          if (closed) return;
-          closed = true;
-          unsubscribe();
-          try {
-            controller.close();
-          } catch {
-            // Already closed
-          }
-        };
-
-        const sendData = (rows: unknown[]) => {
-          if (closed) return;
-          try {
-            const message = `data: ${JSON.stringify(rows)}\n\n`;
-            controller.enqueue(encoder.encode(message));
-          } catch {
-            teardown();
-          }
-        };
-
-        const sendError = () => {
-          if (closed) return;
-          try {
-            controller.enqueue(encoder.encode(`event: stats_error\ndata: {}\n\n`));
-          } catch {
-            teardown();
-          }
-        };
-
+    return createSseStream(request, {
+      onStart: (emit) => {
         try {
-          unsubscribe = statsPollService.subscribe(source, sendData, sendError);
+          return statsPollService.subscribe(
+            source,
+            (rows) => emit.data(rows),
+            () => emit.event('stats_error', {}),
+          );
         } catch {
-          sendError();
-          closed = true;
-          try { controller.close(); } catch { /* already closed */ }
-          return;
+          // Subscribe is unrecoverable for this request: end the stream
+          // now rather than leaving it open with nothing left to send.
+          emit.event('stats_error', {});
+          emit.close();
         }
-
-        request.signal.addEventListener('abort', teardown);
-        // If the client disconnected during the awaits above, the abort event
-        // already fired and the listener will never run; tear down now so the
-        // subscription doesn't leak.
-        if (request.signal.aborted) teardown();
-      },
-    });
-
-    return new Response(stream, {
-      headers: {
-        'Content-Type': 'text/event-stream',
-        'Cache-Control': 'no-cache',
-        Connection: 'keep-alive',
       },
     });
   };

--- a/src/routes/api/__tests__/docker-logs.$containerId.test.ts
+++ b/src/routes/api/__tests__/docker-logs.$containerId.test.ts
@@ -44,8 +44,7 @@ mock.module('@/lib/crypto/agent-jwt', () => ({
   signAgentJwt: mock(async () => 'signed.jwt.token'),
 }));
 
-// Imported after the mocks above so the route's dynamic imports resolve to
-// the mocked modules instead of hitting a real database or agent.
+// Imported after the mocks above so the route's dynamic imports resolve to them.
 const { Route } = await import('@/routes/api/docker-logs.$containerId');
 
 type RouteHandler = (args: { request: Request; params: { containerId: string } }) => Promise<Response>;
@@ -192,9 +191,6 @@ describe('GET /api/docker-logs/$containerId', () => {
       params: { containerId: 'c1' },
     });
 
-    // Before routing through createSseStream, this route had no heartbeat
-    // of its own: a quiet container's log stream would sit silent past
-    // idle timeouts, same failure mode #323 fixed for broadcast streams.
     expect(setSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
 
     setSpy.mockRestore();

--- a/src/routes/api/__tests__/docker-logs.$containerId.test.ts
+++ b/src/routes/api/__tests__/docker-logs.$containerId.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
+
+mock.module('@/lib/auth/sse-auth', () => ({
+  authenticateSSE: mock(async () => ({ id: 1, role: 'admin' })),
+}));
+
+mock.module('@/lib/clients/database-client', () => ({
+  databaseConnectionManager: {
+    getClient: mock(async () => ({ getPool: () => ({}) })),
+  },
+}));
+
+mock.module('@/lib/config/database-config', () => ({
+  loadDatabaseConfig: mock(() => ({})),
+}));
+
+interface FakeManagedHost {
+  id: number;
+  name: string;
+  agentUrl: string;
+}
+
+const findByName = mock(async (_name: string): Promise<FakeManagedHost | null> => ({
+  id: 1,
+  name: 'host1',
+  agentUrl: 'https://agent.example/api',
+}));
+
+mock.module('@/lib/database/repositories/host-repository', () => ({
+  HostRepository: mock().mockImplementation(() => ({ findByName })),
+}));
+
+const getPrivateKeyForHost = mock(async (_hostName: string): Promise<CryptoKey | null> => ({}) as CryptoKey);
+
+mock.module('@/lib/database/repositories/agent-keypairs-repository', () => ({
+  AgentKeypairsRepository: mock().mockImplementation(() => ({ getPrivateKeyForHost })),
+}));
+
+mock.module('@/lib/crypto/master-key', () => ({
+  loadMasterKeyring: mock(async () => ({})),
+}));
+
+mock.module('@/lib/crypto/agent-jwt', () => ({
+  signAgentJwt: mock(async () => 'signed.jwt.token'),
+}));
+
+// Imported after the mocks above so the route's dynamic imports resolve to
+// the mocked modules instead of hitting a real database or agent.
+const { Route } = await import('@/routes/api/docker-logs.$containerId');
+
+type RouteHandler = (args: { request: Request; params: { containerId: string } }) => Promise<Response>;
+
+function getHandler(): RouteHandler {
+  const handlers = Route.options.server!.handlers as unknown as { GET: RouteHandler };
+  return handlers.GET;
+}
+
+function makeRequest(url: string, ac: AbortController): Request {
+  return new Request(url, { signal: ac.signal });
+}
+
+function readerOf(res: Response): ReadableStreamDefaultReader<Uint8Array> {
+  if (!res.body) throw new Error('Response had no body');
+  return res.body.getReader();
+}
+
+async function readFrame(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<string> {
+  const { value, done } = await reader.read();
+  if (done) return '';
+  return new TextDecoder().decode(value);
+}
+
+/** A ReadableStream standing in for the agent's already-framed SSE log body. */
+function agentBodyStream(chunks: string[]): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  let i = 0;
+  return new ReadableStream({
+    pull(controller) {
+      if (i >= chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(encoder.encode(chunks[i]));
+      i += 1;
+    },
+  });
+}
+
+describe('GET /api/docker-logs/$containerId', () => {
+  let fetchSpy: ReturnType<typeof spyOn>;
+  let errorSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    errorSpy = spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    fetchSpy?.mockRestore();
+    errorSpy.mockRestore();
+    findByName.mockClear();
+    getPrivateKeyForHost.mockClear();
+  });
+
+  it('returns 401 when authenticateSSE returns null', async () => {
+    const { authenticateSSE } = require('@/lib/auth/sse-auth') as { authenticateSSE: ReturnType<typeof mock> };
+    authenticateSSE.mockImplementationOnce(async () => null);
+
+    const ac = new AbortController();
+    const res = await getHandler()({
+      request: makeRequest('http://localhost/api/docker-logs/c1?host=host1', ac),
+      params: { containerId: 'c1' },
+    });
+
+    expect(res.status).toBe(401);
+    ac.abort();
+  });
+
+  it('returns 400 when the host query parameter is missing', async () => {
+    const ac = new AbortController();
+    const res = await getHandler()({
+      request: makeRequest('http://localhost/api/docker-logs/c1', ac),
+      params: { containerId: 'c1' },
+    });
+
+    expect(res.status).toBe(400);
+    ac.abort();
+  });
+
+  it('returns 404 when the host is unknown', async () => {
+    findByName.mockImplementationOnce(async () => null);
+
+    const ac = new AbortController();
+    const res = await getHandler()({
+      request: makeRequest('http://localhost/api/docker-logs/c1?host=ghost', ac),
+      params: { containerId: 'c1' },
+    });
+
+    expect(res.status).toBe(404);
+    ac.abort();
+  });
+
+  it('returns 503 when no agent keypair exists for the host', async () => {
+    getPrivateKeyForHost.mockImplementationOnce(async () => null);
+
+    const ac = new AbortController();
+    const res = await getHandler()({
+      request: makeRequest('http://localhost/api/docker-logs/c1?host=host1', ac),
+      params: { containerId: 'c1' },
+    });
+
+    expect(res.status).toBe(503);
+    ac.abort();
+  });
+
+  it('pipes the agent body through with the standard SSE headers and the ": ok" flush first', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(agentBodyStream(['data: log line 1\n\n', 'data: log line 2\n\n']), {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      }),
+    );
+
+    const ac = new AbortController();
+    const res = await getHandler()({
+      request: makeRequest('http://localhost/api/docker-logs/c1?host=host1', ac),
+      params: { containerId: 'c1' },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/event-stream');
+    expect(res.headers.get('Cache-Control')).toBe('no-cache');
+    expect(res.headers.get('Connection')).toBe('keep-alive');
+
+    const reader = readerOf(res);
+    expect(await readFrame(reader)).toBe(': ok\n\n');
+    expect(await readFrame(reader)).toBe('data: log line 1\n\n');
+    expect(await readFrame(reader)).toBe('data: log line 2\n\n');
+
+    ac.abort();
+    reader.cancel();
+  });
+
+  it('carries the shared heartbeat cadence so a quiet log stream does not go idle', async () => {
+    const setSpy = spyOn(globalThis, 'setInterval');
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(agentBodyStream([]), { status: 200, headers: { 'Content-Type': 'text/event-stream' } }),
+    );
+
+    const ac = new AbortController();
+    await getHandler()({
+      request: makeRequest('http://localhost/api/docker-logs/c1?host=host1', ac),
+      params: { containerId: 'c1' },
+    });
+
+    // Before routing through createSseStream, this route had no heartbeat
+    // of its own: a quiet container's log stream would sit silent past
+    // idle timeouts, same failure mode #323 fixed for broadcast streams.
+    expect(setSpy).toHaveBeenCalledWith(expect.any(Function), 5000);
+
+    setSpy.mockRestore();
+    ac.abort();
+  });
+
+  it('returns 502 for an opaque agent redirect', async () => {
+    // Simulates what `redirect: 'manual'` produces when the agent issues a redirect.
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      { type: 'opaqueredirect', status: 0, ok: false, body: null } as unknown as Response,
+    );
+
+    const ac = new AbortController();
+    const res = await getHandler()({
+      request: makeRequest('http://localhost/api/docker-logs/c1?host=host1', ac),
+      params: { containerId: 'c1' },
+    });
+
+    expect(res.status).toBe(502);
+    ac.abort();
+  });
+
+  it('forwards the agent status and body text when the agent request fails', async () => {
+    fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('agent said no', { status: 500 }),
+    );
+
+    const ac = new AbortController();
+    const res = await getHandler()({
+      request: makeRequest('http://localhost/api/docker-logs/c1?host=host1', ac),
+      params: { containerId: 'c1' },
+    });
+
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe('agent said no');
+    ac.abort();
+  });
+});

--- a/src/routes/api/docker-logs.$containerId.ts
+++ b/src/routes/api/docker-logs.$containerId.ts
@@ -59,10 +59,7 @@ export const Route = createFileRoute('/api/docker-logs/$containerId')({
           return new Response(msg, { status: agentResponse.status });
         }
 
-        // Pipe the agent's already-framed SSE bytes straight through.
-        // request.signal was already handed to fetch() above, so an abort
-        // aborts the agent connection and rejects the pending read below;
-        // createSseStream's own abort listener handles the rest.
+        // Pipe the agent's already-framed SSE bytes through; request.signal was passed to fetch() above, so abort propagates.
         const agentBody = agentResponse.body;
 
         return createSseStream(request, {

--- a/src/routes/api/docker-logs.$containerId.ts
+++ b/src/routes/api/docker-logs.$containerId.ts
@@ -1,4 +1,5 @@
 import { createFileRoute } from '@tanstack/react-router';
+import { createSseStream } from '@/lib/sse/create-sse-stream';
 
 export const Route = createFileRoute('/api/docker-logs/$containerId')({
   server: {
@@ -58,45 +59,26 @@ export const Route = createFileRoute('/api/docker-logs/$containerId')({
           return new Response(msg, { status: agentResponse.status });
         }
 
-        // Pipe through a local stream so we can send an initial SSE comment
-        // that forces Nitro to flush response headers immediately.
+        // Pipe the agent's already-framed SSE bytes straight through.
+        // request.signal was already handed to fetch() above, so an abort
+        // aborts the agent connection and rejects the pending read below;
+        // createSseStream's own abort listener handles the rest.
         const agentBody = agentResponse.body;
-        const encoder = new TextEncoder();
-        let closed = false;
 
-        const stream = new ReadableStream({
-          async start(controller) {
-            controller.enqueue(encoder.encode(': ok\n\n'));
-
-            request.signal.addEventListener('abort', () => {
-              closed = true;
-              try { controller.close(); } catch { /* already closed */ }
-            });
-
+        return createSseStream(request, {
+          onStart: async (emit, signal) => {
             const reader = agentBody.getReader();
             try {
               for (;;) {
                 const { done, value } = await reader.read();
-                if (done || closed) break;
-                controller.enqueue(value);
+                if (done || signal.aborted) break;
+                emit.raw(value);
               }
             } catch {
-              // Agent stream errored or client disconnected
+              // Agent stream errored or client disconnected.
             } finally {
               reader.releaseLock();
-              if (!closed) {
-                closed = true;
-                try { controller.close(); } catch { /* already closed */ }
-              }
             }
-          },
-        });
-
-        return new Response(stream, {
-          headers: {
-            'Content-Type': 'text/event-stream',
-            'Cache-Control': 'no-cache',
-            Connection: 'keep-alive',
           },
         });
       },


### PR DESCRIPTION
## What changed

One deep server-side SSE primitive, `createSseStream` (`src/lib/sse/create-sse-stream.ts`), now owns every wire-protocol fact: response headers, the `: ok` flush, heartbeat cadence (default 5000ms, started for every stream), `data:`/`event:` frame serialization via an `SseEmitter`, the `closed` flag, enqueue/serialize-failure teardown, the abort listener, and the post-await abort recheck. The stats factory, broadcast factory, and the docker-logs proxy route are now thin adapters over it.

`StatsPollService` gains an injected-deps constructor (`loadRows`) matching the broadcast-service pattern; production wiring keeps the exported singleton.

## How each acceptance criterion is met

- **All wire facts in one file.** `: ok` flush, heartbeat, `text/event-stream` headers, frame grammar, error-frame construction, and abort teardown live only in `create-sse-stream.ts`. `grep setInterval` across the two adapters and the docker-logs route (non-test) returns zero hits; the sole `setInterval` is in the primitive.
- **Stats + docker-logs now heartbeat at the broadcast cadence.** All three route through the primitive's default 5000ms; tests assert `setInterval(..., 5000)` for stats, broadcast, and docker-logs.
- **One wire-protocol test suite** (`create-sse-stream.test.ts`, 18 tests: headers, flush, heartbeat cadence, frame bytes, abort teardown incl. the onStart-resolves-after-abort race, enqueue/serialize-failure classification). The previously untested stats handler (7) and docker-logs route (8) now have thin-adapter suites.
- **`StatsPollService` tests inject fakes** via `loadRows` instead of `spyOn(databaseConnectionManager)` / `spyOn(StatsRepository.prototype)`.
- **No client-observable change beyond the added heartbeats.** Error-frame payload shapes (`{}` for stats, `{message}` for broadcast) are preserved.

## Rebase note

This branch was originally cut from a base predating #322/#323, then rebased onto current `main`. The conflict resolution keeps the heartbeat owned solely by the primitive: #323's hand-rolled broadcast heartbeat is removed as redundant (its Caddy/idle-timeout rationale comment moved to the primitive, where the heartbeat now covers every stream), #304's file-local post-await abort recheck is subsumed by the primitive's generic one, and main's `inFlight` per-source poll guard in `subscription-service.ts` is preserved (with its in-flight test rewritten onto the `loadRows` seam). `authenticateSSE` call sites are unchanged, keeping the #331 overlap trivial.

## Verification

- `bun run typecheck:all`: clean. `bun run test:agent`: 271 pass.
- Touched test files pass in isolation (create-sse-stream 18, create-stats 7, create-broadcast 11, subscription-service 9, docker-logs 8). Full local suite has pre-existing environment-dependent failures; CI is the arbiter per CLAUDE.md.

Closes #328

Part of epic #337.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq)_