### PR TITLE
fix(demo): export getStackVariableValues from the stacks demo mock

### DIFF
--- a/src/lib/mock/functions/stacks.functions.tsx
+++ b/src/lib/mock/functions/stacks.functions.tsx
@@ -387,6 +387,12 @@ export async function getVariableValue(opts: {
   return MOCK_VARIABLE_VALUES[opts.data.stackName]?.[opts.data.variableName] ?? '';
 }
 
+export async function getStackVariableValues(opts: {
+  data: { stackName: string };
+}): Promise<Record<string, string>> {
+  return MOCK_VARIABLE_VALUES[opts.data.stackName] ?? {};
+}
+
 export async function setVariableValue(_opts: {
   data: { stackName: string; variableName: string; value: string };
 }): Promise<void> {


### PR DESCRIPTION
## What changed

`VariablesPanel` imports `getStackVariableValues` from `@/data/stacks/functions`, which the demo build aliases to `src/lib/mock/functions/stacks.functions.tsx`. #321 added `getStackVariableValues` to the real server functions but never mirrored it in the demo mock, so `bun run build:demo` failed with:

```
[MISSING_EXPORT] "getStackVariableValues" is not exported by "src/lib/mock/functions/stacks.functions.tsx".
```

This adds the missing mock export, returning the full name/value record for the stack from the existing `MOCK_VARIABLE_VALUES`, matching the real handler's `Record<string, string>` return shape (the real one returns `repo.getAll(stackName)`).

## Verification

- `bun run typecheck`: clean.
- `bun run build:demo`: now succeeds (built + prerendered), where it previously failed on the missing export.

## Context

Found while working the epic #337 SSE PRs (the demo build is a shared gate). This is an independent, pre-existing bug on `main`, so it goes straight to `main` rather than into any epic branch. One file, no behavior change outside demo mode.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving all variable values associated with a stack.
  - Returns an empty result when no values are available for the requested stack.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->