### PR TITLE
ci: gate PRs on the demo build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,23 @@ jobs:
           path: agent-updater/license-report.json
           retention-days: 30
 
+  demo-build:
+    name: Demo Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build demo
+        run: bun run build:demo
+
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest
@@ -305,7 +322,7 @@ jobs:
   deploy-demo:
     name: Deploy Demo to GitHub Pages
     runs-on: ubuntu-latest
-    needs: [build-test, agent, agent-updater]
+    needs: [build-test, agent, agent-updater, demo-build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     concurrency:
       group: pages


### PR DESCRIPTION
## What

Adds a `demo-build` job to CI that runs `bun run build:demo` on every PR, and makes the Pages deploy depend on it.

## Why

The demo build was only exercised by the `deploy-demo` job, which is gated to `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`. So a PR that breaks the demo bundle passes all PR checks, merges, and the breakage first appears as a failed Pages deploy on main.

That is exactly how the #347 bug happened: #321 added the `getStackVariableValues` server function without mirroring it in the demo mock. Nothing on the PR path catches that class of bug:

- `tsc` passes because the demo mock swap happens via Vite aliases at bundle time; TypeScript always resolves the real module.
- `bun run build` passes because the regular build never applies the demo aliases.
- Only `vite build` with `VITE_DEMO_MODE=true` surfaces it, as a Rollup `MISSING_EXPORT` error.

Verified both directions locally: `bun run build:demo` fails on current main with the `MISSING_EXPORT "getStackVariableValues"` error and succeeds with #347's fix merged in.

## Notes

- The new job runs in parallel with `build-test`, so it adds no wall-clock time to the critical path. It repeats the typecheck (`build:demo` chains it), which is redundant but keeps CI running the same script developers run locally.
- Merge order: **#347 must merge before this**, otherwise the new check is red on every PR until the demo mock fix lands.
- Related gap, deliberately not addressed here: the `publish` Docker-image job is also push-only, so Dockerfile breakage is not PR-gated either. Image builds are slow enough that gating them (or path-filtering them) deserves its own decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq

---
_Generated by [Claude Code](https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq)_