### PR TITLE
test: replace setTimeout flush waits with deterministic waits

### DIFF
--- a/src/components/__tests__/header/nav-config.test.ts
+++ b/src/components/__tests__/header/nav-config.test.ts
@@ -121,7 +121,10 @@ describe('handlePrefetch', () => {
     const handler = () => { unhandledRejection = true }
     process.on('unhandledRejection', handler)
     handlePrefetch('/docker')
-    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    // Wait on the exact promise handlePrefetch attaches its .catch() to, so the
+    // rejection is settled (and handled) before checking for an unhandled rejection.
+    const rejectingCall = mockPrefetchQuery.mock.results.at(-1)?.value as Promise<unknown> | undefined
+    await rejectingCall?.catch(() => {})
     process.off('unhandledRejection', handler)
     expect(unhandledRejection).toBe(false)
   })

--- a/src/components/__tests__/header/nav-config.test.ts
+++ b/src/components/__tests__/header/nav-config.test.ts
@@ -121,8 +121,7 @@ describe('handlePrefetch', () => {
     const handler = () => { unhandledRejection = true }
     process.on('unhandledRejection', handler)
     handlePrefetch('/docker')
-    // Wait on the exact promise handlePrefetch attaches its .catch() to, so the
-    // rejection is settled (and handled) before checking for an unhandled rejection.
+    // Wait on the promise handlePrefetch's .catch() attaches to, so the rejection is handled first.
     const rejectingCall = mockPrefetchQuery.mock.results.at(-1)?.value as Promise<unknown> | undefined
     await rejectingCall?.catch(() => {})
     process.off('unhandledRejection', handler)

--- a/src/components/__tests__/header/nav-config.test.ts
+++ b/src/components/__tests__/header/nav-config.test.ts
@@ -123,6 +123,7 @@ describe('handlePrefetch', () => {
     handlePrefetch('/docker')
     // Wait on the promise handlePrefetch's .catch() attaches to, so the rejection is handled first.
     const rejectingCall = mockPrefetchQuery.mock.results.at(-1)?.value as Promise<unknown> | undefined
+    expect(rejectingCall).toBeDefined()
     await rejectingCall?.catch(() => {})
     process.off('unhandledRejection', handler)
     expect(unhandledRejection).toBe(false)

--- a/src/components/docker/__tests__/ContainerTerminal.test.tsx
+++ b/src/components/docker/__tests__/ContainerTerminal.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test';
-import { act, render, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 
 interface MockTerminalShape {
   options: Record<string, unknown>;
@@ -148,18 +148,19 @@ describe('ContainerTerminal', () => {
         onShellResolved={onShellResolved}
       />,
     );
-    // The useEffect that calls onShellResolved runs after render; flush with act.
-    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+    // The useEffect that calls onShellResolved runs synchronously during the
+    // render() commit (RTL wraps render in act()), so it has already fired.
     expect(onShellResolved).toHaveBeenCalledWith('bash');
   });
 
   it('flips terminal.options.disableStdin to match the frozen prop on rerender', async () => {
-    // useXtermSetup creates the Terminal inside an async useEffect; wait a tick
-    // inside act() so React state updates are committed before assertions.
+    // useXtermSetup creates the Terminal inside an async useEffect (dynamic
+    // import of @xterm/xterm), so wait for the mock Terminal to actually be
+    // constructed before asserting on it.
     const { rerender } = render(
       <ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} wordWrap={false} />,
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await waitFor(() => { expect(mockTerminalInstances.length).toBeGreaterThan(0); });
     const term = mockTerminalInstances.at(-1);
     if (!term) throw new Error('expected mock Terminal to be constructed');
     expect(term.options.disableStdin).toBe(false);

--- a/src/components/docker/__tests__/ContainerTerminal.test.tsx
+++ b/src/components/docker/__tests__/ContainerTerminal.test.tsx
@@ -148,15 +148,12 @@ describe('ContainerTerminal', () => {
         onShellResolved={onShellResolved}
       />,
     );
-    // The useEffect that calls onShellResolved runs synchronously during the
-    // render() commit (RTL wraps render in act()), so it has already fired.
+    // onShellResolved fires synchronously during render (RTL wraps render in act()).
     expect(onShellResolved).toHaveBeenCalledWith('bash');
   });
 
   it('flips terminal.options.disableStdin to match the frozen prop on rerender', async () => {
-    // useXtermSetup creates the Terminal inside an async useEffect (dynamic
-    // import of @xterm/xterm), so wait for the mock Terminal to actually be
-    // constructed before asserting on it.
+    // Terminal is constructed inside an async useEffect (dynamic import of @xterm/xterm).
     const { rerender } = render(
       <ContainerTerminal containerId="abc123" host="server1" shell="bash" frozen={false} wordWrap={false} />,
     );

--- a/src/components/docker/__tests__/IconPickerDialog.test.tsx
+++ b/src/components/docker/__tests__/IconPickerDialog.test.tsx
@@ -114,7 +114,6 @@ describe('IconPickerDialog', () => {
     fireEvent.click(screen.getByText('Apply'));
     expect(onSelect).toHaveBeenCalledWith('nginx');
 
-    // Component closes after SELECTION_FEEDBACK_MS via a real setTimeout; wait for the callback.
     await waitFor(() => { expect(onClose).toHaveBeenCalledTimes(1); });
   });
 
@@ -126,7 +125,6 @@ describe('IconPickerDialog', () => {
     fireEvent.click(screen.getByText('Use auto-detected'));
     expect(onSelect).toHaveBeenCalledWith(null);
 
-    // Component closes after SELECTION_FEEDBACK_MS via a real setTimeout; wait for the callback.
     await waitFor(() => { expect(onClose).toHaveBeenCalledTimes(1); });
   });
 });

--- a/src/components/docker/__tests__/IconPickerDialog.test.tsx
+++ b/src/components/docker/__tests__/IconPickerDialog.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 
 mock.module('@/lib/utils/icon-resolver', () => ({
   AVAILABLE_ICONS: ['nginx', 'redis', 'postgres', 'docker'],
@@ -114,10 +114,8 @@ describe('IconPickerDialog', () => {
     fireEvent.click(screen.getByText('Apply'));
     expect(onSelect).toHaveBeenCalledWith('nginx');
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1));
-    });
-    expect(onClose).toHaveBeenCalledTimes(1);
+    // Component closes after SELECTION_FEEDBACK_MS via a real setTimeout; wait for the callback.
+    await waitFor(() => { expect(onClose).toHaveBeenCalledTimes(1); });
   });
 
   it('calls onSelect(null) and closes when "Use auto-detected" is clicked', async () => {
@@ -128,9 +126,7 @@ describe('IconPickerDialog', () => {
     fireEvent.click(screen.getByText('Use auto-detected'));
     expect(onSelect).toHaveBeenCalledWith(null);
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 1));
-    });
-    expect(onClose).toHaveBeenCalledTimes(1);
+    // Component closes after SELECTION_FEEDBACK_MS via a real setTimeout; wait for the callback.
+    await waitFor(() => { expect(onClose).toHaveBeenCalledTimes(1); });
   });
 });

--- a/src/hooks/__tests__/useContainerTerminal.test.ts
+++ b/src/hooks/__tests__/useContainerTerminal.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 
 // Mock WebSocket. Real WebSockets start in CONNECTING (0) and only transition
 // to OPEN (1) after the handshake; the hook gates ws.send on OPEN, so the mock
@@ -47,15 +47,10 @@ const mockTerminal = {
 
 const { useContainerTerminal } = await import('@/hooks/useContainerTerminal');
 
-/** Settle effects and transition the latest MockWebSocket to OPEN, mirroring the real handshake. */
+/** Wait for the effect to construct the WebSocket, then transition it to OPEN, mirroring the real handshake. */
 async function settleAndOpen(): Promise<void> {
-  await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
-  await act(async () => { mockWsInstances.at(-1)?.triggerOpen(); });
-}
-
-/** For tests that assert NO WebSocket is constructed (enabled=false, terminal=null). */
-async function flushMicrotasksWithoutOpening(): Promise<void> {
-  await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+  await waitFor(() => { expect(mockWsInstances.length).toBeGreaterThan(0); });
+  act(() => { mockWsInstances.at(-1)?.triggerOpen(); });
 }
 
 describe('useContainerTerminal', () => {
@@ -206,9 +201,9 @@ describe('useContainerTerminal', () => {
     expect(mockWsInstances.length).toBe(1);
     act(() => { mockWsInstances[0]!.onclose?.({ code: 1000, reason: '' } as CloseEvent); });
     expect(result.current.sessionEnded).toBe(true);
-    await act(async () => { result.current.reconnect(); await new Promise((r) => setTimeout(r, 10)); });
+    act(() => { result.current.reconnect(); });
+    await waitFor(() => { expect(mockWsInstances.length).toBe(2); });
     act(() => { mockWsInstances.at(-1)?.triggerOpen(); });
-    expect(mockWsInstances.length).toBe(2);
     expect(result.current.sessionEnded).toBe(false);
   });
 
@@ -238,7 +233,8 @@ describe('useContainerTerminal', () => {
         enabled: false,
       }),
     );
-    await flushMicrotasksWithoutOpening();
+    // The effect bails out before constructing a WebSocket, so this is already
+    // settled once renderHook returns; nothing further to wait on.
     expect(mockWsInstances.length).toBe(0);
   });
 
@@ -251,7 +247,6 @@ describe('useContainerTerminal', () => {
         terminal: null,
       }),
     );
-    await flushMicrotasksWithoutOpening();
     expect(mockWsInstances.length).toBe(0);
   });
 
@@ -268,7 +263,7 @@ describe('useContainerTerminal', () => {
         terminal: mockTerminal as unknown as import('@xterm/xterm').Terminal,
       }),
     );
-    await act(async () => { await new Promise((r) => setTimeout(r, 10)); });
+    await waitFor(() => { expect(mockWsInstances.length).toBeGreaterThan(0); });
     const ws = mockWsInstances[0]!;
     // Pre-open: type before the OPEN transition.
     act(() => { listeners['data']?.('typed-before-open\r'); });

--- a/src/hooks/__tests__/useContainerTerminal.test.ts
+++ b/src/hooks/__tests__/useContainerTerminal.test.ts
@@ -233,8 +233,7 @@ describe('useContainerTerminal', () => {
         enabled: false,
       }),
     );
-    // The effect bails out before constructing a WebSocket, so this is already
-    // settled once renderHook returns; nothing further to wait on.
+    // effect bails out synchronously when disabled; nothing to await
     expect(mockWsInstances.length).toBe(0);
   });
 

--- a/src/hooks/__tests__/useSettings.test.ts
+++ b/src/hooks/__tests__/useSettings.test.ts
@@ -821,7 +821,6 @@ type ReactNode = import('react').ReactNode;
 
             expect(result.current.general.showSparklines).toBe(false);
 
-            // Wait for the persist call to settle
             await act(async () => {
                 await mockUpdateSetting.mock.results[0]?.value;
             });

--- a/src/hooks/__tests__/useSettings.test.ts
+++ b/src/hooks/__tests__/useSettings.test.ts
@@ -821,6 +821,7 @@ type ReactNode = import('react').ReactNode;
 
             expect(result.current.general.showSparklines).toBe(false);
 
+            expect(mockUpdateSetting).toHaveBeenCalledTimes(1);
             await act(async () => {
                 await mockUpdateSetting.mock.results[0]?.value;
             });

--- a/src/hooks/__tests__/useSettings.test.ts
+++ b/src/hooks/__tests__/useSettings.test.ts
@@ -821,9 +821,9 @@ type ReactNode = import('react').ReactNode;
 
             expect(result.current.general.showSparklines).toBe(false);
 
-            // Give the promise time to resolve
+            // Wait for the persist call to settle
             await act(async () => {
-                await new Promise(resolve => setTimeout(resolve, 10));
+                await mockUpdateSetting.mock.results[0]?.value;
             });
 
             // Still false - no rollback

--- a/src/hooks/__tests__/useTimeSeriesStream.test.ts
+++ b/src/hooks/__tests__/useTimeSeriesStream.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { z } from 'zod';
-import { renderHook, act } from '@testing-library/react';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import { useTimeSeriesStream, VISIBILITY_REFRESH_COOLDOWN_MS } from '../useTimeSeriesStream';
 import { defineSseChannel } from '@/lib/sse/define-sse-channel';
 import { MockEventSource } from '@/lib/test/mock-event-source';
@@ -66,8 +66,7 @@ describe('useTimeSeriesStream visibility refresh', () => {
     );
 
     // Wait for initial preload
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-    expect(preloadFn).toHaveBeenCalledTimes(1);
+    await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
 
     // Advance past cooldown
     const originalNow = Date.now;
@@ -76,9 +75,8 @@ describe('useTimeSeriesStream visibility refresh', () => {
 
       act(() => simulateVisibilityChange('visible'));
 
-      // Wait for async refresh
-      await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-      expect(preloadFn).toHaveBeenCalledTimes(2);
+      // Wait for the refresh triggered by the visibility change
+      await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(2); });
     } finally {
       Date.now = originalNow;
     }
@@ -96,21 +94,20 @@ describe('useTimeSeriesStream visibility refresh', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-    expect(preloadFn).toHaveBeenCalledTimes(1);
+    await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
 
-    // Immediately trigger visibility (within cooldown)
+    // useVisibilityRefresh checks the cooldown synchronously in the event
+    // handler (no promise dispatched when within cooldown), so the outcome
+    // is already settled once this call returns.
     act(() => simulateVisibilityChange('visible'));
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
 
-    // Should NOT have called preloadFn again
     expect(preloadFn).toHaveBeenCalledTimes(1);
   });
 });
 
 describe('useTimeSeriesStream reconnect refresh', () => {
   /** Errors the live SSE connection with timers firing synchronously, then opens the replacement. */
-  async function dropAndReopenConnection() {
+  function dropAndReopenConnection() {
     const setTimeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(
       ((fn: () => void) => { fn(); return 0; }) as unknown as typeof setTimeout,
     );
@@ -121,11 +118,8 @@ describe('useTimeSeriesStream reconnect refresh', () => {
       setTimeoutSpy.mockRestore();
     }
     const reconnected = MockEventSource.instances[MockEventSource.instances.length - 1];
-    // Single act scope so the async refresh kicked off by onReconnect settles inside it
-    await act(async () => {
-      reconnected.onopen?.();
-      await new Promise(r => setTimeout(r, 50));
-    });
+    act(() => { reconnected.onopen?.(); });
+    return reconnected;
   }
 
   it('refreshes history when the SSE connection reopens after a failure', async () => {
@@ -140,17 +134,17 @@ describe('useTimeSeriesStream reconnect refresh', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-    expect(preloadFn).toHaveBeenCalledTimes(1);
+    await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
 
     // Advance past the shared refresh cooldown set by the initial preload
     const originalNow = Date.now;
     try {
       Date.now = () => originalNow() + VISIBILITY_REFRESH_COOLDOWN_MS + 100;
 
-      await dropAndReopenConnection();
+      dropAndReopenConnection();
 
-      expect(preloadFn).toHaveBeenCalledTimes(2);
+      // onReconnect kicks off doRefresh() fire-and-forget; wait for it to land.
+      await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(2); });
     } finally {
       Date.now = originalNow;
     }
@@ -168,11 +162,12 @@ describe('useTimeSeriesStream reconnect refresh', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-    expect(preloadFn).toHaveBeenCalledTimes(1);
+    await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
 
-    // Reconnect immediately after preload: cooldown should suppress the refresh
-    await dropAndReopenConnection();
+    // Reconnect immediately after preload: onReconnect's cooldown check is
+    // synchronous and returns before dispatching another preload, so the
+    // outcome is already settled once this call returns.
+    dropAndReopenConnection();
 
     expect(preloadFn).toHaveBeenCalledTimes(1);
   });
@@ -193,8 +188,7 @@ describe('useTimeSeriesStream reconnect refresh', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-    expect(result.current.rows).toHaveLength(1); // seed only
+    await waitFor(() => { expect(result.current.rows).toHaveLength(1); }); // seed only
 
     const es = MockEventSource.instances[MockEventSource.instances.length - 1];
     const now = Date.now();
@@ -207,8 +201,9 @@ describe('useTimeSeriesStream reconnect refresh', () => {
     act(() => { es.onmessage?.({ data: JSON.stringify([{ key: 'f2', time: now - 2000, entity: 'e' }]) }); });
     expect(result.current.rows).toHaveLength(2);
 
-    // Reconnect within cooldown: refresh is suppressed, but the gate must re-arm.
-    await dropAndReopenConnection();
+    // Reconnect within cooldown: refresh is suppressed (synchronous cooldown
+    // check, nothing async dispatched), but the gate must re-arm.
+    dropAndReopenConnection();
     expect(preloadFn).toHaveBeenCalledTimes(1);
 
     // First frame after reconnect paints at once, draining the batched frame with it.
@@ -232,9 +227,8 @@ describe('useTimeSeriesStream preload', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(result.current.hasData).toBe(true); });
 
-    expect(result.current.hasData).toBe(true);
     expect(result.current.rows).toHaveLength(3);
     // Should be sorted ascending by time
     for (let i = 1; i < result.current.rows.length; i++) {
@@ -253,7 +247,10 @@ describe('useTimeSeriesStream preload', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
+    // Empty preload never touches hasData/rows state, so there's nothing to poll
+    // for; wait on the exact promise the hook awaited so it has fully settled.
+    await act(async () => { await preloadFn.mock.results[0]?.value; });
 
     expect(result.current.hasData).toBe(false);
     expect(result.current.rows).toHaveLength(0);
@@ -274,9 +271,8 @@ describe('useTimeSeriesStream preload', () => {
         })
       );
 
-      await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+      await waitFor(() => { expect(result.current.error).not.toBeNull(); });
 
-      expect(result.current.error).not.toBeNull();
       expect(result.current.error?.message).toBe('DB down');
     } finally {
       console.error = origError;
@@ -326,9 +322,8 @@ describe('useTimeSeriesStream preload', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(result.current.latestByEntity.size).toBe(2); });
 
-    expect(result.current.latestByEntity.size).toBe(2);
     expect(result.current.latestByEntity.get('a')?.key).toBe('a-2');
     expect(result.current.latestByEntity.get('b')?.key).toBe('b-1');
   });
@@ -348,7 +343,8 @@ describe('useTimeSeriesStream SSE flush', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
+    await act(async () => { await preloadFn.mock.results[0]?.value; });
 
     // Send data via SSE (useEventSource's onmessage handler parses JSON → calls handleData)
     const es = MockEventSource.instances[0];
@@ -359,10 +355,7 @@ describe('useTimeSeriesStream SSE flush', () => {
     ];
     act(() => { es.onmessage?.({ data: JSON.stringify(sseRows) }); });
 
-    // Wait for flush interval
-    await act(async () => { await new Promise(r => setTimeout(r, 100)); });
-
-    expect(result.current.rows.length).toBeGreaterThanOrEqual(2);
+    await waitFor(() => { expect(result.current.rows.length).toBeGreaterThanOrEqual(2); });
     expect(result.current.hasData).toBe(true);
   });
 
@@ -383,8 +376,7 @@ describe('useTimeSeriesStream SSE flush', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-    expect(result.current.rows).toHaveLength(1);
+    await waitFor(() => { expect(result.current.rows).toHaveLength(1); });
 
     // SSE sends same key + a new one
     const es = MockEventSource.instances[0];
@@ -394,10 +386,8 @@ describe('useTimeSeriesStream SSE flush', () => {
     ];
     act(() => { es.onmessage?.({ data: JSON.stringify(sseRows) }); });
 
-    await act(async () => { await new Promise(r => setTimeout(r, 100)); });
-
     // Should have 2 rows (original + new), not 3
-    expect(result.current.rows).toHaveLength(2);
+    await waitFor(() => { expect(result.current.rows).toHaveLength(2); });
   });
 
   it('evicts rows outside the time window', async () => {
@@ -418,7 +408,9 @@ describe('useTimeSeriesStream SSE flush', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    // Seed includes 'old' too: replaceBuffer's seed mode doesn't evict, only the
+    // SSE-driven flush below does.
+    await waitFor(() => { expect(result.current.rows).toHaveLength(2); });
 
     // Send a new SSE row to trigger flush (which also evicts)
     const es = MockEventSource.instances[0];
@@ -426,13 +418,13 @@ describe('useTimeSeriesStream SSE flush', () => {
       es.onmessage?.({ data: JSON.stringify([{ key: 'new', time: now, entity: 'a' }]) });
     });
 
-    await act(async () => { await new Promise(r => setTimeout(r, 100)); });
-
     // The old row should have been evicted
-    const keys = result.current.rows.map(r => r.key);
-    expect(keys).not.toContain('old');
-    expect(keys).toContain('recent');
-    expect(keys).toContain('new');
+    await waitFor(() => {
+      const keys = result.current.rows.map(r => r.key);
+      expect(keys).not.toContain('old');
+      expect(keys).toContain('recent');
+      expect(keys).toContain('new');
+    });
   });
 
   it('clears preload error when SSE data arrives', async () => {
@@ -456,8 +448,7 @@ describe('useTimeSeriesStream SSE flush', () => {
         })
       );
 
-      await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-      expect(result.current.error?.message).toBe('DB down');
+      await waitFor(() => { expect(result.current.error?.message).toBe('DB down'); });
 
       // SSE data arrives: should clear the preload error
       const es = MockEventSource.instances[0];
@@ -466,9 +457,7 @@ describe('useTimeSeriesStream SSE flush', () => {
         es.onmessage?.({ data: JSON.stringify([{ key: 'x-1', time: now, entity: 'x' }]) });
       });
 
-      await act(async () => { await new Promise(r => setTimeout(r, 100)); });
-
-      expect(result.current.error).toBeNull();
+      await waitFor(() => { expect(result.current.error).toBeNull(); });
     } finally {
       console.error = origError;
     }
@@ -487,7 +476,8 @@ describe('useTimeSeriesStream service error', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
+    await act(async () => { await preloadFn.mock.results[0]?.value; });
 
     // Dispatch stats_error event on MockEventSource
     const es = MockEventSource.instances[0];
@@ -515,12 +505,11 @@ describe('useTimeSeriesStream periodic refresh', () => {
     );
 
     // Wait for initial preload
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-    expect(preloadFn).toHaveBeenCalledTimes(1);
+    await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
 
-    // Wait for at least one periodic refresh
-    await act(async () => { await new Promise(r => setTimeout(r, 150)); });
-    expect(preloadFn.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // Wait for at least one periodic refresh (real setInterval; waitFor polls
+    // for the actual call count instead of sleeping a guessed duration)
+    await waitFor(() => { expect(preloadFn.mock.calls.length).toBeGreaterThanOrEqual(2); });
   });
 
   it('doRefresh silently ignores errors', async () => {
@@ -541,11 +530,10 @@ describe('useTimeSeriesStream periodic refresh', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-    expect(result.current.hasData).toBe(true);
+    await waitFor(() => { expect(result.current.hasData).toBe(true); });
 
     // Wait for periodic refresh that fails
-    await act(async () => { await new Promise(r => setTimeout(r, 150)); });
+    await waitFor(() => { expect(callCount).toBeGreaterThanOrEqual(2); });
 
     // Error should not propagate; data should still be intact
     expect(result.current.rows.length).toBeGreaterThan(0);
@@ -581,13 +569,14 @@ describe('useTimeSeriesStream stale initialData', () => {
     expect(result.current.rows).toHaveLength(2);
 
     // Wait for the stale-data refresh (setTimeout 0 + preloadFn)
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
 
     // preloadFn should have been called, and the buffer should now contain the fresh rows.
-    expect(preloadFn).toHaveBeenCalledTimes(1);
-    const keys = result.current.rows.map(r => r.key);
-    expect(keys).toContain('a-2');
-    expect(keys).toContain('b-2');
+    await waitFor(() => {
+      const keys = result.current.rows.map(r => r.key);
+      expect(keys).toContain('a-2');
+      expect(keys).toContain('b-2');
+    });
   });
 
   it('does not refresh when initialData is fresh', async () => {
@@ -608,9 +597,9 @@ describe('useTimeSeriesStream stale initialData', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-
-    // preloadFn should NOT have been called; initialData was fresh
+    // The staleness check runs synchronously in the mount effect (already
+    // flushed by the time renderHook returns): a fresh initialData never
+    // schedules the refresh, so preloadFn stays uncalled with nothing to wait on.
     expect(preloadFn).toHaveBeenCalledTimes(0);
   });
 });
@@ -634,8 +623,7 @@ describe('useTimeSeriesStream cutoff-only eviction', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-    expect(result.current.rows).toHaveLength(2);
+    await waitFor(() => { expect(result.current.rows).toHaveLength(2); });
 
     // Send a duplicate row: triggers flush with pending > 0, but newRows is empty after dedup.
     // This exercises the cutoff-only branch (hasCutoff && !hasNew).
@@ -644,11 +632,11 @@ describe('useTimeSeriesStream cutoff-only eviction', () => {
       es.onmessage?.({ data: JSON.stringify([{ key: 'recent', time: now - 5000, entity: 'a' }]) });
     });
 
-    await act(async () => { await new Promise(r => setTimeout(r, 100)); });
-
-    const keys = result.current.rows.map(r => r.key);
-    expect(keys).not.toContain('old');
-    expect(keys).toContain('recent');
+    await waitFor(() => {
+      const keys = result.current.rows.map(r => r.key);
+      expect(keys).not.toContain('old');
+      expect(keys).toContain('recent');
+    });
   });
 });
 
@@ -671,9 +659,8 @@ describe('useTimeSeriesStream latestByEntity stability', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(result.current.latestByEntity.size).toBe(2); });
     const firstMap = result.current.latestByEntity;
-    expect(firstMap.size).toBe(2);
 
     // Send SSE data for entity 'a' only - entity 'b' should keep the same row reference
     const es = MockEventSource.instances[0];
@@ -681,11 +668,9 @@ describe('useTimeSeriesStream latestByEntity stability', () => {
       es.onmessage?.({ data: JSON.stringify([{ key: 'a-2', time: now - 1000, entity: 'a' }]) });
     });
 
-    await act(async () => { await new Promise(r => setTimeout(r, 100)); });
+    await waitFor(() => { expect(result.current.latestByEntity.get('a')?.key).toBe('a-2'); });
     const secondMap = result.current.latestByEntity;
 
-    // Map reference changes (entity 'a' updated)
-    expect(secondMap.get('a')?.key).toBe('a-2');
     // But entity 'b' row reference should be the same object
     expect(secondMap.get('b')).toBe(firstMap.get('b'));
   });
@@ -708,20 +693,20 @@ describe('useTimeSeriesStream latestByEntity stability', () => {
       })
     );
 
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(result.current.latestByEntity.size).toBe(2); });
     const firstMap = result.current.latestByEntity;
-    expect(firstMap.size).toBe(2);
 
-    // Send a duplicate row (same key as existing): should be deduped, no latest change
+    // Send a duplicate row (same key as existing): should be deduped, no latest change.
+    // This is the very first SSE message on this hook instance, so the enqueue
+    // gate flushes it synchronously; the flush's `pending` array is non-empty
+    // (the duplicate itself), so `waitFor` below settles on the first poll.
     const es = MockEventSource.instances[0];
     act(() => {
       es.onmessage?.({ data: JSON.stringify([{ key: 'a-1', time: now - 10000, entity: 'a' }]) });
     });
 
-    await act(async () => { await new Promise(r => setTimeout(r, 100)); });
-
     // Map reference should be identical: no entity's latest changed
-    expect(result.current.latestByEntity).toBe(firstMap);
+    await waitFor(() => { expect(result.current.latestByEntity).toBe(firstMap); });
   });
 });
 
@@ -744,26 +729,26 @@ describe('useTimeSeriesStream preloadFn change', () => {
     );
 
     // Initial preload completes; buffer has 'a-1'.
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(result.current.rows).toHaveLength(1); });
     expect(firstFn).toHaveBeenCalledTimes(1);
-    expect(result.current.rows).toHaveLength(1);
 
     // An SSE row arrives that is newer than the (upcoming) refresh snapshot's max.
     const es = MockEventSource.instances[0];
     act(() => {
       es.onmessage?.({ data: JSON.stringify([{ key: 'live', time: now + 5_000, entity: 'a' }]) });
     });
-    await act(async () => { await new Promise(r => setTimeout(r, 60)); });
-    expect(result.current.rows.map(r => r.key)).toContain('live');
+    await waitFor(() => { expect(result.current.rows.map(r => r.key)).toContain('live'); });
 
     // Change preloadFn (e.g. window size changed via settings) → triggers a refresh, not a fresh seed.
     rerender({ fn: secondFn });
-    await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+    await waitFor(() => { expect(secondFn).toHaveBeenCalledTimes(1); });
 
-    expect(secondFn).toHaveBeenCalledTimes(1);
     // The live-tail row must survive the refresh; that's the preserveLiveTail contract.
-    expect(result.current.rows.map(r => r.key)).toContain('live');
-    expect(result.current.rows.map(r => r.key)).toContain('a-1');
+    await waitFor(() => {
+      const keys = result.current.rows.map(r => r.key);
+      expect(keys).toContain('live');
+      expect(keys).toContain('a-1');
+    });
   });
 });
 
@@ -786,7 +771,9 @@ describe('useTimeSeriesStream debug logging', () => {
         })
       );
 
-      await act(async () => { await new Promise(r => setTimeout(r, 150)); });
+      await waitFor(() => {
+        expect(messages.some(m => m.includes('Buffer refresh'))).toBe(true);
+      });
 
       expect(messages.some(m => m.includes('Starting preload'))).toBe(true);
       expect(messages.some(m => m.includes('Preload complete'))).toBe(true);
@@ -812,8 +799,7 @@ describe('useTimeSeriesStream error composition', () => {
       );
 
       // Preload fails → preloadError is set
-      await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-      expect(result.current.error?.message).toBe('DB down');
+      await waitFor(() => { expect(result.current.error?.message).toBe('DB down'); });
 
       // Fire stats_error → serviceError is set. Composed error should switch to "Database unavailable".
       const es = MockEventSource.instances[0];

--- a/src/hooks/__tests__/useTimeSeriesStream.test.ts
+++ b/src/hooks/__tests__/useTimeSeriesStream.test.ts
@@ -75,7 +75,6 @@ describe('useTimeSeriesStream visibility refresh', () => {
 
       act(() => simulateVisibilityChange('visible'));
 
-      // Wait for the refresh triggered by the visibility change
       await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(2); });
     } finally {
       Date.now = originalNow;
@@ -96,9 +95,7 @@ describe('useTimeSeriesStream visibility refresh', () => {
 
     await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
 
-    // useVisibilityRefresh checks the cooldown synchronously in the event
-    // handler (no promise dispatched when within cooldown), so the outcome
-    // is already settled once this call returns.
+    // cooldown check is synchronous; nothing to await
     act(() => simulateVisibilityChange('visible'));
 
     expect(preloadFn).toHaveBeenCalledTimes(1);
@@ -143,7 +140,6 @@ describe('useTimeSeriesStream reconnect refresh', () => {
 
       dropAndReopenConnection();
 
-      // onReconnect kicks off doRefresh() fire-and-forget; wait for it to land.
       await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(2); });
     } finally {
       Date.now = originalNow;
@@ -164,9 +160,8 @@ describe('useTimeSeriesStream reconnect refresh', () => {
 
     await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
 
-    // Reconnect immediately after preload: onReconnect's cooldown check is
-    // synchronous and returns before dispatching another preload, so the
-    // outcome is already settled once this call returns.
+    // Reconnect immediately after preload: cooldown check is synchronous, so
+    // the outcome is settled once this call returns.
     dropAndReopenConnection();
 
     expect(preloadFn).toHaveBeenCalledTimes(1);
@@ -201,8 +196,7 @@ describe('useTimeSeriesStream reconnect refresh', () => {
     act(() => { es.onmessage?.({ data: JSON.stringify([{ key: 'f2', time: now - 2000, entity: 'e' }]) }); });
     expect(result.current.rows).toHaveLength(2);
 
-    // Reconnect within cooldown: refresh is suppressed (synchronous cooldown
-    // check, nothing async dispatched), but the gate must re-arm.
+    // Reconnect within cooldown: refresh is suppressed (synchronous check), but the gate must re-arm.
     dropAndReopenConnection();
     expect(preloadFn).toHaveBeenCalledTimes(1);
 
@@ -248,8 +242,7 @@ describe('useTimeSeriesStream preload', () => {
     );
 
     await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
-    // Empty preload never touches hasData/rows state, so there's nothing to poll
-    // for; wait on the exact promise the hook awaited so it has fully settled.
+    // Empty preload never touches state; await the preload promise directly.
     await act(async () => { await preloadFn.mock.results[0]?.value; });
 
     expect(result.current.hasData).toBe(false);
@@ -507,8 +500,7 @@ describe('useTimeSeriesStream periodic refresh', () => {
     // Wait for initial preload
     await waitFor(() => { expect(preloadFn).toHaveBeenCalledTimes(1); });
 
-    // Wait for at least one periodic refresh (real setInterval; waitFor polls
-    // for the actual call count instead of sleeping a guessed duration)
+    // Wait for at least one periodic refresh
     await waitFor(() => { expect(preloadFn.mock.calls.length).toBeGreaterThanOrEqual(2); });
   });
 
@@ -597,9 +589,7 @@ describe('useTimeSeriesStream stale initialData', () => {
       })
     );
 
-    // The staleness check runs synchronously in the mount effect (already
-    // flushed by the time renderHook returns): a fresh initialData never
-    // schedules the refresh, so preloadFn stays uncalled with nothing to wait on.
+    // staleness check is synchronous; nothing to await
     expect(preloadFn).toHaveBeenCalledTimes(0);
   });
 });
@@ -697,9 +687,7 @@ describe('useTimeSeriesStream latestByEntity stability', () => {
     const firstMap = result.current.latestByEntity;
 
     // Send a duplicate row (same key as existing): should be deduped, no latest change.
-    // This is the very first SSE message on this hook instance, so the enqueue
-    // gate flushes it synchronously; the flush's `pending` array is non-empty
-    // (the duplicate itself), so `waitFor` below settles on the first poll.
+    // First SSE message on this instance flushes synchronously, so waitFor below settles on the first poll.
     const es = MockEventSource.instances[0];
     act(() => {
       es.onmessage?.({ data: JSON.stringify([{ key: 'a-1', time: now - 10000, entity: 'a' }]) });

--- a/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
+++ b/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
@@ -3,6 +3,7 @@ import { DockerInventoryBroadcastService, rowToInventory, notifyPayloadToInvento
 import type { DockerInventorySnapshotContainer, DockerInventoryBroadcastEvent } from '@/types/docker-inventory';
 import type { DockerContainerEventRow } from '@/lib/database/repositories/docker-container-event-repository';
 import type { PoolClient } from 'pg';
+import { waitForCondition } from '@/lib/test/wait-for-condition';
 
 type NotificationHandler = (msg: { channel: string; payload?: string }) => void;
 type ErrorHandler = (err: Error) => void;
@@ -45,10 +46,6 @@ function createMockPoolClient(): MockPoolClient {
     },
   };
   return client;
-}
-
-function flush(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 const container1: DockerInventorySnapshotContainer = {
@@ -104,7 +101,7 @@ describe('DockerInventoryBroadcastService', () => {
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
 
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     expect(received).toHaveLength(1);
     expect(received[0].type).toBe('init');
@@ -124,9 +121,14 @@ describe('DockerInventoryBroadcastService', () => {
     const received: DockerInventoryBroadcastEvent[] = [];
     const unsub = slowService.subscribe((e) => received.push(e));
 
+    // unsub() runs synchronously here, before sendInit() ever awaits the
+    // snapshot, so `subscribers.has(callback)` is already false by the time
+    // sendInit checks it: no timing dependency, nothing to poll for. Only
+    // await the snapshot promise so the service's pending work settles
+    // cleanly before stop() below.
     unsub();
     resolveSnapshot([container1]);
-    await flush();
+    await slowSnapshot;
 
     expect(received).toHaveLength(0);
 
@@ -142,7 +144,7 @@ describe('DockerInventoryBroadcastService', () => {
 
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     expect(received[0].type).toBe('init');
     if (received[0].type === 'init') {
@@ -153,14 +155,14 @@ describe('DockerInventoryBroadcastService', () => {
 
   it('issues LISTEN docker_container_change on subscribe', async () => {
     service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.querySql !== null);
     expect(poolClient.querySql).toBe('LISTEN docker_container_change');
   });
 
   it('broadcasts upsert event from NOTIFY payload', async () => {
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     const notifyPayload = JSON.stringify({
       at: '2026-04-16T11:00:00Z',
@@ -177,6 +179,9 @@ describe('DockerInventoryBroadcastService', () => {
       exit_code: null,
     });
 
+    // handleNotify runs synchronously inside the 'notification' handler, so
+    // emit() has already fanned the event out to subscribers by the time it
+    // returns.
     poolClient.emit('notification', { channel: 'docker_container_change', payload: notifyPayload });
 
     expect(received).toHaveLength(2); // init + upsert
@@ -192,7 +197,7 @@ describe('DockerInventoryBroadcastService', () => {
   it('upsert events omit labels (NOTIFY payload omits labels)', async () => {
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     poolClient.emit('notification', {
       channel: 'docker_container_change',
@@ -222,7 +227,7 @@ describe('DockerInventoryBroadcastService', () => {
   it('broadcasts destroy event from NOTIFY payload', async () => {
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     poolClient.emit('notification', {
       channel: 'docker_container_change',
@@ -256,7 +261,7 @@ describe('DockerInventoryBroadcastService', () => {
 
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     poolClient.emit('notification', {
       channel: 'docker_container_change',
@@ -271,9 +276,11 @@ describe('DockerInventoryBroadcastService', () => {
 
   it('stops listening when last subscriber unsubscribes', async () => {
     const unsub = service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     expect(poolClient.released).toBe(false);
+    // cleanupListenerClient() releases synchronously (no UNLISTEN await) for
+    // this service, so no wait is needed between unsub() and the assertion.
     unsub();
     expect(poolClient.released).toBe(true);
   });
@@ -281,7 +288,7 @@ describe('DockerInventoryBroadcastService', () => {
   it('keeps listening when one of multiple subscribers unsubscribes', async () => {
     const unsub1 = service.subscribe(() => {});
     const unsub2 = service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     unsub1();
     expect(poolClient.released).toBe(false);
@@ -294,8 +301,10 @@ describe('DockerInventoryBroadcastService', () => {
     const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
 
     service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
+    // The 'error' handler schedules the reconnect via a synchronous
+    // setTimeout call, so no wait is needed between emit and assertion.
     poolClient.emit('error', new Error('connection reset'));
 
     expect(setTimeoutSpy).toHaveBeenCalled();
@@ -319,10 +328,10 @@ describe('DockerInventoryBroadcastService', () => {
     });
 
     multiConnectService.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => connectCount >= 1);
 
     poolClient.emit('error', new Error('transient error'));
-    await flush();
+    await waitForCondition(() => connectCount >= 2);
 
     expect(connectCount).toBeGreaterThanOrEqual(2);
 
@@ -336,7 +345,7 @@ describe('DockerInventoryBroadcastService', () => {
 
     service.subscribe((e) => received1.push(e));
     service.subscribe((e) => received2.push(e));
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     poolClient.emit('notification', {
       channel: 'docker_container_change',
@@ -377,7 +386,7 @@ describe('DockerInventoryBroadcastService', () => {
     });
 
     resetService.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => client1.notificationHandlers.length > 0);
 
     const capturedDelays: number[] = [];
     const setTimeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(
@@ -390,8 +399,13 @@ describe('DockerInventoryBroadcastService', () => {
 
     try {
       client1.emit('error', new Error('first disconnect'));
-      await flush();
-      await flush();
+      // Wait for client2's LISTEN query to actually complete, not just
+      // connectCount incrementing: getPoolClient() bumps the counter before
+      // the awaited connect resolves, and reconnectFailures only resets to 0
+      // right after the LISTEN query succeeds. Emitting client2's error before
+      // that reset would carry over the stale backoff counter from the first
+      // disconnect, producing 1000ms instead of the expected reset to 500ms.
+      await waitForCondition(() => client2.querySql !== null);
 
       const firstCycleBackoffs = capturedDelays.filter((d) => d >= 500);
       expect(firstCycleBackoffs[0]).toBe(500);
@@ -401,7 +415,7 @@ describe('DockerInventoryBroadcastService', () => {
       // delay would be 1000ms (500 * 2) rather than the base 500ms.
       capturedDelays.length = 0;
       client2.emit('error', new Error('second disconnect'));
-      await flush();
+      await waitForCondition(() => capturedDelays.some((d) => d >= 500));
 
       const secondCycleBackoffs = capturedDelays.filter((d) => d >= 500);
       expect(secondCycleBackoffs[0]).toBe(500);
@@ -414,7 +428,7 @@ describe('DockerInventoryBroadcastService', () => {
   it('ignores notifications on other channels', async () => {
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     poolClient.emit('notification', {
       channel: 'some_other_channel',
@@ -432,7 +446,7 @@ describe('DockerInventoryBroadcastService', () => {
 
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     expect(received[0].type).toBe('init');
     if (received[0].type === 'init') {
@@ -595,8 +609,7 @@ describe('DockerInventoryBroadcastService: malformed NOTIFY does not crash', () 
 
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    const flush = () => new Promise<void>((r) => setTimeout(r, 0));
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     poolClient.emit('notification', {
       channel: 'docker_container_change',
@@ -700,9 +713,7 @@ describe('DockerInventoryBroadcastService: connection failure retry', () => {
     try {
       service.subscribe(() => {});
       // Allow the retry loop to complete.
-      await new Promise<void>((r) => queueMicrotask(r));
-      await new Promise<void>((r) => queueMicrotask(r));
-      await new Promise<void>((r) => queueMicrotask(r));
+      await waitForCondition(() => connectAttempts >= 2);
 
       // The service should have retried and connected on the second attempt.
       expect(connectAttempts).toBeGreaterThanOrEqual(2);
@@ -726,8 +737,7 @@ describe('DockerInventoryBroadcastService: zod validation at NOTIFY boundary', (
 
     const received: DockerInventoryBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    const flushLocal = () => new Promise<void>((r) => setTimeout(r, 0));
-    await flushLocal();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     // NOTIFY payload with event_type 'upsert' but an invalid state value:
     // notifyPayloadToInventory builds an object, then zod rejects it.

--- a/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
+++ b/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
@@ -121,11 +121,7 @@ describe('DockerInventoryBroadcastService', () => {
     const received: DockerInventoryBroadcastEvent[] = [];
     const unsub = slowService.subscribe((e) => received.push(e));
 
-    // unsub() runs synchronously here, before sendInit() ever awaits the
-    // snapshot, so `subscribers.has(callback)` is already false by the time
-    // sendInit checks it: no timing dependency, nothing to poll for. Only
-    // await the snapshot promise so the service's pending work settles
-    // cleanly before stop() below.
+    // unsub() runs before sendInit() awaits the snapshot; await it only so pending work settles before stop().
     unsub();
     resolveSnapshot([container1]);
     await slowSnapshot;
@@ -179,9 +175,7 @@ describe('DockerInventoryBroadcastService', () => {
       exit_code: null,
     });
 
-    // handleNotify runs synchronously inside the 'notification' handler, so
-    // emit() has already fanned the event out to subscribers by the time it
-    // returns.
+    // handleNotify runs synchronously, so emit() has already fanned out by the time it returns.
     poolClient.emit('notification', { channel: 'docker_container_change', payload: notifyPayload });
 
     expect(received).toHaveLength(2); // init + upsert
@@ -279,8 +273,7 @@ describe('DockerInventoryBroadcastService', () => {
     await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     expect(poolClient.released).toBe(false);
-    // cleanupListenerClient() releases synchronously (no UNLISTEN await) for
-    // this service, so no wait is needed between unsub() and the assertion.
+    // cleanupListenerClient() releases synchronously; no wait needed.
     unsub();
     expect(poolClient.released).toBe(true);
   });
@@ -303,8 +296,7 @@ describe('DockerInventoryBroadcastService', () => {
     service.subscribe(() => {});
     await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
-    // The 'error' handler schedules the reconnect via a synchronous
-    // setTimeout call, so no wait is needed between emit and assertion.
+    // error handler schedules reconnect via synchronous setTimeout; no wait needed.
     poolClient.emit('error', new Error('connection reset'));
 
     expect(setTimeoutSpy).toHaveBeenCalled();
@@ -399,12 +391,9 @@ describe('DockerInventoryBroadcastService', () => {
 
     try {
       client1.emit('error', new Error('first disconnect'));
-      // Wait for client2's LISTEN query to actually complete, not just
-      // connectCount incrementing: getPoolClient() bumps the counter before
-      // the awaited connect resolves, and reconnectFailures only resets to 0
-      // right after the LISTEN query succeeds. Emitting client2's error before
-      // that reset would carry over the stale backoff counter from the first
-      // disconnect, producing 1000ms instead of the expected reset to 500ms.
+      // Wait for client2's LISTEN to complete, not just connectCount incrementing:
+      // reconnectFailures only resets after LISTEN succeeds, and emitting client2's
+      // error before that would carry over the stale backoff (1000ms instead of 500ms).
       await waitForCondition(() => client2.querySql !== null);
 
       const firstCycleBackoffs = capturedDelays.filter((d) => d >= 500);

--- a/src/lib/mock/__tests__/mock-event-source.test.ts
+++ b/src/lib/mock/__tests__/mock-event-source.test.ts
@@ -247,9 +247,7 @@ describe('MockEventSource', () => {
         instance.onopen = () => resolve();
       });
 
-      // _start() resolves the generator synchronously on open and returns
-      // without scheduling anything when the path is unrecognized, so once
-      // onopen has fired there is nothing further to wait on.
+      // unrecognized path schedules nothing after open; nothing further to await
       expect(messageReceived).toBe(false);
     });
   });

--- a/src/lib/mock/__tests__/mock-event-source.test.ts
+++ b/src/lib/mock/__tests__/mock-event-source.test.ts
@@ -247,8 +247,9 @@ describe('MockEventSource', () => {
         instance.onopen = () => resolve();
       });
 
-      // Wait a bit to confirm no messages arrive
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // _start() resolves the generator synchronously on open and returns
+      // without scheduling anything when the path is unrecognized, so once
+      // onopen has fired there is nothing further to wait on.
       expect(messageReceived).toBe(false);
     });
   });

--- a/src/lib/settings/__tests__/settings-broadcast-service.test.ts
+++ b/src/lib/settings/__tests__/settings-broadcast-service.test.ts
@@ -105,8 +105,7 @@ describe('SettingsBroadcastService', () => {
     await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     poolClient.emit('notification', { channel: 'other_channel', payload: 'theme' });
-    // The channel filter is checked synchronously inside the notification
-    // handler, so an unrelated channel is a same-tick no-op.
+    // channel filter is synchronous; an unrelated channel is a same-tick no-op
     expect(received.filter((m) => m.type === 'change')).toHaveLength(0);
   });
 
@@ -139,8 +138,7 @@ describe('SettingsBroadcastService', () => {
         service.subscribe(() => {});
         await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
-        // The 'error' handler schedules the reconnect via a synchronous
-        // setTimeout call, so no wait is needed between emit and assertion.
+        // error handler schedules reconnect via synchronous setTimeout; no wait needed.
         setTimeoutSpy.mockClear();
         poolClient.emit('error', new Error('connection reset'));
 
@@ -162,8 +160,7 @@ describe('SettingsBroadcastService', () => {
         loadSingleSetting: async () => null,
       });
 
-      // Auto-fire timers via microtask (not real elapsed time) so the retry
-      // chain runs inline while still going through the async setTimeout path.
+      // Auto-fire timers via microtask so the retry chain runs inline.
       setTimeoutSpy.mockImplementation(
         ((fn: TimerHandler) => {
           if (typeof fn === 'function') queueMicrotask(fn as () => void);
@@ -204,11 +201,9 @@ describe('SettingsBroadcastService', () => {
       const client2 = createMockPoolClient();
       const client3 = createMockPoolClient();
       let connectCount = 0;
-      // A successful reconnect resets `reconnecting` to false *before*
-      // resyncAllSubscribers() (and its loadAllSettings() call) runs, so this
-      // count reaching 2 is a safe proxy for "the reconnect cycle fully
-      // completed", unlike client2's error handler being registered (which
-      // happens earlier, while `reconnecting` may still read true).
+      // `reconnecting` resets to false *before* resyncAllSubscribers() runs, so
+      // loadAllSettings call count is a safer "reconnect fully completed" proxy
+      // than connectCount, which bumps while `reconnecting` may still read true.
       let loadAllSettingsCallCount = 0;
 
       const resetService = new SettingsBroadcastService({

--- a/src/lib/settings/__tests__/settings-broadcast-service.test.ts
+++ b/src/lib/settings/__tests__/settings-broadcast-service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, beforeEach, afterEach, spyOn } from 'bun:te
 import { SettingsBroadcastService } from '../settings-broadcast-service';
 import type { SettingsSSEMessage } from '@/types/settings';
 import type { PoolClient } from 'pg';
+import { waitForCondition } from '@/lib/test/wait-for-condition';
 
 type NotificationHandler = (msg: { channel: string; payload?: string }) => void;
 type ErrorHandler = (err: Error) => void;
@@ -46,10 +47,6 @@ function createMockPoolClient(): MockPoolClient {
   return client;
 }
 
-function flush(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
-}
-
 describe('SettingsBroadcastService', () => {
   let poolClient: MockPoolClient;
   let service: SettingsBroadcastService;
@@ -71,7 +68,7 @@ describe('SettingsBroadcastService', () => {
     const received: SettingsSSEMessage[] = [];
     service.subscribe((m) => received.push(m));
 
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     expect(received).toHaveLength(1);
     expect(received[0].type).toBe('init');
@@ -82,17 +79,17 @@ describe('SettingsBroadcastService', () => {
 
   it('issues LISTEN settings_change on subscribe', async () => {
     service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.querySql !== null);
     expect(poolClient.querySql).toBe('LISTEN settings_change');
   });
 
   it('broadcasts change event from NOTIFY payload', async () => {
     const received: SettingsSSEMessage[] = [];
     service.subscribe((m) => received.push(m));
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     poolClient.emit('notification', { channel: 'settings_change', payload: 'theme' });
-    await flush();
+    await waitForCondition(() => received.some((m) => m.type === 'change'));
 
     const change = received.find((m) => m.type === 'change');
     expect(change).toBeDefined();
@@ -105,21 +102,21 @@ describe('SettingsBroadcastService', () => {
   it('ignores NOTIFY on unrelated channels', async () => {
     const received: SettingsSSEMessage[] = [];
     service.subscribe((m) => received.push(m));
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     poolClient.emit('notification', { channel: 'other_channel', payload: 'theme' });
-    await flush();
-
+    // The channel filter is checked synchronously inside the notification
+    // handler, so an unrelated channel is a same-tick no-op.
     expect(received.filter((m) => m.type === 'change')).toHaveLength(0);
   });
 
   it('stops listening when last subscriber unsubscribes', async () => {
     const unsub = service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     expect(poolClient.released).toBe(false);
     unsub();
-    await flush();
+    await waitForCondition(() => poolClient.released);
     expect(poolClient.released).toBe(true);
   });
 
@@ -140,9 +137,10 @@ describe('SettingsBroadcastService', () => {
 
       try {
         service.subscribe(() => {});
-        await flush();
+        await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
-        // Filter to setTimeout calls with delay >= 100ms to ignore flush() 0ms calls.
+        // The 'error' handler schedules the reconnect via a synchronous
+        // setTimeout call, so no wait is needed between emit and assertion.
         setTimeoutSpy.mockClear();
         poolClient.emit('error', new Error('connection reset'));
 
@@ -164,7 +162,8 @@ describe('SettingsBroadcastService', () => {
         loadSingleSetting: async () => null,
       });
 
-      // Auto-fire timers synchronously so the retry chain runs inline.
+      // Auto-fire timers via microtask (not real elapsed time) so the retry
+      // chain runs inline while still going through the async setTimeout path.
       setTimeoutSpy.mockImplementation(
         ((fn: TimerHandler) => {
           if (typeof fn === 'function') queueMicrotask(fn as () => void);
@@ -174,10 +173,15 @@ describe('SettingsBroadcastService', () => {
 
       const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
 
+      const backoffDelaysAtLeast3 = () =>
+        (setTimeoutSpy.mock.calls as Array<[unknown, unknown?]>)
+          .map(([, delay]) => delay)
+          .filter((d): d is number => typeof d === 'number' && d >= 100).length >= 3;
+
       try {
         failingService.subscribe(() => {});
         // Allow several retry cycles to elapse.
-        for (let i = 0; i < 10; i++) await flush();
+        await waitForCondition(backoffDelaysAtLeast3);
 
         const backoffDelays = (setTimeoutSpy.mock.calls as Array<[unknown, unknown?]>)
           .map(([, delay]) => delay)
@@ -200,6 +204,12 @@ describe('SettingsBroadcastService', () => {
       const client2 = createMockPoolClient();
       const client3 = createMockPoolClient();
       let connectCount = 0;
+      // A successful reconnect resets `reconnecting` to false *before*
+      // resyncAllSubscribers() (and its loadAllSettings() call) runs, so this
+      // count reaching 2 is a safe proxy for "the reconnect cycle fully
+      // completed", unlike client2's error handler being registered (which
+      // happens earlier, while `reconnecting` may still read true).
+      let loadAllSettingsCallCount = 0;
 
       const resetService = new SettingsBroadcastService({
         getPoolClient: async () => {
@@ -208,7 +218,7 @@ describe('SettingsBroadcastService', () => {
           if (connectCount === 2) return client2 as unknown as PoolClient;
           return client3 as unknown as PoolClient;
         },
-        loadAllSettings: async () => new Map(),
+        loadAllSettings: async () => { loadAllSettingsCallCount++; return new Map(); },
         loadSingleSetting: async () => null,
       });
 
@@ -225,12 +235,12 @@ describe('SettingsBroadcastService', () => {
 
       try {
         resetService.subscribe(() => {});
-        await flush();
+        await waitForCondition(() => client1.notificationHandlers.length > 0);
 
         // First disconnect cycle: client1 errors → retry schedules delay 500
         // → reconnect callback runs → client2 connects successfully → counter resets.
         client1.emit('error', new Error('first disconnect'));
-        for (let i = 0; i < 5; i++) await flush();
+        await waitForCondition(() => loadAllSettingsCallCount >= 2);
 
         expect(capturedDelays[0]).toBe(500);
         expect(connectCount).toBeGreaterThanOrEqual(2);
@@ -240,7 +250,7 @@ describe('SettingsBroadcastService', () => {
         // would continue from 1000ms.
         capturedDelays.length = 0;
         client2.emit('error', new Error('second disconnect'));
-        for (let i = 0; i < 5; i++) await flush();
+        await waitForCondition(() => loadAllSettingsCallCount >= 3);
 
         expect(capturedDelays[0]).toBe(500);
       } finally {

--- a/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
@@ -204,11 +204,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     const unsub = slowService.subscribe((e) => received.push(e));
-    // unsub() runs synchronously here, before sendInit() ever awaits the
-    // snapshot, so `subscribers.has(callback)` is already false by the time
-    // sendInit checks it: no timing dependency, nothing to poll for. Only
-    // await the snapshot promise so the service's pending work settles
-    // cleanly before stop() below.
+    // unsub() runs before sendInit() awaits the snapshot; await it only so pending work settles before stop().
     unsub();
     resolveSnapshot([composeContainer1]);
     await slowSnapshot;
@@ -245,8 +241,7 @@ describe('StackStatusBroadcastService', () => {
       exit_code: 0,
     });
 
-    // handleContainerChange runs synchronously inside the 'notification'
-    // handler, so emit() has already broadcast by the time it returns.
+    // handleContainerChange runs synchronously, so emit() has already broadcast by the time it returns.
     poolClient.emit('notification', { channel: 'docker_container_change', payload: notifyPayload });
 
     expect(received.length).toBeGreaterThanOrEqual(2);
@@ -410,8 +405,7 @@ describe('StackStatusBroadcastService', () => {
     await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     expect(poolClient.released).toBe(false);
-    // cleanupListenerClient() releases synchronously, so no wait is needed
-    // between unsub() and the assertion.
+    // cleanupListenerClient() releases synchronously; no wait needed.
     unsub();
     expect(poolClient.released).toBe(true);
   });
@@ -434,8 +428,7 @@ describe('StackStatusBroadcastService', () => {
     service.subscribe(() => {});
     await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
-    // The 'error' handler schedules the reconnect via a synchronous
-    // setTimeout call, so no wait is needed between emit and assertion.
+    // error handler schedules reconnect via synchronous setTimeout; no wait needed.
     poolClient.emit('error', new Error('connection reset'));
 
     expect(setTimeoutSpy).toHaveBeenCalled();
@@ -795,9 +788,7 @@ describe('StackStatusBroadcastService', () => {
 
     received2.length = 0;
 
-    // Once the in-memory stack state is seeded (as it is here), sendInit()
-    // for additional subscribers builds the payload synchronously from
-    // memory and calls back immediately, so no wait is needed.
+    // Stack state is already seeded, so sendInit() for this subscriber builds from memory synchronously.
     service.subscribe(() => {});
 
     poolClient.emit('notification', {

--- a/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
@@ -3,6 +3,7 @@ import { StackStatusBroadcastService } from '../stack-status-broadcast-service';
 import type { StackBroadcastEvent } from '../stack-status-broadcast-service';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
 import type { PoolClient } from 'pg';
+import { waitForCondition } from '@/lib/test/wait-for-condition';
 
 type NotificationHandler = (msg: { channel: string; payload?: string }) => void;
 type ErrorHandler = (err: Error) => void;
@@ -45,10 +46,6 @@ function createMockPoolClient(): MockPoolClient {
     },
   };
   return client;
-}
-
-function flush(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 const composeContainer1: DockerInventorySnapshotContainer = {
@@ -134,7 +131,7 @@ describe('StackStatusBroadcastService', () => {
   it('sends init with only compose rows grouped by (host, stack)', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     expect(received).toHaveLength(1);
     const init = received[0];
@@ -156,7 +153,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const init = received[0];
     expect(init.type).toBe('status');
@@ -174,7 +171,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const init = received[0];
     expect(init.type).toBe('status');
@@ -188,7 +185,7 @@ describe('StackStatusBroadcastService', () => {
   it('excludes non-compose containers from init payload', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const init = received[0];
     if (init.type === 'status') {
@@ -207,9 +204,14 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     const unsub = slowService.subscribe((e) => received.push(e));
+    // unsub() runs synchronously here, before sendInit() ever awaits the
+    // snapshot, so `subscribers.has(callback)` is already false by the time
+    // sendInit checks it: no timing dependency, nothing to poll for. Only
+    // await the snapshot promise so the service's pending work settles
+    // cleanly before stop() below.
     unsub();
     resolveSnapshot([composeContainer1]);
-    await flush();
+    await slowSnapshot;
 
     expect(received).toHaveLength(0);
     await slowService.stop();
@@ -217,7 +219,7 @@ describe('StackStatusBroadcastService', () => {
 
   it('issues LISTEN for both docker_container_change and deploy_change', async () => {
     service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.issuedQueries.includes('LISTEN deploy_change'));
 
     expect(poolClient.issuedQueries).toContain('LISTEN docker_container_change');
     expect(poolClient.issuedQueries).toContain('LISTEN deploy_change');
@@ -226,7 +228,7 @@ describe('StackStatusBroadcastService', () => {
   it('broadcasts stack status update when compose container upserted', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const notifyPayload = JSON.stringify({
       at: '2026-04-16T11:00:00Z',
@@ -243,6 +245,8 @@ describe('StackStatusBroadcastService', () => {
       exit_code: 0,
     });
 
+    // handleContainerChange runs synchronously inside the 'notification'
+    // handler, so emit() has already broadcast by the time it returns.
     poolClient.emit('notification', { channel: 'docker_container_change', payload: notifyPayload });
 
     expect(received.length).toBeGreaterThanOrEqual(2);
@@ -258,7 +262,7 @@ describe('StackStatusBroadcastService', () => {
   it('ignores upsert of non-compose container (null compose_project)', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const countBefore = received.length;
 
@@ -291,7 +295,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     poolClient.emit('notification', {
       channel: 'docker_container_change',
@@ -321,7 +325,7 @@ describe('StackStatusBroadcastService', () => {
   it('broadcasts empty containers array when last container in stack is destroyed', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     poolClient.emit('notification', {
       channel: 'docker_container_change',
@@ -350,7 +354,7 @@ describe('StackStatusBroadcastService', () => {
   it('forwards deploy_change NOTIFY as deploy_changed event', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     poolClient.emit('notification', {
       channel: 'deploy_change',
@@ -370,7 +374,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const countBefore = received.length;
     poolClient.emit('notification', {
@@ -388,7 +392,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const countBefore = received.length;
     poolClient.emit('notification', {
@@ -403,9 +407,11 @@ describe('StackStatusBroadcastService', () => {
 
   it('auto-starts on first subscriber and auto-stops on last unsubscribe', async () => {
     const unsub = service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     expect(poolClient.released).toBe(false);
+    // cleanupListenerClient() releases synchronously, so no wait is needed
+    // between unsub() and the assertion.
     unsub();
     expect(poolClient.released).toBe(true);
   });
@@ -413,7 +419,7 @@ describe('StackStatusBroadcastService', () => {
   it('keeps listening when one of multiple subscribers unsubscribes', async () => {
     const unsub1 = service.subscribe(() => {});
     const unsub2 = service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     unsub1();
     expect(poolClient.released).toBe(false);
@@ -426,8 +432,10 @@ describe('StackStatusBroadcastService', () => {
     const setTimeoutSpy = spyOn(globalThis, 'setTimeout');
 
     service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
+    // The 'error' handler schedules the reconnect via a synchronous
+    // setTimeout call, so no wait is needed between emit and assertion.
     poolClient.emit('error', new Error('connection reset'));
 
     expect(setTimeoutSpy).toHaveBeenCalled();
@@ -450,10 +458,10 @@ describe('StackStatusBroadcastService', () => {
     });
 
     reconnectService.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => connectCount >= 1);
 
     poolClient.emit('error', new Error('transient error'));
-    await flush();
+    await waitForCondition(() => connectCount >= 2);
 
     expect(connectCount).toBeGreaterThanOrEqual(2);
 
@@ -464,7 +472,7 @@ describe('StackStatusBroadcastService', () => {
   it('ignores notifications on unrecognized channels', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const countBefore = received.length;
     poolClient.emit('notification', {
@@ -481,7 +489,7 @@ describe('StackStatusBroadcastService', () => {
 
     service.subscribe((e) => received1.push(e));
     service.subscribe((e) => received2.push(e));
-    await flush();
+    await waitForCondition(() => received1.length > 0 && received2.length > 0);
 
     poolClient.emit('notification', {
       channel: 'deploy_change',
@@ -500,7 +508,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const init = received[0];
     if (init.type === 'status') {
@@ -512,7 +520,7 @@ describe('StackStatusBroadcastService', () => {
   it('produces StackStatusRow with correct container fields', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const init = received[0];
     if (init.type === 'status') {
@@ -539,7 +547,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     noPrefixService.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const init = received[0];
     if (init.type === 'status') {
@@ -561,7 +569,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     emptyKeyService.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const init = received[0];
     if (init.type === 'status') {
@@ -584,7 +592,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     trailingSlashService.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const init = received[0];
     if (init.type === 'status') {
@@ -596,7 +604,7 @@ describe('StackStatusBroadcastService', () => {
   it('updated_at is an ISO string', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     const init = received[0] as Extract<StackBroadcastEvent, { type: 'status' }>;
     expect(typeof init.entries[0].updated_at).toBe('string');
@@ -606,7 +614,7 @@ describe('StackStatusBroadcastService', () => {
   it('broadcasts empty-stack destroy with event at timestamp as ISO string', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     poolClient.emit('notification', {
       channel: 'docker_container_change',
@@ -641,7 +649,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     // Real Docker destroy events carry labels: {} so compose_project is null,
     // so removal must still find the container via its in-memory stack entry.
@@ -723,7 +731,7 @@ describe('StackStatusBroadcastService', () => {
 
     const received: StackBroadcastEvent[] = [];
     reconnectService.subscribe((e) => received.push(e));
-    await flush();
+    await waitForCondition(() => received.length > 0);
 
     expect(received.length).toBeGreaterThanOrEqual(1);
     const initStatus = received[0] as Extract<StackBroadcastEvent, { type: 'status' }>;
@@ -739,7 +747,7 @@ describe('StackStatusBroadcastService', () => {
 
     try {
       firstClient.emit('error', new Error('connection lost'));
-      for (let i = 0; i < 20; i++) await flush();
+      await waitForCondition(() => connectCount >= 3 && snapshotCallCount >= 2);
 
       expect(connectCount).toBeGreaterThanOrEqual(3);
       expect(snapshotCallCount).toBeGreaterThanOrEqual(2);
@@ -783,12 +791,14 @@ describe('StackStatusBroadcastService', () => {
       throw new Error('subscriber 1 is broken');
     });
     service.subscribe((e) => received2.push(e));
-    await flush();
+    await waitForCondition(() => received2.length > 0);
 
     received2.length = 0;
 
+    // Once the in-memory stack state is seeded (as it is here), sendInit()
+    // for additional subscribers builds the payload synchronously from
+    // memory and calls back immediately, so no wait is needed.
     service.subscribe(() => {});
-    await flush();
 
     poolClient.emit('notification', {
       channel: 'docker_container_change',
@@ -823,7 +833,7 @@ describe('StackStatusBroadcastService', () => {
     let timerSet = false;
 
     service.subscribe(() => {});
-    await flush();
+    await waitForCondition(() => poolClient.notificationHandlers.length > 0);
 
     (globalThis as any).setTimeout = (fn: () => void) => {
       capturedTimers.push(fn);
@@ -879,8 +889,7 @@ describe('default dependency implementations', () => {
     const service = new StackStatusBroadcastService();
     const received: unknown[] = [];
     const unsub = service.subscribe((event) => { received.push(event); });
-    await flush();
-    await flush();
+    await waitForCondition(() => received.some((e) => (e as { type: string }).type === 'status'));
     unsub();
     await service.stop();
     // sendInit fires a 'status' event with an empty entries list (snapshot is empty)

--- a/src/lib/test/wait-for-condition.ts
+++ b/src/lib/test/wait-for-condition.ts
@@ -1,11 +1,8 @@
 /**
  * Polls `predicate` until it returns true, throwing if `timeoutMs` elapses first.
  *
- * Used in place of a fixed `setTimeout` sleep to await async side effects
- * (NOTIFY fan-out, reconnect retries, listener registration) deterministically:
- * the wait ends the instant the condition is actually met instead of hoping a
- * magic-number delay happened to be long enough, which is both slower than
- * necessary when the condition settles fast and flaky when it doesn't.
+ * For plain async services (NOTIFY fan-out, reconnect retries, listener
+ * registration) where no promise or callback exposes the awaited state.
  */
 export async function waitForCondition(
   predicate: () => boolean,

--- a/src/lib/test/wait-for-condition.ts
+++ b/src/lib/test/wait-for-condition.ts
@@ -1,0 +1,22 @@
+/**
+ * Polls `predicate` until it returns true, throwing if `timeoutMs` elapses first.
+ *
+ * Used in place of a fixed `setTimeout` sleep to await async side effects
+ * (NOTIFY fan-out, reconnect retries, listener registration) deterministically:
+ * the wait ends the instant the condition is actually met instead of hoping a
+ * magic-number delay happened to be long enough, which is both slower than
+ * necessary when the condition settles fast and flaky when it doesn't.
+ */
+export async function waitForCondition(
+  predicate: () => boolean,
+  opts: { timeoutMs?: number; intervalMs?: number; message?: string } = {},
+): Promise<void> {
+  const { timeoutMs = 2000, intervalMs = 5, message = 'waitForCondition: condition not met within timeout' } = opts;
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(message);
+    }
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+}

--- a/src/worker/collectors/__tests__/agent-sse-stream.test.ts
+++ b/src/worker/collectors/__tests__/agent-sse-stream.test.ts
@@ -290,12 +290,21 @@ describe('connectAgentSseStream', () => {
     const encoder = new TextEncoder();
     const abortController = new AbortController();
     let pullCount = 0;
+    // Gates are pre-created (not assigned lazily inside pull()) so releasing
+    // one is safe even before pull() has reached the matching await; the
+    // consumer below releases pull N only after actually consuming item N,
+    // keeping producer and consumer in lockstep.
+    const gates = Array.from({ length: 5 }, () => {
+      let release: () => void = () => {};
+      const promise = new Promise<void>(resolve => { release = resolve; });
+      return { promise, release };
+    });
     const stream = new ReadableStream<Uint8Array>({
       async pull(controller) {
         pullCount++;
         if (pullCount <= 5) {
           controller.enqueue(encoder.encode(`data: {"n":${pullCount}}\n\n`));
-          await new Promise((resolve) => setTimeout(resolve, 10));
+          await gates[pullCount - 1].promise;
         } else {
           controller.close();
         }
@@ -313,9 +322,16 @@ describe('connectAgentSseStream', () => {
       fetchFn,
     });
 
-    setTimeout(() => abortController.abort(new DOMException('Shutdown', 'AbortError')), 15);
+    const results: unknown[] = [];
+    for await (const item of gen) {
+      results.push(item);
+      // Abort partway through: readFrames()'s while-loop checks
+      // `signal.aborted` before requesting the next chunk, so no further
+      // items are produced once this fires.
+      if (results.length === 2) abortController.abort(new DOMException('Shutdown', 'AbortError'));
+      gates[results.length - 1].release();
+    }
 
-    const results = await collect(gen);
     expect(results.length).toBeGreaterThan(0);
     expect(results.length).toBeLessThan(5);
   });

--- a/src/worker/collectors/__tests__/agent-sse-stream.test.ts
+++ b/src/worker/collectors/__tests__/agent-sse-stream.test.ts
@@ -290,10 +290,7 @@ describe('connectAgentSseStream', () => {
     const encoder = new TextEncoder();
     const abortController = new AbortController();
     let pullCount = 0;
-    // Gates are pre-created (not assigned lazily inside pull()) so releasing
-    // one is safe even before pull() has reached the matching await; the
-    // consumer below releases pull N only after actually consuming item N,
-    // keeping producer and consumer in lockstep.
+    // Gates are pre-created so releasing one is safe even before pull() awaits it.
     const gates = Array.from({ length: 5 }, () => {
       let release: () => void = () => {};
       const promise = new Promise<void>(resolve => { release = resolve; });
@@ -325,9 +322,7 @@ describe('connectAgentSseStream', () => {
     const results: unknown[] = [];
     for await (const item of gen) {
       results.push(item);
-      // Abort partway through: readFrames()'s while-loop checks
-      // `signal.aborted` before requesting the next chunk, so no further
-      // items are produced once this fires.
+      // readFrames() checks signal.aborted before requesting the next chunk.
       if (results.length === 2) abortController.abort(new DOMException('Shutdown', 'AbortError'));
       gates[results.length - 1].release();
     }

--- a/src/worker/collectors/__tests__/agent-stats-collector.test.ts
+++ b/src/worker/collectors/__tests__/agent-stats-collector.test.ts
@@ -34,9 +34,9 @@ function createMockDb() {
 function watchFirstPush(collector: AgentStatsCollector): Promise<void> {
   let mark = () => {};
   const queued = new Promise<void>(resolve => { mark = resolve; });
-  const pendingRows = (collector as any).pendingRows as DockerStatsRow[];
+  const pendingRows = (collector as any).pendingRows as NewDockerStat[];
   const originalPush = pendingRows.push.bind(pendingRows);
-  pendingRows.push = ((...rows: DockerStatsRow[]) => {
+  pendingRows.push = ((...rows: NewDockerStat[]) => {
     const result = originalPush(...rows);
     mark();
     return result;

--- a/src/worker/collectors/__tests__/agent-stats-collector.test.ts
+++ b/src/worker/collectors/__tests__/agent-stats-collector.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, mock, spyOn } from 'bun:test';
 import { AgentStatsCollector } from '../agent-stats-collector';
 import type { ManagedHost } from '@/lib/database/repositories/host-repository';
 import type { NewDockerStat } from '@/lib/database/repositories/stats-repository';
@@ -297,15 +297,26 @@ describe('AgentStatsCollector', () => {
     // Wait for the first row instead of sleeping past the real 150ms FLUSH_INTERVAL_MS.
     const firstRowQueued = watchFirstPush(collector);
 
-    const collectPromise = (collector as any).collect();
+    // Capture the flush callback collect() registers so the test drives the real
+    // interval wiring, just without the 150ms wait.
+    let intervalFlush: (() => void) | undefined;
+    const setIntervalSpy = spyOn(globalThis, 'setInterval').mockImplementation(
+      ((fn: () => void) => { intervalFlush = fn; return 0; }) as unknown as typeof setInterval,
+    );
+    try {
+      const collectPromise = (collector as any).collect();
 
-    await firstRowQueued;
-    await (collector as any).flushPendingRows();
+      await firstRowQueued;
+      expect(intervalFlush).toBeDefined();
+      intervalFlush!();
 
-    releaseSecondEvent();
-    await collectPromise;
+      releaseSecondEvent();
+      await collectPromise;
+    } finally {
+      setIntervalSpy.mockRestore();
+    }
 
-    // First event flushed by the manually-driven interval flush, second by the final drain
+    // First event flushed by the interval callback, second by the final drain
     expect(mockDb.insertedRows).toHaveLength(2);
     expect(mockDb.insertedRows[0][0].containerName).toBe('plex');
     expect(mockDb.insertedRows[1][0].containerName).toBe('sonarr');

--- a/src/worker/collectors/__tests__/agent-stats-collector.test.ts
+++ b/src/worker/collectors/__tests__/agent-stats-collector.test.ts
@@ -30,6 +30,24 @@ function createMockDb() {
   };
 }
 
+/**
+ * Resolves the instant the collector's pendingRows buffer receives its first
+ * row. Used in place of a fixed sleep to know exactly when a queued event is
+ * safe to act on (manually flush, abort mid-stream, etc).
+ */
+function watchFirstPush(collector: AgentStatsCollector): Promise<void> {
+  let mark = () => {};
+  const queued = new Promise<void>(resolve => { mark = resolve; });
+  const pendingRows = (collector as any).pendingRows as DockerStatsRow[];
+  const originalPush = pendingRows.push.bind(pendingRows);
+  pendingRows.push = ((...rows: DockerStatsRow[]) => {
+    const result = originalPush(...rows);
+    mark();
+    return result;
+  }) as typeof pendingRows.push;
+  return queued;
+}
+
 const defaultConfig = {
   docker: { enabled: true },
   zfs: { enabled: false },
@@ -280,25 +298,40 @@ describe('AgentStatsCollector', () => {
     );
     mockDb.patchRepository(collector);
 
+    // Resolves the instant the first row lands in the collector's pending
+    // buffer, so the test can drive the flush deterministically instead of
+    // sleeping past the real 150ms FLUSH_INTERVAL_MS timer.
+    const firstRowQueued = watchFirstPush(collector);
+
     const collectPromise = (collector as any).collect();
 
-    // Wait past the flush interval, then let the second event through
-    await new Promise(resolve => setTimeout(resolve, 250));
+    // Drive the flush the interval timer would otherwise perform.
+    await firstRowQueued;
+    await (collector as any).flushPendingRows();
+
     releaseSecondEvent();
     await collectPromise;
 
-    // First event flushed by the interval timer, second by the final drain
+    // First event flushed by the manually-driven interval flush, second by the final drain
     expect(mockDb.insertedRows).toHaveLength(2);
     expect(mockDb.insertedRows[0][0].containerName).toBe('plex');
     expect(mockDb.insertedRows[1][0].containerName).toBe('sonarr');
   });
 
   it('stops processing when abort signal fires', async () => {
-    // Emit events with a delay between them so abort can fire mid-stream
+    // Emit events one at a time, gated so the test controls exactly when the
+    // stream advances to the next event. Gates are pre-created (not assigned
+    // lazily inside the generator) so releasing one is safe even before the
+    // generator has reached the matching await.
+    const gates = Array.from({ length: 5 }, () => {
+      let release: () => void = () => {};
+      const promise = new Promise<void>(resolve => { release = resolve; });
+      return { promise, release };
+    });
     const streamConnector: StreamConnector = async function* () {
       for (let i = 0; i < 5; i++) {
         yield sampleAgentEvent;
-        await new Promise(resolve => setTimeout(resolve, 20));
+        await gates[i].promise;
       }
     } as unknown as StreamConnector;
 
@@ -307,11 +340,21 @@ describe('AgentStatsCollector', () => {
     );
     mockDb.patchRepository(collector);
 
-    // Abort after a short delay
-    setTimeout(() => abortController.abort(new DOMException('Shutdown', 'AbortError')), 50);
+    // Resolves once the first event has been queued into pendingRows: the
+    // deterministic point at which abort mid-stream should be exercised.
+    const firstRowQueued = watchFirstPush(collector);
+
+    const collectPromise = (collector as any).collect();
+    await firstRowQueued;
+
+    // Abort, then let the stream advance: the for-await loop checks
+    // `signal.aborted` before processing the next frame, so no further
+    // event is queued once this fires.
+    abortController.abort(new DOMException('Shutdown', 'AbortError'));
+    gates[0].release();
 
     // collect() should return once abort fires
-    await (collector as any).collect();
+    await collectPromise;
 
     // At least one row should have been inserted before abort
     expect(mockDb.insertedRows.length).toBeGreaterThanOrEqual(1);

--- a/src/worker/collectors/__tests__/agent-stats-collector.test.ts
+++ b/src/worker/collectors/__tests__/agent-stats-collector.test.ts
@@ -30,11 +30,7 @@ function createMockDb() {
   };
 }
 
-/**
- * Resolves the instant the collector's pendingRows buffer receives its first
- * row. Used in place of a fixed sleep to know exactly when a queued event is
- * safe to act on (manually flush, abort mid-stream, etc).
- */
+/** Resolves when the collector's pendingRows buffer receives its first row. */
 function watchFirstPush(collector: AgentStatsCollector): Promise<void> {
   let mark = () => {};
   const queued = new Promise<void>(resolve => { mark = resolve; });
@@ -298,14 +294,11 @@ describe('AgentStatsCollector', () => {
     );
     mockDb.patchRepository(collector);
 
-    // Resolves the instant the first row lands in the collector's pending
-    // buffer, so the test can drive the flush deterministically instead of
-    // sleeping past the real 150ms FLUSH_INTERVAL_MS timer.
+    // Wait for the first row instead of sleeping past the real 150ms FLUSH_INTERVAL_MS.
     const firstRowQueued = watchFirstPush(collector);
 
     const collectPromise = (collector as any).collect();
 
-    // Drive the flush the interval timer would otherwise perform.
     await firstRowQueued;
     await (collector as any).flushPendingRows();
 
@@ -319,10 +312,7 @@ describe('AgentStatsCollector', () => {
   });
 
   it('stops processing when abort signal fires', async () => {
-    // Emit events one at a time, gated so the test controls exactly when the
-    // stream advances to the next event. Gates are pre-created (not assigned
-    // lazily inside the generator) so releasing one is safe even before the
-    // generator has reached the matching await.
+    // Gates are pre-created so releasing one is safe even before the generator awaits it.
     const gates = Array.from({ length: 5 }, () => {
       let release: () => void = () => {};
       const promise = new Promise<void>(resolve => { release = resolve; });
@@ -340,16 +330,12 @@ describe('AgentStatsCollector', () => {
     );
     mockDb.patchRepository(collector);
 
-    // Resolves once the first event has been queued into pendingRows: the
-    // deterministic point at which abort mid-stream should be exercised.
     const firstRowQueued = watchFirstPush(collector);
 
     const collectPromise = (collector as any).collect();
     await firstRowQueued;
 
-    // Abort, then let the stream advance: the for-await loop checks
-    // `signal.aborted` before processing the next frame, so no further
-    // event is queued once this fires.
+    // for-await loop checks signal.aborted before processing the next frame.
     abortController.abort(new DOMException('Shutdown', 'AbortError'));
     gates[0].release();
 

--- a/src/worker/collectors/__tests__/zfs-collector.test.ts
+++ b/src/worker/collectors/__tests__/zfs-collector.test.ts
@@ -30,11 +30,11 @@ function createMockDb() {
 }
 
 /** Resolves when a row batch is written to `insertedRows` (first cycle flushed to the DB). */
-function watchFirstInsert(insertedRows: ZFSStatsRow[][]): Promise<void> {
+function watchFirstInsert(insertedRows: NewZFSStat[][]): Promise<void> {
   let mark = () => {};
   const written = new Promise<void>(resolve => { mark = resolve; });
   const originalPush = insertedRows.push.bind(insertedRows);
-  insertedRows.push = ((...rows: ZFSStatsRow[][]) => {
+  insertedRows.push = ((...rows: NewZFSStat[][]) => {
     const result = originalPush(...rows);
     mark();
     return result;

--- a/src/worker/collectors/__tests__/zfs-collector.test.ts
+++ b/src/worker/collectors/__tests__/zfs-collector.test.ts
@@ -29,11 +29,7 @@ function createMockDb() {
   };
 }
 
-/**
- * Resolves the instant a row batch is written to `insertedRows`. Used in
- * place of a fixed sleep to know exactly when the first cycle has actually
- * been flushed to the DB.
- */
+/** Resolves when a row batch is written to `insertedRows` (first cycle flushed to the DB). */
 function watchFirstInsert(insertedRows: ZFSStatsRow[][]): Promise<void> {
   let mark = () => {};
   const written = new Promise<void>(resolve => { mark = resolve; });
@@ -295,9 +291,7 @@ describe('ZFSCollector', () => {
       const headerLine = { line: '              capacity     operations     bandwidth' };
       const dataLine = { line: 'tank        1.81T  2.19T     10     20   100K   200K' };
 
-      // Gates are pre-created (not assigned lazily inside the generator) so
-      // releasing one is safe even before the generator has reached the
-      // matching await.
+      // Gates are pre-created so releasing one is safe even before the generator awaits it.
       const gates = Array.from({ length: 10 }, () => {
         let release: () => void = () => {};
         const promise = new Promise<void>(resolve => { release = resolve; });
@@ -317,21 +311,15 @@ describe('ZFSCollector', () => {
       );
       mockDb.patchRepository(collector);
 
-      // Resolves once the first full cycle has been flushed to the DB (on the
-      // second header line), the deterministic point at which abort mid-stream
-      // should be exercised.
       const firstCycleWritten = watchFirstInsert(mockDb.insertedRows);
 
       const collectPromise = (collector as any).collect();
 
-      // Let the first cycle's header+data flow through so the second header
-      // line can trigger the flush.
+      // Release the first cycle's header+data so the second header line triggers the flush.
       gates[0].release();
       await firstCycleWritten;
 
-      // Abort now: the for-await loop checks `signal.aborted` before
-      // processing the next frame (the second cycle's data line), so no
-      // further row is queued once this fires.
+      // for-await loop checks signal.aborted before processing the next frame.
       abortController.abort(new DOMException('Shutdown', 'AbortError'));
 
       await collectPromise;

--- a/src/worker/collectors/__tests__/zfs-collector.test.ts
+++ b/src/worker/collectors/__tests__/zfs-collector.test.ts
@@ -29,6 +29,23 @@ function createMockDb() {
   };
 }
 
+/**
+ * Resolves the instant a row batch is written to `insertedRows`. Used in
+ * place of a fixed sleep to know exactly when the first cycle has actually
+ * been flushed to the DB.
+ */
+function watchFirstInsert(insertedRows: ZFSStatsRow[][]): Promise<void> {
+  let mark = () => {};
+  const written = new Promise<void>(resolve => { mark = resolve; });
+  const originalPush = insertedRows.push.bind(insertedRows);
+  insertedRows.push = ((...rows: ZFSStatsRow[][]) => {
+    const result = originalPush(...rows);
+    mark();
+    return result;
+  }) as typeof insertedRows.push;
+  return written;
+}
+
 const defaultConfig = {
   docker: { enabled: false },
   zfs: { enabled: true },
@@ -278,11 +295,20 @@ describe('ZFSCollector', () => {
       const headerLine = { line: '              capacity     operations     bandwidth' };
       const dataLine = { line: 'tank        1.81T  2.19T     10     20   100K   200K' };
 
+      // Gates are pre-created (not assigned lazily inside the generator) so
+      // releasing one is safe even before the generator has reached the
+      // matching await.
+      const gates = Array.from({ length: 10 }, () => {
+        let release: () => void = () => {};
+        const promise = new Promise<void>(resolve => { release = resolve; });
+        return { promise, release };
+      });
+
       const streamConnector: StreamConnector = async function* () {
         for (let i = 0; i < 10; i++) {
           yield headerLine;
           yield dataLine;
-          await new Promise((resolve) => setTimeout(resolve, 20));
+          await gates[i].promise;
         }
       } as unknown as StreamConnector;
 
@@ -291,10 +317,24 @@ describe('ZFSCollector', () => {
       );
       mockDb.patchRepository(collector);
 
-      // Abort after a short delay
-      setTimeout(() => abortController.abort(new DOMException('Shutdown', 'AbortError')), 50);
+      // Resolves once the first full cycle has been flushed to the DB (on the
+      // second header line), the deterministic point at which abort mid-stream
+      // should be exercised.
+      const firstCycleWritten = watchFirstInsert(mockDb.insertedRows);
 
-      await (collector as any).collect();
+      const collectPromise = (collector as any).collect();
+
+      // Let the first cycle's header+data flow through so the second header
+      // line can trigger the flush.
+      gates[0].release();
+      await firstCycleWritten;
+
+      // Abort now: the for-await loop checks `signal.aborted` before
+      // processing the next frame (the second cycle's data line), so no
+      // further row is queued once this fires.
+      abortController.abort(new DOMException('Shutdown', 'AbortError'));
+
+      await collectPromise;
 
       // At least one cycle should have been written before abort
       expect(mockDb.insertedRows.length).toBeGreaterThanOrEqual(1);


### PR DESCRIPTION
Removes the `await new Promise(resolve => setTimeout(resolve, N))` flush anti-pattern from the test suite. Each instance is replaced with a wait on the actual condition the test needs, not a guessed duration.

React tests use React Testing Library's `waitFor`. For the three plain service test files (broadcast services), a small helper `src/lib/test/wait-for-condition.ts` polls the condition instead.

**Why not RTL's `waitFor` in the service tests too?** It was tried and reverted. RTL's `waitFor` is the same mechanism (a 50ms `setInterval` plus timeout; the MutationObserver fast path never fires for non-DOM predicates), and it is incompatible with the Bun `spyOn(globalThis, 'setTimeout')` pattern these files use for backoff tests: `waitFor` detects the spy's `_isMockFunction` marker, assumes Jest fake timers, and calls `jest.advanceTimersByTime()`, which Bun's jest shim throws on. It also schedules its own deadline timer through the spied `setTimeout`, so auto-firing spies crash it (TDZ on its timer id). Working around that required a 56-line setTimeout stub with threshold constants, and one test (an unbounded microtask retry chain) hangs under `waitFor` regardless. The 19-line transparent poller is the smaller footprint.

## Files changed

**`src/hooks/__tests__/useContainerTerminal.test.ts`**
`settleAndOpen`/`flushMicrotasksWithoutOpening` waited a flat 10ms for the WebSocket construction effect to run. Replaced with `waitFor(() => expect(mockWsInstances.length).toBeGreaterThan(0))`; the two "does not connect" tests dropped the wait entirely since the effect bails out synchronously before constructing anything.

**`src/hooks/__tests__/useSettings.test.ts`**
One `setTimeout(resolve, 10)` waited for the mocked `updateSetting` promise to resolve before asserting no rollback occurred. Replaced with `await mockUpdateSetting.mock.results[0]?.value`, the exact promise the hook awaits.

**`src/components/__tests__/header/nav-config.test.ts`**
`setTimeout(resolve, 0)` waited for a rejected `prefetchQuery` promise to settle before checking for an unhandled rejection. Replaced with awaiting the specific rejecting promise that `handlePrefetch`'s own `.catch()` attaches to.

**`src/components/docker/__tests__/ContainerTerminal.test.tsx`**
One `setTimeout(resolve, 0)` waited for a synchronous `useEffect` that had already run by the time `render()` returned; removed. One `setTimeout(resolve, 10)` waited for the mock `Terminal` to be constructed via a dynamic import; replaced with `waitFor` on the constructed-instance count.

**`src/components/docker/__tests__/IconPickerDialog.test.tsx`**
Two `setTimeout(resolve, 1)` calls waited for the component's own `SELECTION_FEEDBACK_MS` timer to fire `onClose`. Replaced with `waitFor(() => expect(onClose).toHaveBeenCalledTimes(1))`.

**`src/hooks/__tests__/useTimeSeriesStream.test.ts`**
Around 40 `setTimeout(r, 50/100/150)` calls waited for preload/refresh/SSE-flush state to land. All replaced with `waitFor(...)` polling the actual `result.current` state or mock call counts. A few became no-ops where the checked code path (cooldown checks, the "fresh initialData" mount effect) is fully synchronous.

**`src/worker/collectors/__tests__/agent-stats-collector.test.ts`**
`setTimeout(resolve, 250)` waited past the real 150ms `FLUSH_INTERVAL_MS` for the periodic flush; replaced by hooking `pendingRows.push` to resolve a promise the instant a row queues, then invoking `flushPendingRows()` directly. `setTimeout(resolve, 20)` paced a 5-event stream so a timed abort would land mid-stream; replaced with pre-created gate promises per event, so abort fires after exactly one row is processed.

**`src/worker/collectors/__tests__/zfs-collector.test.ts`**
Same abort-mid-stream pattern, adapted to the ZFS collector's header/data-line cycle boundary: waits for the first `insertZFSStats` call before aborting.

**`src/lib/mock/__tests__/mock-event-source.test.ts`**
`setTimeout(resolve, 100)` waited to confirm no message ever arrives for an unrecognized SSE path. `_start()` returns synchronously without scheduling anything for that path, so the wait was removed.

**`src/worker/collectors/__tests__/agent-sse-stream.test.ts`**
`setTimeout(resolve, 10)` inside `pull()` paced a 5-chunk stream so a timed abort would land partway through. Replaced with pre-created gate promises per chunk, released by the consumer after consuming each item, so the abort point (after the 2nd item) is exact.

**`src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts`**, **`src/lib/settings/__tests__/settings-broadcast-service.test.ts`**, **`src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts`**
All three shared a `flush()` helper (`setTimeout(resolve, 0)`) used after every `subscribe()`/`emit()` call. Replaced with `waitForCondition` polling the actual signal each call needed (LISTEN handler registered, init received, query issued, reconnect count). Waits were dropped entirely where the service's notification/error handlers are synchronous.

A follow-up commit tersens the explanatory comments to one line each, keeping only the ones that document real timing invariants (backoff-counter reset ordering, the `reconnecting` flag reset, seed/evict semantics). A final commit aligns two collector test helpers with the `NewDockerStat`/`NewZFSStat` type names from the stats repository refactor that merged in the meantime.

## Left as-is (judged legitimate)

- **`src/worker/__tests__/hosts-listener.test.ts`**: its `flush()` uses `setImmediate`, not `setTimeout`; the backoff timer is already faked to fire synchronously, so one macrotask hop drains the whole reconnect chain. Same category as the fake-timer pattern this task keeps.
- `flushTimers()` in `Header.test.tsx`, `useMenuController.test.ts`, `AuthManagementCard.test.tsx`, and `flushOneFrame()` in `SparklineCanvas.test.tsx`: all intercept `setTimeout`/`requestAnimationFrame` with an in-memory queue and fire callbacks manually inside `act()`. No real timer or sleep involved.
- `tick` in `subscription-service.test.ts`: a captured fake-interval callback invoked directly, not a timer wait.

## Verification

Rebased onto main (post #345). `bun run typecheck` clean; all 13 touched test files pass under `bun test --isolate` (259 tests, repeated runs on the previously flaky ones).

---
_Generated by [Claude Code](https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved asynchronous test reliability across navigation, terminal, settings, streaming, broadcast, and collector workflows.
  * Replaced timer- and flush-based delays (`act`/`setTimeout`) with deterministic `waitFor`/condition checks and controlled event sequencing.
  * Added a reusable `waitForCondition` utility with configurable timeouts to synchronize on observable outcomes.
  * Strengthened assertions for rejection handling, reconnect/backoff behavior, unsubscribe/snapshot ordering, and abort-driven stream shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->