### PR TITLE
feat(agent): carry container ports and mounts in inventory protocol

### DIFF
--- a/agent/src/__tests__/containers-events.test.ts
+++ b/agent/src/__tests__/containers-events.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test, mock, beforeAll, beforeEach, afterEach, afterAl
 import { EventEmitter } from 'node:events';
 import { handleContainerEvents } from '../routes/containers-events';
 import { _resetBroadcasterForTesting } from '../lib/docker-events-broadcaster';
+import { zInventorySnapshotContainer } from '../types/protocol';
 
 const originalConsoleError = console.error;
 
@@ -489,6 +490,114 @@ describe('handleContainerEvents: error resilience', () => {
     expect(response.status).toBe(200);
     await new Promise((r) => setTimeout(r, 20));
     ac.abort();
+  });
+});
+
+describe('handleContainerEvents: ports and mounts pass-through', () => {
+  test('init event carries ports and mounts from inspect', async () => {
+    const containers = [makeContainer('c1', 'app1')];
+    const docker = makeDocker(containers, new EventEmitter(), (id) => Promise.resolve({
+      Id: id,
+      Name: '/app1',
+      State: { Status: 'running' },
+      Config: { Image: 'nginx:latest', Labels: {} },
+      NetworkSettings: { Ports: { '80/tcp': [{ HostIp: '0.0.0.0', HostPort: '8080' }] } },
+      Mounts: [{ Type: 'bind', Source: '/host', Destination: '/data', RW: true }],
+    }));
+
+    const ac = new AbortController();
+    const request = new Request('http://localhost/containers/events', { signal: ac.signal });
+    const response = await handleContainerEvents(docker as any, request);
+
+    const text = await readUntil(response, (s) => s.includes('"op":"init"'));
+    ac.abort();
+
+    const event = JSON.parse(text.split('\n\n').find(Boolean)!.replace(/^data: /, ''));
+    const c = event.containers[0];
+    expect(c.ports).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 }]);
+    expect(c.mounts).toEqual([{ type: 'bind', source: '/host', destination: '/data', rw: true }]);
+  });
+
+  test('init event has empty ports and mounts when the container exposes none', async () => {
+    const containers = [makeContainer('c1', 'app1')];
+    const docker = makeDocker(containers);
+
+    const ac = new AbortController();
+    const request = new Request('http://localhost/containers/events', { signal: ac.signal });
+    const response = await handleContainerEvents(docker as any, request);
+
+    const text = await readUntil(response, (s) => s.includes('"op":"init"'));
+    ac.abort();
+
+    const event = JSON.parse(text.split('\n\n').find(Boolean)!.replace(/^data: /, ''));
+    const c = event.containers[0];
+    expect(c.ports).toEqual([]);
+    expect(c.mounts).toEqual([]);
+  });
+
+  test('upsert event carries ports and mounts from inspect', async () => {
+    const eventsEmitter = new EventEmitter();
+    const containers = [makeContainer('c1', 'app1')];
+    const docker = makeDocker(containers, eventsEmitter, (id) => Promise.resolve({
+      Id: id,
+      Name: '/app1',
+      State: { Status: 'running' },
+      Config: { Image: 'nginx:latest', Labels: {} },
+      NetworkSettings: { Ports: { '53/udp': [{ HostIp: '::', HostPort: '5353' }] } },
+      Mounts: [{ Type: 'volume', Source: 'vol1', Destination: '/var/data', RW: true }],
+    }));
+
+    const ac = new AbortController();
+    const request = new Request('http://localhost/containers/events', { signal: ac.signal });
+    const response = await handleContainerEvents(docker as any, request);
+
+    await new Promise((r) => setTimeout(r, 50));
+
+    eventsEmitter.emit('data', Buffer.from(JSON.stringify({
+      Type: 'container',
+      Action: 'start',
+      Actor: { ID: 'c1' },
+    }) + '\n'));
+
+    const text = await readUntil(response, (s) => {
+      const events = s.split('\n\n').filter(Boolean);
+      return events.length >= 2;
+    });
+    ac.abort();
+
+    const events = text.split('\n\n').filter(Boolean).map((line) => JSON.parse(line.replace(/^data: /, '')));
+    const upsert = events.find((e) => e.op === 'upsert');
+    expect(upsert.container.ports).toEqual([{ containerPort: 53, protocol: 'udp', hostIp: '::', hostPort: 5353 }]);
+    expect(upsert.container.mounts).toEqual([{ type: 'volume', source: 'vol1', destination: '/var/data', rw: true }]);
+  });
+});
+
+describe('zInventorySnapshotContainer: ports/mounts schema round-trip', () => {
+  const base = {
+    id: 'c1',
+    name: 'app1',
+    image: 'nginx:latest',
+    state: 'running' as const,
+    labels: {},
+    startedAt: null,
+    finishedAt: null,
+    exitCode: null,
+  };
+
+  test('defaults ports and mounts to [] when absent (version-skew with an older agent)', () => {
+    const parsed = zInventorySnapshotContainer.parse(base);
+    expect(parsed.ports).toEqual([]);
+    expect(parsed.mounts).toEqual([]);
+  });
+
+  test('passes through ports and mounts when present', () => {
+    const parsed = zInventorySnapshotContainer.parse({
+      ...base,
+      ports: [{ containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 }],
+      mounts: [{ type: 'bind', source: '/host', destination: '/data', rw: true }],
+    });
+    expect(parsed.ports).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 }]);
+    expect(parsed.mounts).toEqual([{ type: 'bind', source: '/host', destination: '/data', rw: true }]);
   });
 });
 

--- a/agent/src/__tests__/containers-events.test.ts
+++ b/agent/src/__tests__/containers-events.test.ts
@@ -547,11 +547,20 @@ describe('handleContainerEvents: ports and mounts pass-through', () => {
       Mounts: [{ Type: 'volume', Source: 'vol1', Destination: '/var/data', RW: true }],
     }));
 
+    // 'newListener' fires synchronously right before the broadcaster's own
+    // listener is attached, so this resolves exactly when the events stream
+    // is ready to receive, instead of guessing with a fixed-delay sleep.
+    const dataListenerAttached = new Promise<void>((resolve) => {
+      eventsEmitter.once('newListener', (eventName) => {
+        if (eventName === 'data') resolve();
+      });
+    });
+
     const ac = new AbortController();
     const request = new Request('http://localhost/containers/events', { signal: ac.signal });
     const response = await handleContainerEvents(docker as any, request);
 
-    await new Promise((r) => setTimeout(r, 50));
+    await dataListenerAttached;
 
     eventsEmitter.emit('data', Buffer.from(JSON.stringify({
       Type: 'container',

--- a/agent/src/lib/__tests__/docker-events-broadcaster.test.ts
+++ b/agent/src/lib/__tests__/docker-events-broadcaster.test.ts
@@ -1210,6 +1210,27 @@ describe('portCandidatesFromInspect + normalizePorts: inspect shape', () => {
     expect(normalizePorts(portCandidatesFromInspect(null))).toEqual([]);
     expect(normalizePorts(portCandidatesFromInspect(undefined))).toEqual([]);
   });
+
+  test('skips a malformed port key with no "/protocol" suffix', () => {
+    const result = normalizePorts(portCandidatesFromInspect({
+      garbage: null as unknown as Array<{ HostIp: string; HostPort: string }>,
+    }));
+    expect(result).toEqual([]);
+  });
+
+  test('empty-string HostIp normalizes to null, matching the list shape', () => {
+    const result = normalizePorts(portCandidatesFromInspect({
+      '80/tcp': [{ HostIp: '', HostPort: '8080' }],
+    }));
+    expect(result).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: 8080 }]);
+  });
+
+  test('empty-string HostPort normalizes to null rather than Number("") === 0', () => {
+    const result = normalizePorts(portCandidatesFromInspect({
+      '80/tcp': [{ HostIp: '0.0.0.0', HostPort: '' }],
+    }));
+    expect(result).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: null }]);
+  });
 });
 
 describe('portCandidatesFromList + normalizePorts: list shape', () => {
@@ -1282,6 +1303,35 @@ describe('normalizeMounts', () => {
     expect(result).toEqual([{ type: 'volume', source: 'my-volume', destination: '/var/lib/data', rw: true }]);
   });
 
+  test('volume type prefers Name over Source when both are present', () => {
+    const result = normalizeMounts([{
+      Type: 'volume',
+      Name: 'my-volume',
+      Source: '/var/lib/docker/volumes/my-volume/_data',
+      Destination: '/var/lib/data',
+      RW: true,
+    }]);
+    expect(result).toEqual([{ type: 'volume', source: 'my-volume', destination: '/var/lib/data', rw: true }]);
+  });
+
+  test('equivalence: a named volume normalizes identically from the inspect shape (resolved path Source) and the list shape (empty Source)', () => {
+    const fromInspect = normalizeMounts([{
+      Type: 'volume',
+      Name: 'my-volume',
+      Source: '/var/lib/docker/volumes/my-volume/_data',
+      Destination: '/var/lib/data',
+      RW: true,
+    }]);
+    const fromList = normalizeMounts([{
+      Type: 'volume',
+      Name: 'my-volume',
+      Source: '',
+      Destination: '/var/lib/data',
+      RW: true,
+    }]);
+    expect(fromList).toEqual(fromInspect);
+  });
+
   test('sorts by destination', () => {
     const result = normalizeMounts([
       { Type: 'bind', Source: '/b', Destination: '/z', RW: true },
@@ -1352,8 +1402,16 @@ describe('subscribe: init and upsert carry ports and mounts', () => {
     };
 
     const received: BroadcasterEvent[] = [];
-    const unsub = await subscribe(docker as any, (e) => received.push(e));
-    await new Promise((r) => setTimeout(r, 20));
+    let resolveUpsert: (() => void) | null = null;
+    const upsertReceived = new Promise<void>((resolve) => {
+      resolveUpsert = resolve;
+    });
+    // subscribe() awaits startEventsSubscription internally, so by the time it
+    // resolves the 'data' listener is already attached; no need to wait before emitting.
+    const unsub = await subscribe(docker as any, (e) => {
+      received.push(e);
+      if (e.op === 'upsert') resolveUpsert?.();
+    });
 
     eventsEmitter.emit('data', Buffer.from(JSON.stringify({
       Type: 'container',
@@ -1361,7 +1419,7 @@ describe('subscribe: init and upsert carry ports and mounts', () => {
       Actor: { ID: 'c1' },
     }) + '\n'));
 
-    await new Promise((r) => setTimeout(r, 30));
+    await upsertReceived;
     unsub();
 
     const upserts = received.filter((e) => e.op === 'upsert');

--- a/agent/src/lib/__tests__/docker-events-broadcaster.test.ts
+++ b/agent/src/lib/__tests__/docker-events-broadcaster.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test, mock, beforeAll, beforeEach, afterAll } from 'bun:test';
 import { EventEmitter } from 'node:events';
+import type Dockerode from 'dockerode';
 import {
   subscribe,
   _resetBroadcasterForTesting,
   _handleDockerEventForTesting,
+  normalizePorts,
+  normalizeMounts,
+  portCandidatesFromInspect,
+  portCandidatesFromList,
 } from '../docker-events-broadcaster';
 import type { MinimalContainerInfo, BroadcasterEvent } from '../docker-events-broadcaster';
 
@@ -38,6 +43,8 @@ function makeContainer(
     StartedAt: null,
     FinishedAt: null,
     ExitCode: null,
+    Ports: [],
+    Mounts: [],
   };
 }
 
@@ -1137,5 +1144,257 @@ describe('_resetBroadcasterForTesting: with active reconnect timer', () => {
       globalThis.setTimeout = originalSetTimeout;
       unsub();
     }
+  });
+});
+
+describe('portCandidatesFromInspect + normalizePorts: inspect shape', () => {
+  test('published port coerces string HostPort to number', () => {
+    const result = normalizePorts(portCandidatesFromInspect({
+      '80/tcp': [{ HostIp: '0.0.0.0', HostPort: '8080' }],
+    }));
+    expect(result).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 }]);
+  });
+
+  test('unpublished exposed port has null bindings array', () => {
+    const result = normalizePorts(portCandidatesFromInspect({
+      '80/tcp': null as unknown as Array<{ HostIp: string; HostPort: string }>,
+    }));
+    expect(result).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: null }]);
+  });
+
+  test('udp port normalizes with its protocol', () => {
+    const result = normalizePorts(portCandidatesFromInspect({
+      '53/udp': [{ HostIp: '0.0.0.0', HostPort: '5353' }],
+    }));
+    expect(result).toEqual([{ containerPort: 53, protocol: 'udp', hostIp: '0.0.0.0', hostPort: 5353 }]);
+  });
+
+  test('multiple host bindings (ipv4 and ipv6) each produce a distinct entry', () => {
+    const result = normalizePorts(portCandidatesFromInspect({
+      '80/tcp': [
+        { HostIp: '0.0.0.0', HostPort: '8080' },
+        { HostIp: '::', HostPort: '8080' },
+      ],
+    }));
+    expect(result).toEqual([
+      { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 },
+      { containerPort: 80, protocol: 'tcp', hostIp: '::', hostPort: 8080 },
+    ]);
+  });
+
+  test('sorts deterministically by containerPort, protocol, hostIp, hostPort', () => {
+    const result = normalizePorts(portCandidatesFromInspect({
+      '443/tcp': [{ HostIp: '0.0.0.0', HostPort: '8443' }],
+      '80/udp': [{ HostIp: '0.0.0.0', HostPort: '8081' }],
+      '80/tcp': [
+        { HostIp: '::', HostPort: '8080' },
+        { HostIp: '0.0.0.0', HostPort: '8080' },
+      ],
+    }));
+    expect(result).toEqual([
+      { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 },
+      { containerPort: 80, protocol: 'tcp', hostIp: '::', hostPort: 8080 },
+      { containerPort: 80, protocol: 'udp', hostIp: '0.0.0.0', hostPort: 8081 },
+      { containerPort: 443, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8443 },
+    ]);
+  });
+
+  test('skips a malformed binding with non-numeric HostPort', () => {
+    const result = normalizePorts(portCandidatesFromInspect({
+      '80/tcp': [{ HostIp: '0.0.0.0', HostPort: 'not-a-port' }],
+    }));
+    expect(result).toEqual([]);
+  });
+
+  test('null/undefined Ports map produces no entries', () => {
+    expect(normalizePorts(portCandidatesFromInspect(null))).toEqual([]);
+    expect(normalizePorts(portCandidatesFromInspect(undefined))).toEqual([]);
+  });
+});
+
+describe('portCandidatesFromList + normalizePorts: list shape', () => {
+  test('published port uses number PublicPort directly', () => {
+    const result = normalizePorts(portCandidatesFromList([
+      { IP: '0.0.0.0', PrivatePort: 80, PublicPort: 8080, Type: 'tcp' },
+    ]));
+    expect(result).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 }]);
+  });
+
+  test('unpublished port has absent IP and PublicPort', () => {
+    const result = normalizePorts(portCandidatesFromList([
+      { PrivatePort: 80, Type: 'tcp' } as unknown as Dockerode.Port,
+    ]));
+    expect(result).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: null }]);
+  });
+
+  test('null Ports array produces no entries', () => {
+    expect(normalizePorts(portCandidatesFromList(null))).toEqual([]);
+  });
+
+  test('equivalence: inspect shape and list shape normalize a published port identically', () => {
+    const fromInspect = normalizePorts(portCandidatesFromInspect({
+      '80/tcp': [{ HostIp: '0.0.0.0', HostPort: '8080' }],
+    }));
+    const fromList = normalizePorts(portCandidatesFromList([
+      { IP: '0.0.0.0', PrivatePort: 80, PublicPort: 8080, Type: 'tcp' },
+    ]));
+    expect(fromList).toEqual(fromInspect);
+  });
+
+  test('equivalence: inspect shape and list shape normalize an unpublished port identically', () => {
+    const fromInspect = normalizePorts(portCandidatesFromInspect({
+      '80/tcp': null as unknown as Array<{ HostIp: string; HostPort: string }>,
+    }));
+    const fromList = normalizePorts(portCandidatesFromList([
+      { PrivatePort: 80, Type: 'tcp' } as unknown as Dockerode.Port,
+    ]));
+    expect(fromList).toEqual(fromInspect);
+  });
+
+  test('equivalence: multiple ports of mixed protocols normalize to the same sorted output', () => {
+    const fromInspect = normalizePorts(portCandidatesFromInspect({
+      '443/tcp': [{ HostIp: '0.0.0.0', HostPort: '8443' }],
+      '53/udp': [{ HostIp: '0.0.0.0', HostPort: '5353' }],
+      '80/tcp': null as unknown as Array<{ HostIp: string; HostPort: string }>,
+    }));
+    const fromList = normalizePorts(portCandidatesFromList([
+      { IP: '0.0.0.0', PrivatePort: 53, PublicPort: 5353, Type: 'udp' },
+      { PrivatePort: 80, Type: 'tcp' } as unknown as Dockerode.Port,
+      { IP: '0.0.0.0', PrivatePort: 443, PublicPort: 8443, Type: 'tcp' },
+    ]));
+    expect(fromList).toEqual(fromInspect);
+  });
+});
+
+describe('normalizeMounts', () => {
+  test('bind mount with rw true', () => {
+    const result = normalizeMounts([{ Type: 'bind', Source: '/host/data', Destination: '/data', RW: true }]);
+    expect(result).toEqual([{ type: 'bind', source: '/host/data', destination: '/data', rw: true }]);
+  });
+
+  test('bind mount with rw false (read-only)', () => {
+    const result = normalizeMounts([{ Type: 'bind', Source: '/host/data', Destination: '/data', RW: false }]);
+    expect(result).toEqual([{ type: 'bind', source: '/host/data', destination: '/data', rw: false }]);
+  });
+
+  test('volume type mount', () => {
+    const result = normalizeMounts([{ Type: 'volume', Source: 'my-volume', Destination: '/var/lib/data', RW: true }]);
+    expect(result).toEqual([{ type: 'volume', source: 'my-volume', destination: '/var/lib/data', rw: true }]);
+  });
+
+  test('sorts by destination', () => {
+    const result = normalizeMounts([
+      { Type: 'bind', Source: '/b', Destination: '/z', RW: true },
+      { Type: 'bind', Source: '/a', Destination: '/a', RW: true },
+    ]);
+    expect(result.map((m) => m.destination)).toEqual(['/a', '/z']);
+  });
+
+  test('skips a malformed entry missing Type or Destination', () => {
+    const result = normalizeMounts([
+      { Source: '/a', Destination: '/a', RW: true },
+      { Type: 'bind', Source: '/b', RW: true },
+      { Type: 'bind', Source: '/c', Destination: '/c', RW: true },
+    ]);
+    expect(result).toEqual([{ type: 'bind', source: '/c', destination: '/c', rw: true }]);
+  });
+
+  test('null/undefined mounts produces no entries', () => {
+    expect(normalizeMounts(null)).toEqual([]);
+    expect(normalizeMounts(undefined)).toEqual([]);
+  });
+});
+
+describe('subscribe: init and upsert carry ports and mounts', () => {
+  test('init event includes ports and mounts from inspect', async () => {
+    const eventsEmitter = new EventEmitter();
+    const listEntry = makeContainer('c1', 'app1', 'running');
+    const docker = {
+      listContainers: mock(() => Promise.resolve([listEntry])),
+      getEvents: mock(() => Promise.resolve(eventsEmitter)),
+      getContainer: mock(() => ({
+        inspect: mock(() => Promise.resolve({
+          Id: 'c1',
+          Name: '/app1',
+          State: { Status: 'running' },
+          Config: { Image: 'nginx:latest', Labels: {} },
+          NetworkSettings: { Ports: { '80/tcp': [{ HostIp: '0.0.0.0', HostPort: '8080' }] } },
+          Mounts: [{ Type: 'bind', Source: '/host', Destination: '/data', RW: true }],
+        })),
+      })),
+    };
+
+    const received: BroadcasterEvent[] = [];
+    const unsub = await subscribe(docker as any, (e) => received.push(e));
+    unsub();
+
+    const init = received[0] as Extract<BroadcasterEvent, { op: 'init' }>;
+    expect(init.containers[0].Ports).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 }]);
+    expect(init.containers[0].Mounts).toEqual([{ type: 'bind', source: '/host', destination: '/data', rw: true }]);
+  });
+
+  test('upsert event includes ports and mounts from inspect', async () => {
+    const eventsEmitter = new EventEmitter();
+    const containers = [makeContainer('c1', 'app1')];
+    const docker = {
+      listContainers: mock(() => Promise.resolve(containers)),
+      getEvents: mock(() => Promise.resolve(eventsEmitter)),
+      getContainer: mock(() => ({
+        inspect: mock(() => Promise.resolve({
+          Id: 'c1',
+          Name: '/app1',
+          State: { Status: 'running' },
+          Config: { Image: 'nginx:latest', Labels: {} },
+          NetworkSettings: { Ports: { '80/tcp': [{ HostIp: '0.0.0.0', HostPort: '8080' }] } },
+          Mounts: [{ Type: 'volume', Source: 'vol1', Destination: '/var/data', RW: true }],
+        })),
+      })),
+    };
+
+    const received: BroadcasterEvent[] = [];
+    const unsub = await subscribe(docker as any, (e) => received.push(e));
+    await new Promise((r) => setTimeout(r, 20));
+
+    eventsEmitter.emit('data', Buffer.from(JSON.stringify({
+      Type: 'container',
+      Action: 'start',
+      Actor: { ID: 'c1' },
+    }) + '\n'));
+
+    await new Promise((r) => setTimeout(r, 30));
+    unsub();
+
+    const upserts = received.filter((e) => e.op === 'upsert');
+    const upsert = upserts[0] as Extract<BroadcasterEvent, { op: 'upsert' }>;
+    expect(upsert.container.Ports).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 }]);
+    expect(upsert.container.Mounts).toEqual([{ type: 'volume', source: 'vol1', destination: '/var/data', rw: true }]);
+  });
+
+  test('init falls back to list normalization (Ports/Mounts) when inspect fails', async () => {
+    const eventsEmitter = new EventEmitter();
+    const listEntry = {
+      Id: 'c1',
+      Names: ['/app1'],
+      State: 'running',
+      Image: 'nginx:latest',
+      Labels: {},
+      Ports: [{ IP: '0.0.0.0', PrivatePort: 80, PublicPort: 8080, Type: 'tcp' }],
+      Mounts: [{ Type: 'bind', Source: '/host', Destination: '/data', RW: true, Mode: 'rw' }],
+    };
+    const docker = {
+      listContainers: mock(() => Promise.resolve([listEntry])),
+      getEvents: mock(() => Promise.resolve(eventsEmitter)),
+      getContainer: mock(() => ({
+        inspect: mock(() => Promise.reject(new Error('inspect blew up'))),
+      })),
+    };
+
+    const received: BroadcasterEvent[] = [];
+    const unsub = await subscribe(docker as any, (e) => received.push(e));
+    unsub();
+
+    const init = received[0] as Extract<BroadcasterEvent, { op: 'init' }>;
+    expect(init.containers[0].Ports).toEqual([{ containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 }]);
+    expect(init.containers[0].Mounts).toEqual([{ type: 'bind', source: '/host', destination: '/data', rw: true }]);
   });
 });

--- a/agent/src/lib/docker-events-broadcaster.ts
+++ b/agent/src/lib/docker-events-broadcaster.ts
@@ -13,6 +13,20 @@ const TERMINAL_STATES = new Set(['exited', 'dead']);
 /** Actions that trigger state updates. */
 const RELEVANT_ACTIONS = new Set(['start', 'stop', 'die', 'restart', 'create', 'destroy', 'pause', 'unpause']);
 
+export interface NormalizedPort {
+  containerPort: number;
+  protocol: string;
+  hostIp: string | null;
+  hostPort: number | null;
+}
+
+export interface NormalizedMount {
+  type: string;
+  source: string;
+  destination: string;
+  rw: boolean;
+}
+
 /** Minimal shape stored in the in-memory map. Avoids force-casting to the full Dockerode.ContainerInfo. */
 export interface MinimalContainerInfo {
   Id: string;
@@ -23,6 +37,8 @@ export interface MinimalContainerInfo {
   StartedAt: string | null;
   FinishedAt: string | null;
   ExitCode: number | null;
+  Ports: NormalizedPort[];
+  Mounts: NormalizedMount[];
 }
 
 function normalizeTimestamp(value: string | null | undefined): string | null {
@@ -33,6 +49,113 @@ function normalizeTimestamp(value: string | null | undefined): string | null {
 function normalizeExitCode(state: string, exitCode: number | null | undefined): number | null {
   if (!TERMINAL_STATES.has(state)) return null;
   return typeof exitCode === 'number' ? exitCode : null;
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+function comparePorts(a: NormalizedPort, b: NormalizedPort): number {
+  if (a.containerPort !== b.containerPort) return a.containerPort - b.containerPort;
+  if (a.protocol !== b.protocol) return compareStrings(a.protocol, b.protocol);
+  const aHostIp = a.hostIp ?? '';
+  const bHostIp = b.hostIp ?? '';
+  if (aHostIp !== bHostIp) return compareStrings(aHostIp, bHostIp);
+  return (a.hostPort ?? -1) - (b.hostPort ?? -1);
+}
+
+function compareMounts(a: NormalizedMount, b: NormalizedMount): number {
+  return compareStrings(a.destination, b.destination);
+}
+
+/** Loosely-typed candidate produced by either Docker API shape before validation and sorting. */
+export interface RawPortCandidate {
+  containerPort: number;
+  protocol: string | undefined;
+  hostIp: string | null | undefined;
+  hostPort: string | number | null | undefined;
+}
+
+/** Shared by buildFromInspect and buildFromListEntry so both paths produce identical canonical output for the same container. */
+export function normalizePorts(candidates: RawPortCandidate[]): NormalizedPort[] {
+  const result: NormalizedPort[] = [];
+
+  for (const candidate of candidates) {
+    if (!Number.isFinite(candidate.containerPort) || !candidate.protocol) continue;
+
+    if (candidate.hostPort === null || candidate.hostPort === undefined) {
+      result.push({ containerPort: candidate.containerPort, protocol: candidate.protocol, hostIp: null, hostPort: null });
+      continue;
+    }
+
+    const hostPort = Number(candidate.hostPort);
+    if (!Number.isFinite(hostPort)) continue;
+    result.push({
+      containerPort: candidate.containerPort,
+      protocol: candidate.protocol,
+      hostIp: candidate.hostIp ?? null,
+      hostPort,
+    });
+  }
+
+  return result.sort(comparePorts);
+}
+
+/** NetworkSettings.Ports value is null at runtime for exposed-but-unpublished ports, despite the dockerode type saying array. */
+export function portCandidatesFromInspect(
+  ports: Dockerode.ContainerInspectInfo['NetworkSettings']['Ports'] | null | undefined,
+): RawPortCandidate[] {
+  const candidates: RawPortCandidate[] = [];
+  if (!ports) return candidates;
+
+  for (const [key, bindings] of Object.entries(ports)) {
+    const [containerPortRaw, protocol] = key.split('/');
+    const containerPort = Number(containerPortRaw);
+
+    if (!bindings || bindings.length === 0) {
+      candidates.push({ containerPort, protocol, hostIp: null, hostPort: null });
+      continue;
+    }
+
+    for (const binding of bindings) {
+      candidates.push({ containerPort, protocol, hostIp: binding.HostIp, hostPort: binding.HostPort });
+    }
+  }
+
+  return candidates;
+}
+
+/** c.Ports is an array of {IP?, PrivatePort, PublicPort?, Type}; IP/PublicPort are absent when unpublished. */
+export function portCandidatesFromList(ports: Dockerode.Port[] | null | undefined): RawPortCandidate[] {
+  if (!ports) return [];
+  return ports.map((port) => ({
+    containerPort: port.PrivatePort,
+    protocol: port.Type,
+    hostIp: port.IP ?? null,
+    hostPort: port.PublicPort ?? null,
+  }));
+}
+
+/** Shared mount canonicalization; both Docker API shapes already agree on field names. */
+export function normalizeMounts(
+  mounts: Array<{ Type?: string; Source?: string; Destination?: string; RW?: boolean }> | null | undefined,
+): NormalizedMount[] {
+  const result: NormalizedMount[] = [];
+  if (!mounts) return result;
+
+  for (const mount of mounts) {
+    if (!mount.Type || !mount.Destination) continue;
+    result.push({
+      type: mount.Type,
+      source: mount.Source ?? '',
+      destination: mount.Destination,
+      rw: mount.RW ?? false,
+    });
+  }
+
+  return result.sort(compareMounts);
 }
 
 function buildFromInspect(inspectData: Dockerode.ContainerInspectInfo): MinimalContainerInfo {
@@ -46,6 +169,8 @@ function buildFromInspect(inspectData: Dockerode.ContainerInspectInfo): MinimalC
     StartedAt: normalizeTimestamp(inspectData.State?.StartedAt),
     FinishedAt: normalizeTimestamp(inspectData.State?.FinishedAt),
     ExitCode: normalizeExitCode(state, inspectData.State?.ExitCode),
+    Ports: normalizePorts(portCandidatesFromInspect(inspectData.NetworkSettings?.Ports)),
+    Mounts: normalizeMounts(inspectData.Mounts),
   };
 }
 
@@ -59,6 +184,8 @@ function buildFromListEntry(c: Dockerode.ContainerInfo): MinimalContainerInfo {
     StartedAt: null,
     FinishedAt: null,
     ExitCode: null,
+    Ports: normalizePorts(portCandidatesFromList(c.Ports)),
+    Mounts: normalizeMounts(c.Mounts),
   };
 }
 

--- a/agent/src/lib/docker-events-broadcaster.ts
+++ b/agent/src/lib/docker-events-broadcaster.ts
@@ -1,5 +1,6 @@
 import type { Readable } from 'node:stream';
 import type Dockerode from 'dockerode';
+import type { ContainerPort, ContainerMount } from '../types/protocol';
 
 const BACKOFF_BASE_MS = 500;
 const BACKOFF_CAP_MS = 32_000;
@@ -13,20 +14,6 @@ const TERMINAL_STATES = new Set(['exited', 'dead']);
 /** Actions that trigger state updates. */
 const RELEVANT_ACTIONS = new Set(['start', 'stop', 'die', 'restart', 'create', 'destroy', 'pause', 'unpause']);
 
-export interface NormalizedPort {
-  containerPort: number;
-  protocol: string;
-  hostIp: string | null;
-  hostPort: number | null;
-}
-
-export interface NormalizedMount {
-  type: string;
-  source: string;
-  destination: string;
-  rw: boolean;
-}
-
 /** Minimal shape stored in the in-memory map. Avoids force-casting to the full Dockerode.ContainerInfo. */
 export interface MinimalContainerInfo {
   Id: string;
@@ -37,8 +24,8 @@ export interface MinimalContainerInfo {
   StartedAt: string | null;
   FinishedAt: string | null;
   ExitCode: number | null;
-  Ports: NormalizedPort[];
-  Mounts: NormalizedMount[];
+  Ports: ContainerPort[];
+  Mounts: ContainerMount[];
 }
 
 function normalizeTimestamp(value: string | null | undefined): string | null {
@@ -57,7 +44,7 @@ function compareStrings(a: string, b: string): number {
   return 0;
 }
 
-function comparePorts(a: NormalizedPort, b: NormalizedPort): number {
+function comparePorts(a: ContainerPort, b: ContainerPort): number {
   if (a.containerPort !== b.containerPort) return a.containerPort - b.containerPort;
   if (a.protocol !== b.protocol) return compareStrings(a.protocol, b.protocol);
   const aHostIp = a.hostIp ?? '';
@@ -66,7 +53,7 @@ function comparePorts(a: NormalizedPort, b: NormalizedPort): number {
   return (a.hostPort ?? -1) - (b.hostPort ?? -1);
 }
 
-function compareMounts(a: NormalizedMount, b: NormalizedMount): number {
+function compareMounts(a: ContainerMount, b: ContainerMount): number {
   return compareStrings(a.destination, b.destination);
 }
 
@@ -79,23 +66,26 @@ export interface RawPortCandidate {
 }
 
 /** Shared by buildFromInspect and buildFromListEntry so both paths produce identical canonical output for the same container. */
-export function normalizePorts(candidates: RawPortCandidate[]): NormalizedPort[] {
-  const result: NormalizedPort[] = [];
+export function normalizePorts(candidates: RawPortCandidate[]): ContainerPort[] {
+  const result: ContainerPort[] = [];
 
   for (const candidate of candidates) {
     if (!Number.isFinite(candidate.containerPort) || !candidate.protocol) continue;
 
-    if (candidate.hostPort === null || candidate.hostPort === undefined) {
+    const hostIp = candidate.hostIp ? candidate.hostIp : null;
+    const hostPortRaw = typeof candidate.hostPort === 'string' ? candidate.hostPort.trim() : candidate.hostPort;
+
+    if (hostPortRaw === null || hostPortRaw === undefined || hostPortRaw === '') {
       result.push({ containerPort: candidate.containerPort, protocol: candidate.protocol, hostIp: null, hostPort: null });
       continue;
     }
 
-    const hostPort = Number(candidate.hostPort);
+    const hostPort = Number(hostPortRaw);
     if (!Number.isFinite(hostPort)) continue;
     result.push({
       containerPort: candidate.containerPort,
       protocol: candidate.protocol,
-      hostIp: candidate.hostIp ?? null,
+      hostIp,
       hostPort,
     });
   }
@@ -138,18 +128,24 @@ export function portCandidatesFromList(ports: Dockerode.Port[] | null | undefine
   }));
 }
 
-/** Shared mount canonicalization; both Docker API shapes already agree on field names. */
+/**
+ * For named volumes, inspect's Source is the resolved host path
+ * (/var/lib/docker/volumes/<name>/_data) while listContainers' Source is "".
+ * Name is present and identical in both shapes, so it is the canonical
+ * source for volume mounts; Source remains canonical for bind mounts.
+ */
 export function normalizeMounts(
-  mounts: Array<{ Type?: string; Source?: string; Destination?: string; RW?: boolean }> | null | undefined,
-): NormalizedMount[] {
-  const result: NormalizedMount[] = [];
+  mounts: Array<{ Type?: string; Name?: string; Source?: string; Destination?: string; RW?: boolean }> | null | undefined,
+): ContainerMount[] {
+  const result: ContainerMount[] = [];
   if (!mounts) return result;
 
   for (const mount of mounts) {
     if (!mount.Type || !mount.Destination) continue;
+    const source = mount.Type === 'volume' && mount.Name ? mount.Name : (mount.Source ?? '');
     result.push({
       type: mount.Type,
-      source: mount.Source ?? '',
+      source,
       destination: mount.Destination,
       rw: mount.RW ?? false,
     });

--- a/agent/src/routes/containers-events.ts
+++ b/agent/src/routes/containers-events.ts
@@ -30,6 +30,8 @@ function toSnapshotContainer(c: MinimalContainerInfo): InventorySnapshotContaine
     startedAt: c.StartedAt,
     finishedAt: c.FinishedAt,
     exitCode: c.ExitCode,
+    ports: c.Ports,
+    mounts: c.Mounts,
   };
 }
 
@@ -44,6 +46,8 @@ function toUpdateContainer(c: MinimalContainerInfo): InventoryUpdateContainer {
     startedAt: c.StartedAt,
     finishedAt: c.FinishedAt,
     exitCode: c.ExitCode,
+    ports: c.Ports,
+    mounts: c.Mounts,
   };
 }
 

--- a/agent/src/types/protocol.ts
+++ b/agent/src/types/protocol.ts
@@ -27,6 +27,22 @@ export const zContainerState = z.enum([
 ]);
 export type ContainerState = z.infer<typeof zContainerState>;
 
+export const zContainerPort = z.object({
+  containerPort: z.number(),
+  protocol: z.string(),
+  hostIp: z.string().nullable(),
+  hostPort: z.number().nullable(),
+});
+export type ContainerPort = z.infer<typeof zContainerPort>;
+
+export const zContainerMount = z.object({
+  type: z.string(),
+  source: z.string(),
+  destination: z.string(),
+  rw: z.boolean(),
+});
+export type ContainerMount = z.infer<typeof zContainerMount>;
+
 /**
  * Snapshot shape: emitted only on `op: 'init'`, sourced from `listContainers`
  * + inspect(). Labels are populated with real values.
@@ -43,6 +59,8 @@ export const zInventorySnapshotContainer = z.object({
   finishedAt: z.string().nullable(),
   /** Only meaningful when state is 'exited' or 'dead'. */
   exitCode: z.number().nullable(),
+  ports: z.array(zContainerPort).default([]),
+  mounts: z.array(zContainerMount).default([]),
 });
 export type InventorySnapshotContainer = z.infer<typeof zInventorySnapshotContainer>;
 


### PR DESCRIPTION
## Why

The container inventory pipeline (agent SSE -> worker -> DB -> web) discards port mappings and mounts at the very first hop: the agent's `MinimalContainerInfo` never reads them from Docker. This PR adds them to the agent protocol so the dashboard can show port details and bind mounts per container. The worker/DB/UI side lands in a follow-up PR stacked on this one.

Originally stacked on #352 (agent update route); rebased onto main after that merged.

## What

- `zContainerPort` (`containerPort`, `protocol`, `hostIp | null`, `hostPort | null`) and `zContainerMount` (`type`, `source`, `destination`, `rw`) in the protocol; `zInventorySnapshotContainer` gains both fields with `.default([])` so old agents remain parseable by a new worker. `zInventoryUpdateContainer` stays an alias, so upserts carry them automatically.
- One shared `normalizePorts` canonicalizer fed by two thin shape adapters, since inspect (`NetworkSettings.Ports` map, string `HostPort`, null map values for unpublished ports at runtime despite the dockerode type) and `listContainers` (`Ports[]`, number `PublicPort`, absent fields when unpublished) describe the same container differently. Explicit equivalence tests assert both shapes produce identical canonical output; the downstream worker will fingerprint these arrays, so a mismatch between the init and event paths would cause rewrite churn.
- Named volumes canonicalize by `Name` (identical in both shapes), not `Source` (inspect resolves it to `/var/lib/docker/volumes/<name>/_data`, listContainers leaves it empty).
- Empty-string `HostIp`/`HostPort` normalize to null, matching the list shape's absent fields.
- Deterministic sort (ports by containerPort/protocol/hostIp/hostPort, mounts by destination) with plain string comparison, not `localeCompare` (ICU collation mis-sorts `0.0.0.0` vs `::`).
- Malformed entries are skipped defensively; SSE init and upsert frames pass the fields through.

No version bump: 0.2.0 from #352 covers this release train.

## Tests

Both-shape normalization matrices (published/unpublished/udp/multi-binding/malformed), inspect-vs-list equivalence suites for ports and mounts, SSE pass-through, and schema round-trips with fields absent (defaults) and present. Agent: 318 tests, 99.79% functions / 98.41% lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq