### PR TITLE
feat(stacks): toast real deploy outcomes, not just request acceptance

### DIFF
--- a/src/components/stacks/DeployHistoryList.tsx
+++ b/src/components/stacks/DeployHistoryList.tsx
@@ -8,13 +8,14 @@ import type { triggerDeploy } from '@/data/stacks/functions';
 import DeployHistoryRow from '@/components/stacks/DeployHistoryRow';
 
 type StatusFilter = DeployStatus | 'all';
+type TriggerDeployResult = Awaited<ReturnType<typeof triggerDeploy>>;
 
 interface DeployHistoryListProps {
   records: StackDeployRecord[];
   isLoading: boolean;
   stackName?: string;
   host?: string;
-  onRollbackComplete?: () => void;
+  onRollbackComplete?: (result: TriggerDeployResult) => void;
   onRollbackError?: (err: Error) => void;
   onApprove?: (deployId: number) => void;
   onReject?: (deployId: number) => void;

--- a/src/components/stacks/DeployHistoryRow.tsx
+++ b/src/components/stacks/DeployHistoryRow.tsx
@@ -8,6 +8,8 @@ import type { StackDeployRecord, DeployAction, DeployStatus } from '@/types/stac
 import { triggerDeploy } from '@/data/stacks/functions';
 import RollbackDialog from '@/components/stacks/RollbackDialog';
 
+type TriggerDeployResult = Awaited<ReturnType<typeof triggerDeploy>>;
+
 const PENDING_APPROVAL_LABEL = 'Pending approval';
 
 const STATUS_COLOR: Record<DeployStatus, string> = {
@@ -42,7 +44,7 @@ interface DeployHistoryRowProps {
   record: StackDeployRecord;
   stackName?: string;
   host?: string;
-  onRollbackComplete?: () => void;
+  onRollbackComplete?: (result: TriggerDeployResult) => void;
   onRollbackError?: (err: Error) => void;
   onApprove?: (deployId: number) => void;
   onReject?: (deployId: number) => void;
@@ -63,7 +65,7 @@ export default function DeployHistoryRow({ record, stackName, host, onRollbackCo
   const rollbackMutation = useMutation({
     mutationFn: () =>
       (_triggerDeploy ?? triggerDeploy)({ data: { stack: stackName!, host: host!, action: 'deploy', commitSha: record.commitSha } }),
-    onSuccess: () => onRollbackComplete?.(),
+    onSuccess: (data) => onRollbackComplete?.(data),
     onError: (err) => onRollbackError?.(err instanceof Error ? err : new Error(String(err))),
   });
 

--- a/src/components/stacks/StackEditorForm.tsx
+++ b/src/components/stacks/StackEditorForm.tsx
@@ -169,11 +169,10 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
   const deleteMutation = useMutation({
     mutationFn: (teardown: boolean) =>
       deleteStack({ data: { stackName, teardown } }),
-    onSuccess: (result) => {
+    // The SSE outcome toast in useStackStatus covers this: deleteStack awaits the
+    // full teardown, so its terminal NOTIFY beats this response.
+    onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY })
-      if (result.status === 'teardown-pending') {
-        showToast(`Teardown started for ${stackName}`, 'info')
-      }
     },
     onError: (err) => {
       showToast(err instanceof Error ? err.message : String(err), 'error')
@@ -181,11 +180,8 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
   })
 
   function handleDeleteConfirm(teardown: boolean) {
-    // Fire the mutation without awaiting; for teardown the server returns
-    // immediately with a deployId and the pipeline handles the manifest delete
-    // asynchronously. Close the dialog and navigate right away so the user
-    // isn't held up waiting for the agent. Bypass the unsaved-changes guard
-    // since deleting the stack intentionally discards any in-progress edits.
+    // Navigate away without awaiting the mutation, and bypass the unsaved-changes
+    // guard: deleting the stack intentionally discards in-progress edits.
     bypassRef.current = true
     deleteMutation.mutate(teardown)
     setDeleteDialogOpen(false)
@@ -194,9 +190,7 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
 
   const approveMutation = useMutation({
     mutationFn: (deployId: number) => resumeDeploy({ data: { deployId } }),
-    // Claim the gate before the request resolves: the deployId is known upfront
-    // (it's the mutation argument), so this wins the race against the SSE
-    // deploy_changed outcome that the pipeline's dispatch will also notify.
+    // Claim before the SSE outcome for the same deployId can arrive.
     onMutate: (deployId: number) => {
       deployToastGate.claim(deployId)
     },
@@ -219,8 +213,7 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
 
   const rejectMutation = useMutation({
     mutationFn: (deployId: number) => rejectDeploy({ data: { deployId } }),
-    // Claim the gate so the SSE "Manually rejected" outcome (dispatched by
-    // rejectPendingDeploy) doesn't also toast once it arrives.
+    // Claim before the SSE "Manually rejected" outcome for the same deployId can arrive.
     onMutate: (deployId: number) => {
       deployToastGate.claim(deployId)
     },

--- a/src/components/stacks/StackEditorForm.tsx
+++ b/src/components/stacks/StackEditorForm.tsx
@@ -205,7 +205,10 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
       if (outcome) showToast(outcome.message, outcome.severity)
       invalidateDeployAndStacks()
     },
-    onError: (err) => {
+    // Release the pre-claim: if the server did resume the deploy, its terminal SSE
+    // outcome must still be free to toast rather than being suppressed by the claim.
+    onError: (err, deployId) => {
+      deployToastGate.release(deployId)
       showToast(err instanceof Error ? err.message : String(err), 'error')
       queryClient.invalidateQueries({ queryKey: [...DEPLOY_HISTORY_QUERY_KEY, stackName] })
     },
@@ -221,7 +224,8 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
       showToast(`Deploy rejected for ${stackName}`, 'success')
       invalidateDeployAndStacks()
     },
-    onError: (err) => {
+    onError: (err, deployId) => {
+      deployToastGate.release(deployId)
       showToast(err instanceof Error ? err.message : String(err), 'error')
       queryClient.invalidateQueries({ queryKey: [...DEPLOY_HISTORY_QUERY_KEY, stackName] })
     },

--- a/src/components/stacks/StackEditorForm.tsx
+++ b/src/components/stacks/StackEditorForm.tsx
@@ -8,6 +8,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { Settings2 } from 'lucide-react'
 import { useStackStatusContext } from '@/components/stacks/stacks-context'
 import { useToast } from '@/hooks/toastAtom'
+import { deployToastGate, formatDeployOutcome } from '@/lib/stacks/deploy-outcome-toast'
 import {
   getDeployHistory,
   triggerDeploy,
@@ -127,8 +128,17 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
   const deployMutation = useMutation({
     mutationFn: (action: 'deploy' | 'teardown') =>
       triggerDeploy({ data: { stack: stackName, host: detail.host, action, forceRecreate: action === 'deploy' ? forceRecreate : undefined } }),
-    onSuccess: (_data, action) => {
-      showToast(`${action} triggered successfully`, 'success')
+    onSuccess: (data, action) => {
+      if (deployToastGate.shouldToast(data.deployId)) {
+        const outcome = formatDeployOutcome({
+          stack: stackName,
+          action,
+          status: data.status,
+          trigger: 'ui',
+          message: data.logs,
+        })
+        if (outcome) showToast(outcome.message, outcome.severity)
+      }
       invalidateDeployAndStacks()
     },
     onError: (err) => {
@@ -162,7 +172,7 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
     onSuccess: (result) => {
       queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY })
       if (result.status === 'teardown-pending') {
-        showToast(`Teardown queued for ${stackName}: the stack will be removed when the agent finishes.`, 'success')
+        showToast(`Teardown started for ${stackName}`, 'info')
       }
     },
     onError: (err) => {
@@ -184,8 +194,21 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
 
   const approveMutation = useMutation({
     mutationFn: (deployId: number) => resumeDeploy({ data: { deployId } }),
-    onSuccess: () => {
-      showToast(`Deploy approved for ${stackName}`, 'success')
+    // Claim the gate before the request resolves: the deployId is known upfront
+    // (it's the mutation argument), so this wins the race against the SSE
+    // deploy_changed outcome that the pipeline's dispatch will also notify.
+    onMutate: (deployId: number) => {
+      deployToastGate.claim(deployId)
+    },
+    onSuccess: (data) => {
+      const outcome = formatDeployOutcome({
+        stack: stackName,
+        action: 'deploy',
+        status: data.status,
+        trigger: 'ui',
+        message: data.logs,
+      })
+      if (outcome) showToast(outcome.message, outcome.severity)
       invalidateDeployAndStacks()
     },
     onError: (err) => {
@@ -196,6 +219,11 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
 
   const rejectMutation = useMutation({
     mutationFn: (deployId: number) => rejectDeploy({ data: { deployId } }),
+    // Claim the gate so the SSE "Manually rejected" outcome (dispatched by
+    // rejectPendingDeploy) doesn't also toast once it arrives.
+    onMutate: (deployId: number) => {
+      deployToastGate.claim(deployId)
+    },
     onSuccess: () => {
       showToast(`Deploy rejected for ${stackName}`, 'success')
       invalidateDeployAndStacks()
@@ -289,8 +317,17 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
                 isLoading={historyLoading}
                 stackName={stackName}
                 host={detail.host}
-                onRollbackComplete={() => {
-                  showToast('Rollback triggered successfully', 'success')
+                onRollbackComplete={(result) => {
+                  if (deployToastGate.shouldToast(result.deployId)) {
+                    const outcome = formatDeployOutcome({
+                      stack: stackName,
+                      action: 'deploy',
+                      status: result.status,
+                      trigger: 'manual_rollback',
+                      message: result.logs,
+                    })
+                    if (outcome) showToast(outcome.message, outcome.severity)
+                  }
                   queryClient.invalidateQueries({ queryKey: [...DEPLOY_HISTORY_QUERY_KEY, stackName] })
                   queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY })
                 }}

--- a/src/components/stacks/__tests__/StackEditorForm.test.tsx
+++ b/src/components/stacks/__tests__/StackEditorForm.test.tsx
@@ -38,14 +38,14 @@ mock.module('@/components/stacks/DeployHistoryList', () => ({
   default: ({ onApprove, onReject, onRollbackComplete, onRollbackError }: {
     onApprove: (id: number) => void;
     onReject: (id: number) => void;
-    onRollbackComplete: () => void;
+    onRollbackComplete: (result: { deployId: number; status: string; logs: string }) => void;
     onRollbackError: (err: Error) => void;
   }) => (
     <div>
       deploy-history
       <button onClick={() => onApprove(7)}>approve</button>
       <button onClick={() => onReject(7)}>reject</button>
-      <button onClick={onRollbackComplete}>rollback-ok</button>
+      <button onClick={() => onRollbackComplete({ deployId: 99, status: 'succeeded', logs: '' })}>rollback-ok</button>
       <button onClick={() => onRollbackError(new Error('rollback boom'))}>rollback-err</button>
     </div>
   ),
@@ -73,10 +73,16 @@ const mockShowToast = mock((_message: string, _severity: string) => {});
 mock.module('@/hooks/toastAtom', () => ({ useToast: () => ({ showToast: mockShowToast }) }));
 
 type DeleteResult = { status: 'removed'; commitSha: string } | { status: 'teardown-pending'; deployId: number };
-const mockTriggerDeploy = mock((_args: unknown) => Promise.resolve({ deployId: 1 }));
+// The deploy-outcome toast gate dedupes by deployId across the whole module (it's a
+// singleton), and its state persists across tests in this file. A fixed mock deployId
+// would make the second toast in a test (or a later test reusing the same id) silently
+// suppressed as a "duplicate". Each call gets a fresh id, matching real backend behavior
+// where every triggered deploy gets a new deploy_history row.
+let nextDeployId = 1;
+const mockTriggerDeploy = mock((_args: unknown) => Promise.resolve({ deployId: nextDeployId++, status: 'succeeded' as const, logs: '' }));
 const mockDeleteStack = mock((_args: unknown): Promise<DeleteResult> => Promise.resolve({ status: 'removed', commitSha: 'x' }));
 const mockUpdateSettings = mock((_args: unknown) => Promise.resolve({ commitSha: 'x' }));
-const mockResumeDeploy = mock((_args: unknown) => Promise.resolve({ deployId: 1 }));
+const mockResumeDeploy = mock((_args: unknown) => Promise.resolve({ deployId: 1, status: 'succeeded' as const, logs: '' }));
 const mockRejectDeploy = mock((_args: unknown) => Promise.resolve({ deployId: 1 }));
 const realFns = await import('@/data/stacks/functions');
 mock.module('@/data/stacks/functions', () => ({
@@ -127,10 +133,10 @@ describe('StackEditorForm', () => {
     mockUpdateSettings.mockClear();
     mockResumeDeploy.mockClear();
     mockRejectDeploy.mockClear();
-    mockTriggerDeploy.mockImplementation(() => Promise.resolve({ deployId: 1 }));
+    mockTriggerDeploy.mockImplementation(() => Promise.resolve({ deployId: nextDeployId++, status: 'succeeded' as const, logs: '' }));
     mockDeleteStack.mockImplementation(() => Promise.resolve({ status: 'removed', commitSha: 'x' }));
     mockUpdateSettings.mockImplementation(() => Promise.resolve({ commitSha: 'x' }));
-    mockResumeDeploy.mockImplementation(() => Promise.resolve({ deployId: 1 }));
+    mockResumeDeploy.mockImplementation(() => Promise.resolve({ deployId: 1, status: 'succeeded' as const, logs: '' }));
     mockRejectDeploy.mockImplementation(() => Promise.resolve({ deployId: 1 }));
     capturedBlockerOpts = undefined;
     blockerReturn = { status: 'idle', proceed: proceedSpy, reset: resetSpy };
@@ -224,11 +230,11 @@ describe('StackEditorForm', () => {
     await renderForm();
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'action-deploy' })); });
     await waitFor(() => expect(mockTriggerDeploy).toHaveBeenCalledTimes(1));
-    expect(mockShowToast).toHaveBeenCalledWith('deploy triggered successfully', 'success');
+    expect(mockShowToast).toHaveBeenCalledWith('Deploy of web succeeded', 'success');
 
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'action-teardown' })); });
     await waitFor(() => expect(mockTriggerDeploy).toHaveBeenCalledTimes(2));
-    expect(mockShowToast).toHaveBeenCalledWith('teardown triggered successfully', 'success');
+    expect(mockShowToast).toHaveBeenCalledWith('Teardown of web succeeded', 'success');
   });
 
   it('warns before deploying with unsaved changes and deploys on confirm', async () => {
@@ -278,7 +284,7 @@ describe('StackEditorForm', () => {
     fireEvent.click(screen.getByRole('tab', { name: /Deploys/ }));
 
     fireEvent.click(screen.getByRole('button', { name: 'rollback-ok' }));
-    expect(mockShowToast).toHaveBeenCalledWith('Rollback triggered successfully', 'success');
+    expect(mockShowToast).toHaveBeenCalledWith('Rollback of web succeeded', 'success');
 
     fireEvent.click(screen.getByRole('button', { name: 'rollback-err' }));
     expect(mockShowToast).toHaveBeenCalledWith('rollback boom', 'error');
@@ -320,13 +326,13 @@ describe('StackEditorForm', () => {
     await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('delete failed', 'error'));
   });
 
-  it('shows a teardown-pending toast when a teardown is queued', async () => {
+  it('shows a teardown-started toast when a teardown is queued', async () => {
     mockDeleteStack.mockImplementation(() => Promise.resolve({ status: 'teardown-pending', deployId: 5 }));
     await renderForm();
     fireEvent.click(screen.getByRole('button', { name: 'action-delete' }));
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'confirm-delete' })); });
     await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith(
-      expect.stringContaining('Teardown queued'), 'success',
+      'Teardown started for web', 'info',
     ));
   });
 });

--- a/src/components/stacks/__tests__/StackEditorForm.test.tsx
+++ b/src/components/stacks/__tests__/StackEditorForm.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, mock, beforeEach } from 'bun:test';
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { useFormContext } from 'react-hook-form';
-import type { StackDetail } from '@/types/stacks';
+import type { StackDetail, DeployStatus } from '@/types/stacks';
 
 // Router hooks are the only things StackEditorForm needs from the router; stub
 // them so we can drive the blocker state and observe navigation.
@@ -73,16 +73,12 @@ const mockShowToast = mock((_message: string, _severity: string) => {});
 mock.module('@/hooks/toastAtom', () => ({ useToast: () => ({ showToast: mockShowToast }) }));
 
 type DeleteResult = { status: 'removed'; commitSha: string } | { status: 'teardown-pending'; deployId: number };
-// The deploy-outcome toast gate dedupes by deployId across the whole module (it's a
-// singleton), and its state persists across tests in this file. A fixed mock deployId
-// would make the second toast in a test (or a later test reusing the same id) silently
-// suppressed as a "duplicate". Each call gets a fresh id, matching real backend behavior
-// where every triggered deploy gets a new deploy_history row.
+// Fresh id per call: the deployToastGate singleton dedupes by id across this whole file.
 let nextDeployId = 1;
-const mockTriggerDeploy = mock((_args: unknown) => Promise.resolve({ deployId: nextDeployId++, status: 'succeeded' as const, logs: '' }));
+const mockTriggerDeploy = mock((_args: unknown): Promise<{ deployId: number; status: DeployStatus; logs: string }> => Promise.resolve({ deployId: nextDeployId++, status: 'succeeded', logs: '' }));
 const mockDeleteStack = mock((_args: unknown): Promise<DeleteResult> => Promise.resolve({ status: 'removed', commitSha: 'x' }));
 const mockUpdateSettings = mock((_args: unknown) => Promise.resolve({ commitSha: 'x' }));
-const mockResumeDeploy = mock((_args: unknown) => Promise.resolve({ deployId: 1, status: 'succeeded' as const, logs: '' }));
+const mockResumeDeploy = mock((_args: unknown): Promise<{ deployId: number; status: DeployStatus; logs: string }> => Promise.resolve({ deployId: 1, status: 'succeeded', logs: '' }));
 const mockRejectDeploy = mock((_args: unknown) => Promise.resolve({ deployId: 1 }));
 const realFns = await import('@/data/stacks/functions');
 mock.module('@/data/stacks/functions', () => ({
@@ -261,11 +257,18 @@ describe('StackEditorForm', () => {
     expect(mockTriggerDeploy).not.toHaveBeenCalled();
   });
 
-  it('surfaces a toast when a deploy fails', async () => {
+  it('surfaces a toast when a deploy fails (request rejects)', async () => {
     mockTriggerDeploy.mockImplementation(() => Promise.reject(new Error('deploy failed')));
     await renderForm();
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'action-deploy' })); });
     await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('deploy failed', 'error'));
+  });
+
+  it('formats a failed outcome when the deploy request resolves with status failed', async () => {
+    mockTriggerDeploy.mockImplementation(() => Promise.resolve({ deployId: nextDeployId++, status: 'failed' as const, logs: 'image not found' }));
+    await renderForm();
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'action-deploy' })); });
+    await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('Deploy of web failed: image not found', 'error'));
   });
 
   it('approves and rejects pending deploys from the deploys panel', async () => {
@@ -274,9 +277,36 @@ describe('StackEditorForm', () => {
 
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'approve' })); });
     await waitFor(() => expect(mockResumeDeploy).toHaveBeenCalledWith({ data: { deployId: 7 } }));
+    expect(mockShowToast).toHaveBeenCalledWith('Deploy of web succeeded', 'success');
 
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'reject' })); });
     await waitFor(() => expect(mockRejectDeploy).toHaveBeenCalledWith({ data: { deployId: 7 } }));
+  });
+
+  it('formats a failed outcome when the approve request resolves with status failed', async () => {
+    mockResumeDeploy.mockImplementation(() => Promise.resolve({ deployId: 1, status: 'failed' as const, logs: 'agent down' }));
+    await renderForm();
+    fireEvent.click(screen.getByRole('tab', { name: /Deploys/ }));
+
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'approve' })); });
+    await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('Deploy of web failed: agent down', 'error'));
+  });
+
+  it('cross-source dedupe through the real gate: a pre-claim suppresses the mutation toast, and the mutation claiming first suppresses a later check for the same id', async () => {
+    const { deployToastGate } = await import('@/lib/stacks/deploy-outcome-toast');
+    await renderForm();
+
+    const preClaimedId = nextDeployId;
+    deployToastGate.claim(preClaimedId);
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'action-deploy' })); });
+    await waitFor(() => expect(mockTriggerDeploy).toHaveBeenCalledTimes(1));
+    expect(mockShowToast).not.toHaveBeenCalledWith('Deploy of web succeeded', 'success');
+
+    mockShowToast.mockClear();
+    const secondId = nextDeployId;
+    await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'action-deploy' })); });
+    await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('Deploy of web succeeded', 'success'));
+    expect(deployToastGate.shouldToast(secondId)).toBe(false);
   });
 
   it('reports rollback outcomes via toast', async () => {
@@ -326,13 +356,12 @@ describe('StackEditorForm', () => {
     await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('delete failed', 'error'));
   });
 
-  it('shows a teardown-started toast when a teardown is queued', async () => {
+  it('fires no optimistic toast for a teardown-pending delete: the SSE outcome owns it', async () => {
     mockDeleteStack.mockImplementation(() => Promise.resolve({ status: 'teardown-pending', deployId: 5 }));
     await renderForm();
     fireEvent.click(screen.getByRole('button', { name: 'action-delete' }));
     await act(async () => { fireEvent.click(screen.getByRole('button', { name: 'confirm-delete' })); });
-    await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith(
-      'Teardown started for web', 'info',
-    ));
+    await waitFor(() => expect(mockDeleteStack).toHaveBeenCalledTimes(1));
+    expect(mockShowToast).not.toHaveBeenCalled();
   });
 });

--- a/src/data/stacks/__tests__/functions.test.ts
+++ b/src/data/stacks/__tests__/functions.test.ts
@@ -59,7 +59,7 @@ const mockGetStackDetailByName = mock(() => Promise.resolve({
   composeContent: 'version: "3"',
   variables: {},
 }));
-const mockTriggerStackDeploy = mock(() => Promise.resolve({ deployId: 42 }));
+const mockTriggerStackDeploy = mock(() => Promise.resolve({ deployId: 42, status: 'succeeded' as const, logs: 'deployed ok' }));
 const mockGetStackDeployHistory = mock(() => Promise.resolve([
   { id: 1, stack: 'nginx', action: 'deploy', status: 'success', timestamp: '2026-01-01T00:00:00Z' },
 ]));
@@ -73,7 +73,7 @@ const mockGetManagedHostNames = mock(() => Promise.resolve(['server1']));
 const mockResolveDeleteStack = mock(() =>
   Promise.resolve({ status: 'removed' as const, commitSha: 'abc123' }),
 );
-const mockResumePendingDeploy = mock(() => Promise.resolve({ deployId: 7 }));
+const mockResumePendingDeploy = mock(() => Promise.resolve({ deployId: 7, status: 'succeeded' as const, logs: 'ok' }));
 const mockRejectPendingDeploy = mock(() => Promise.resolve({ deployId: 7 }));
 const mockControlStackForHost = mock(() => Promise.resolve(undefined));
 

--- a/src/data/stacks/functions.tsx
+++ b/src/data/stacks/functions.tsx
@@ -1,6 +1,6 @@
 import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
-import type { StackSummary, StackDetail, StackDeployRecord } from '@/types/stacks';
+import type { StackSummary, StackDetail, StackDeployRecord, DeployStatus } from '@/types/stacks';
 import { stackSecretsMiddleware } from '@/middleware/stack-secrets-middleware';
 import type { StackControlRequest } from '@/lib/clients/agent-client';
 import { authMiddleware } from '@/middleware/auth-middleware';
@@ -47,7 +47,7 @@ export const getStackDetail = createServerFn()
 export const triggerDeploy = createServerFn()
   .middleware([authMiddleware])
   .inputValidator(triggerDeploySchema)
-  .handler(async ({ data, context }): Promise<{ deployId: number }> => {
+  .handler(async ({ data, context }): Promise<{ deployId: number; status: DeployStatus; logs: string }> => {
     requireRole('admin', 'operator')(context.user);
     const { triggerStackDeploy } = await import('@/lib/stacks/stack-service');
     return triggerStackDeploy(data);
@@ -57,7 +57,7 @@ export const triggerDeploy = createServerFn()
 export const resumeDeploy = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])
   .inputValidator(resumeDeploySchema)
-  .handler(async ({ data, context }): Promise<{ deployId: number }> => {
+  .handler(async ({ data, context }): Promise<{ deployId: number; status: DeployStatus; logs: string }> => {
     requireRole('admin', 'operator')(context.user);
     const { resumePendingDeploy } = await import('@/lib/stacks/stack-service');
     return resumePendingDeploy(data.deployId);
@@ -254,8 +254,8 @@ const deleteStackSchema = z.object({
 });
 
 /**
- * Delete a stack from the git repo. If `teardown` is true, queues an async
- * teardown via the deploy pipeline and returns immediately; the pipeline's
+ * Delete a stack from the git repo. If `teardown` is true, dispatches a
+ * teardown via the deploy pipeline and awaits its completion; the pipeline's
  * postSuccess hook removes the manifest entry once the agent reports success.
  * If `teardown` is false, removes the stack from the manifest synchronously.
  */

--- a/src/hooks/__tests__/useStackStatus.test.ts
+++ b/src/hooks/__tests__/useStackStatus.test.ts
@@ -166,6 +166,34 @@ describe('useStackStatus', () => {
     expect(mockShowToast).toHaveBeenCalledTimes(1);
   });
 
+  it('a non-terminal outcome does not consume the gate, so the later terminal outcome still toasts', () => {
+    const { result } = renderHook(() => useStackStatus());
+    const es = MockEventSource.instances[0];
+
+    const pending = JSON.stringify({
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      outcome: { deployId: 200, status: 'in_progress', action: 'deploy', trigger: 'ui' },
+    });
+    const succeeded = JSON.stringify({
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      outcome: { deployId: 200, status: 'succeeded', action: 'deploy', trigger: 'ui' },
+    });
+
+    act(() => {
+      es.onopen?.();
+      es.onmessage?.({ data: pending });
+      es.onmessage?.({ data: succeeded });
+    });
+
+    expect(result.current.deployVersion).toBe(2);
+    expect(mockShowToast).toHaveBeenCalledTimes(1);
+    expect(mockShowToast).toHaveBeenCalledWith('Deploy of plex succeeded', 'success');
+  });
+
   it('never toasts for the init status-entries array', () => {
     const { result } = renderHook(() => useStackStatus());
     const es = MockEventSource.instances[0];

--- a/src/hooks/__tests__/useStackStatus.test.ts
+++ b/src/hooks/__tests__/useStackStatus.test.ts
@@ -7,7 +7,7 @@ mock.module('@/hooks/toastAtom', () => ({
   useToast: () => ({ showToast: mockShowToast }),
 }));
 
-const { useStackStatus } = await import('../useStackStatus');
+const { useStackStatus } = await import('@/hooks/useStackStatus');
 
 const originalEventSource = globalThis.EventSource;
 

--- a/src/hooks/__tests__/useStackStatus.test.ts
+++ b/src/hooks/__tests__/useStackStatus.test.ts
@@ -1,12 +1,19 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
 import { renderHook, act } from '@testing-library/react';
 import { MockEventSource } from '@/lib/test/mock-event-source';
-import { useStackStatus } from '../useStackStatus';
+
+const mockShowToast = mock((_message: string, _severity: string) => {});
+mock.module('@/hooks/toastAtom', () => ({
+  useToast: () => ({ showToast: mockShowToast }),
+}));
+
+const { useStackStatus } = await import('../useStackStatus');
 
 const originalEventSource = globalThis.EventSource;
 
 beforeEach(() => {
   MockEventSource.reset();
+  mockShowToast.mockClear();
   (globalThis as unknown as Record<string, unknown>).EventSource = MockEventSource;
 });
 
@@ -58,6 +65,110 @@ describe('useStackStatus', () => {
     });
 
     expect(result.current.deployVersion).toBe(1);
+  });
+
+  it('legacy deploy_changed payload without outcome fields bumps version but never toasts', () => {
+    const { result } = renderHook(() => useStackStatus());
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.onopen?.();
+      es.onmessage?.({
+        data: JSON.stringify({ type: 'deploy_changed', stack: 'plex', host: 'server1' }),
+      });
+    });
+
+    expect(result.current.deployVersion).toBe(1);
+    expect(mockShowToast).not.toHaveBeenCalled();
+  });
+
+  it('toasts once for a terminal deploy_changed outcome carrying a deployId', () => {
+    const { result } = renderHook(() => useStackStatus());
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.onopen?.();
+      es.onmessage?.({
+        data: JSON.stringify({
+          type: 'deploy_changed',
+          stack: 'plex',
+          host: 'server1',
+          deployId: 101,
+          status: 'succeeded',
+          action: 'deploy',
+          trigger: 'ui',
+        }),
+      });
+    });
+
+    expect(result.current.deployVersion).toBe(1);
+    expect(mockShowToast).toHaveBeenCalledTimes(1);
+    expect(mockShowToast).toHaveBeenCalledWith('Deploy of plex succeeded', 'success');
+  });
+
+  it('toasts a failed outcome with the sanitized message', () => {
+    const { result } = renderHook(() => useStackStatus());
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.onopen?.();
+      es.onmessage?.({
+        data: JSON.stringify({
+          type: 'deploy_changed',
+          stack: 'plex',
+          host: 'server1',
+          deployId: 102,
+          status: 'failed',
+          action: 'deploy',
+          trigger: 'git_push',
+          message: 'image not found',
+        }),
+      });
+    });
+
+    expect(result.current.deployVersion).toBe(1);
+    expect(mockShowToast).toHaveBeenCalledWith('Deploy of plex (git push) failed: image not found', 'error');
+  });
+
+  it('toasts a duplicate deployId only once, even across separate SSE messages', () => {
+    const { result } = renderHook(() => useStackStatus());
+    const es = MockEventSource.instances[0];
+
+    const frame = JSON.stringify({
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      deployId: 103,
+      status: 'succeeded',
+      action: 'deploy',
+      trigger: 'ui',
+    });
+
+    act(() => {
+      es.onopen?.();
+      es.onmessage?.({ data: frame });
+      es.onmessage?.({ data: frame });
+    });
+
+    expect(result.current.deployVersion).toBe(2);
+    expect(mockShowToast).toHaveBeenCalledTimes(1);
+  });
+
+  it('never toasts for the init status-entries array', () => {
+    const { result } = renderHook(() => useStackStatus());
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.onopen?.();
+      es.onmessage?.({
+        data: JSON.stringify([
+          { stack: 'plex', host: 'server1', containers: [], updated_at: '2026-03-21T00:00:00Z' },
+        ]),
+      });
+    });
+
+    expect(result.current.statusMap.size).toBe(1);
+    expect(mockShowToast).not.toHaveBeenCalled();
   });
 
   it('does not create a new Map when container data is unchanged', () => {

--- a/src/hooks/__tests__/useStackStatus.test.ts
+++ b/src/hooks/__tests__/useStackStatus.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { renderHook, act } from '@testing-library/react';
 import { MockEventSource } from '@/lib/test/mock-event-source';
 
@@ -93,10 +93,7 @@ describe('useStackStatus', () => {
           type: 'deploy_changed',
           stack: 'plex',
           host: 'server1',
-          deployId: 101,
-          status: 'succeeded',
-          action: 'deploy',
-          trigger: 'ui',
+          outcome: { deployId: 101, status: 'succeeded', action: 'deploy', trigger: 'ui' },
         }),
       });
     });
@@ -117,17 +114,35 @@ describe('useStackStatus', () => {
           type: 'deploy_changed',
           stack: 'plex',
           host: 'server1',
-          deployId: 102,
-          status: 'failed',
-          action: 'deploy',
-          trigger: 'git_push',
-          message: 'image not found',
+          outcome: { deployId: 102, status: 'failed', action: 'deploy', trigger: 'git_push', message: 'image not found' },
         }),
       });
     });
 
     expect(result.current.deployVersion).toBe(1);
     expect(mockShowToast).toHaveBeenCalledWith('Deploy of plex (git push) failed: image not found', 'error');
+  });
+
+  it('drops a frame whose outcome is missing a required field: no version bump, no toast', () => {
+    const errSpy = spyOn(console, 'error').mockImplementation(() => {});
+    const { result } = renderHook(() => useStackStatus());
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.onopen?.();
+      es.onmessage?.({
+        data: JSON.stringify({
+          type: 'deploy_changed',
+          stack: 'plex',
+          host: 'server1',
+          outcome: { deployId: 104, status: 'failed', action: 'deploy' },
+        }),
+      });
+    });
+
+    expect(result.current.deployVersion).toBe(0);
+    expect(mockShowToast).not.toHaveBeenCalled();
+    errSpy.mockRestore();
   });
 
   it('toasts a duplicate deployId only once, even across separate SSE messages', () => {
@@ -138,10 +153,7 @@ describe('useStackStatus', () => {
       type: 'deploy_changed',
       stack: 'plex',
       host: 'server1',
-      deployId: 103,
-      status: 'succeeded',
-      action: 'deploy',
-      trigger: 'ui',
+      outcome: { deployId: 103, status: 'succeeded', action: 'deploy', trigger: 'ui' },
     });
 
     act(() => {

--- a/src/hooks/useStackStatus.ts
+++ b/src/hooks/useStackStatus.ts
@@ -35,20 +35,8 @@ export function useStackStatus() {
   const handleData = useCallback((data: StackSSEMessage) => {
     if (isDeployChanged(data)) {
       setDeployVersion((v) => v + 1);
-      if (
-        data.deployId !== undefined &&
-        data.status !== undefined &&
-        data.action !== undefined &&
-        data.trigger !== undefined &&
-        deployToastGate.shouldToast(data.deployId)
-      ) {
-        const outcome = formatDeployOutcome({
-          stack: data.stack,
-          action: data.action,
-          status: data.status,
-          trigger: data.trigger,
-          message: data.message,
-        });
+      if (data.outcome !== undefined && deployToastGate.shouldToast(data.outcome.deployId)) {
+        const outcome = formatDeployOutcome({ stack: data.stack, ...data.outcome });
         if (outcome) showToast(outcome.message, outcome.severity);
       }
       return;

--- a/src/hooks/useStackStatus.ts
+++ b/src/hooks/useStackStatus.ts
@@ -1,9 +1,13 @@
 import { useCallback, useState } from 'react';
 import { useSseChannel } from '@/hooks/useSseChannel';
 import { stackStatusChannel, type StackSSEMessage } from '@/lib/sse/channels/stack-status';
+import { useToast } from '@/hooks/toastAtom';
+import { deployToastGate, formatDeployOutcome } from '@/lib/stacks/deploy-outcome-toast';
 import type { StackStatusEntry } from '@/types/stacks';
 
-function isDeployChanged(data: StackSSEMessage): data is { type: 'deploy_changed'; stack: string; host: string } {
+type DeployChangedMessage = Extract<StackSSEMessage, { type: 'deploy_changed' }>;
+
+function isDeployChanged(data: StackSSEMessage): data is DeployChangedMessage {
   return !Array.isArray(data) && 'type' in data && data.type === 'deploy_changed';
 }
 
@@ -26,10 +30,27 @@ function shallowEqualContainers(
 export function useStackStatus() {
   const [statusMap, setStatusMap] = useState<Map<string, StackStatusEntry>>(new Map());
   const [deployVersion, setDeployVersion] = useState(0);
+  const { showToast } = useToast();
 
   const handleData = useCallback((data: StackSSEMessage) => {
     if (isDeployChanged(data)) {
       setDeployVersion((v) => v + 1);
+      if (
+        data.deployId !== undefined &&
+        data.status !== undefined &&
+        data.action !== undefined &&
+        data.trigger !== undefined &&
+        deployToastGate.shouldToast(data.deployId)
+      ) {
+        const outcome = formatDeployOutcome({
+          stack: data.stack,
+          action: data.action,
+          status: data.status,
+          trigger: data.trigger,
+          message: data.message,
+        });
+        if (outcome) showToast(outcome.message, outcome.severity);
+      }
       return;
     }
 
@@ -45,7 +66,7 @@ export function useStackStatus() {
       }
       return changed ? next : prev;
     });
-  }, []);
+  }, [showToast]);
 
   const { isConnected, error } = useSseChannel(stackStatusChannel, {
     onData: handleData,

--- a/src/hooks/useStackStatus.ts
+++ b/src/hooks/useStackStatus.ts
@@ -35,9 +35,13 @@ export function useStackStatus() {
   const handleData = useCallback((data: StackSSEMessage) => {
     if (isDeployChanged(data)) {
       setDeployVersion((v) => v + 1);
-      if (data.outcome !== undefined && deployToastGate.shouldToast(data.outcome.deployId)) {
+      if (data.outcome !== undefined) {
         const outcome = formatDeployOutcome({ stack: data.stack, ...data.outcome });
-        if (outcome) showToast(outcome.message, outcome.severity);
+        // Gate only when there is a toast to show; a non-terminal frame must not
+        // consume the deployId's one-shot gate and suppress the later terminal toast.
+        if (outcome && deployToastGate.shouldToast(data.outcome.deployId)) {
+          showToast(outcome.message, outcome.severity);
+        }
       }
       return;
     }

--- a/src/lib/database/repositories/__tests__/deploy-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/deploy-repository.test.ts
@@ -330,6 +330,95 @@ describe('DeployRepository', () => {
       expect(mock.queries[0].sql).toContain("pg_notify('deploy_change'");
       expect(mock.queries[0].params).toEqual([JSON.stringify({ type: 'deploy_changed', stack: 'plex', host: 'homeserver' })]);
     });
+
+    it('includes outcome fields when provided', async () => {
+      await repo.notifyStackChange('plex', 'homeserver', {
+        deployId: 42,
+        status: 'succeeded',
+        action: 'deploy',
+        trigger: 'ui',
+      });
+
+      expect(mock.queries[0].params).toEqual([JSON.stringify({
+        type: 'deploy_changed',
+        stack: 'plex',
+        host: 'homeserver',
+        deployId: 42,
+        status: 'succeeded',
+        action: 'deploy',
+        trigger: 'ui',
+      })]);
+    });
+
+    it('sanitizes and truncates the outcome message, taking the first line', async () => {
+      const rawMessage = 'first line of logs\nsecond line should be dropped';
+      await repo.notifyStackChange('plex', 'homeserver', {
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: rawMessage,
+      });
+
+      const payload = JSON.parse(mock.queries[0].params[0] as string);
+      expect(payload.message).toBe('first line of logs');
+    });
+
+    it('strips control characters including embedded nulls from the message', async () => {
+      await repo.notifyStackChange('plex', 'homeserver', {
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'ui',
+        message: 'bad' + String.fromCharCode(0) + 'value' + String.fromCharCode(1) + 'here',
+      });
+
+      const payload = JSON.parse(mock.queries[0].params[0] as string);
+      expect(payload.message).toBe('badvaluehere');
+    });
+
+    it('truncates the message to 200 chars', async () => {
+      const longMessage = 'x'.repeat(300);
+      await repo.notifyStackChange('plex', 'homeserver', {
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'ui',
+        message: longMessage,
+      });
+
+      const payload = JSON.parse(mock.queries[0].params[0] as string);
+      expect(payload.message).toHaveLength(200);
+      expect(payload.message).toBe('x'.repeat(200));
+    });
+
+    it('does not truncate mid-surrogate-pair', async () => {
+      // 199 'x' chars followed by a surrogate-pair emoji (2 UTF-16 code units)
+      // straddling the 200-char boundary: the emoji must be dropped whole.
+      const longMessage = 'x'.repeat(199) + '\u{1F600}' + 'y'.repeat(10);
+      await repo.notifyStackChange('plex', 'homeserver', {
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'ui',
+        message: longMessage,
+      });
+
+      const payload = JSON.parse(mock.queries[0].params[0] as string);
+      expect(payload.message).toBe('x'.repeat(199));
+    });
+
+    it('omits the message field when no message is given', async () => {
+      await repo.notifyStackChange('plex', 'homeserver', {
+        deployId: 42,
+        status: 'succeeded',
+        action: 'deploy',
+        trigger: 'ui',
+      });
+
+      const payload = JSON.parse(mock.queries[0].params[0] as string);
+      expect('message' in payload).toBe(false);
+    });
   });
 
   describe('recoverStuckDeploys', () => {
@@ -342,19 +431,19 @@ describe('DeployRepository', () => {
       expect(sql).toContain("SET status = 'failed'");
       expect(sql).toContain('logs = $1');
       expect(sql).toContain("status IN ('pending', 'in_progress')");
-      expect(sql).toContain('RETURNING id, stack, host');
+      expect(sql).toContain('RETURNING id, stack, host, action, trigger');
       expect(mock.queries[0].params).toEqual(['boom']);
     });
 
     it('returns the recovered rows with Number-coerced ids', async () => {
       mock.pushResult([
-        { id: '7', stack: 'plex', host: 'homeserver' },
-        { id: '8', stack: 'traefik', host: 'other' },
+        { id: '7', stack: 'plex', host: 'homeserver', action: 'deploy', trigger: 'git_push' },
+        { id: '8', stack: 'traefik', host: 'other', action: 'teardown', trigger: 'ui' },
       ]);
       const rows = await repo.recoverStuckDeploys('crashed');
       expect(rows).toEqual([
-        { id: 7, stack: 'plex', host: 'homeserver' },
-        { id: 8, stack: 'traefik', host: 'other' },
+        { id: 7, stack: 'plex', host: 'homeserver', action: 'deploy', trigger: 'git_push' },
+        { id: 8, stack: 'traefik', host: 'other', action: 'teardown', trigger: 'ui' },
       ]);
     });
   });
@@ -394,17 +483,17 @@ describe('DeployRepository', () => {
       expect(sql).toContain('logs = $2');
       expect(sql).toContain("status = 'in_progress'");
       expect(sql).toContain('make_interval(mins => $1)');
-      expect(sql).toContain('RETURNING id, stack, host');
+      expect(sql).toContain('RETURNING id, stack, host, action, trigger');
       expect(mock.queries[0].params).toEqual([30, 'timed out']);
     });
 
     it('returns the timed-out rows with Number-coerced ids', async () => {
       mock.pushResult([
-        { id: '42', stack: 'plex', host: 'homeserver' },
+        { id: '42', stack: 'plex', host: 'homeserver', action: 'deploy', trigger: 'git_push' },
       ]);
       const rows = await repo.timeoutStuckDeploys(15, 'slow');
       expect(rows).toEqual([
-        { id: 42, stack: 'plex', host: 'homeserver' },
+        { id: 42, stack: 'plex', host: 'homeserver', action: 'deploy', trigger: 'git_push' },
       ]);
     });
   });

--- a/src/lib/database/repositories/__tests__/deploy-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/deploy-repository.test.ts
@@ -331,7 +331,7 @@ describe('DeployRepository', () => {
       expect(mock.queries[0].params).toEqual([JSON.stringify({ type: 'deploy_changed', stack: 'plex', host: 'homeserver' })]);
     });
 
-    it('includes outcome fields when provided', async () => {
+    it('nests outcome fields under a single outcome object when provided', async () => {
       await repo.notifyStackChange('plex', 'homeserver', {
         deployId: 42,
         status: 'succeeded',
@@ -343,10 +343,12 @@ describe('DeployRepository', () => {
         type: 'deploy_changed',
         stack: 'plex',
         host: 'homeserver',
-        deployId: 42,
-        status: 'succeeded',
-        action: 'deploy',
-        trigger: 'ui',
+        outcome: {
+          deployId: 42,
+          status: 'succeeded',
+          action: 'deploy',
+          trigger: 'ui',
+        },
       })]);
     });
 
@@ -361,7 +363,7 @@ describe('DeployRepository', () => {
       });
 
       const payload = JSON.parse(mock.queries[0].params[0] as string);
-      expect(payload.message).toBe('first line of logs');
+      expect(payload.outcome.message).toBe('first line of logs');
     });
 
     it('strips control characters including embedded nulls from the message', async () => {
@@ -374,7 +376,7 @@ describe('DeployRepository', () => {
       });
 
       const payload = JSON.parse(mock.queries[0].params[0] as string);
-      expect(payload.message).toBe('badvaluehere');
+      expect(payload.outcome.message).toBe('badvaluehere');
     });
 
     it('truncates the message to 200 chars', async () => {
@@ -388,8 +390,8 @@ describe('DeployRepository', () => {
       });
 
       const payload = JSON.parse(mock.queries[0].params[0] as string);
-      expect(payload.message).toHaveLength(200);
-      expect(payload.message).toBe('x'.repeat(200));
+      expect(payload.outcome.message).toHaveLength(200);
+      expect(payload.outcome.message).toBe('x'.repeat(200));
     });
 
     it('does not truncate mid-surrogate-pair', async () => {
@@ -405,7 +407,7 @@ describe('DeployRepository', () => {
       });
 
       const payload = JSON.parse(mock.queries[0].params[0] as string);
-      expect(payload.message).toBe('x'.repeat(199));
+      expect(payload.outcome.message).toBe('x'.repeat(199));
     });
 
     it('omits the message field when no message is given', async () => {
@@ -417,7 +419,7 @@ describe('DeployRepository', () => {
       });
 
       const payload = JSON.parse(mock.queries[0].params[0] as string);
-      expect('message' in payload).toBe(false);
+      expect('message' in payload.outcome).toBe(false);
     });
   });
 

--- a/src/lib/database/repositories/deploy-repository.ts
+++ b/src/lib/database/repositories/deploy-repository.ts
@@ -227,11 +227,13 @@ export class DeployRepository {
       stack,
       host,
       ...(outcome ? {
-        deployId: outcome.deployId,
-        status: outcome.status,
-        action: outcome.action,
-        trigger: outcome.trigger,
-        ...(outcome.message ? { message: truncateDeployMessage(outcome.message) } : {}),
+        outcome: {
+          deployId: outcome.deployId,
+          status: outcome.status,
+          action: outcome.action,
+          trigger: outcome.trigger,
+          ...(outcome.message ? { message: truncateDeployMessage(outcome.message) } : {}),
+        },
       } : {}),
     });
     await this.pool.query("SELECT pg_notify('deploy_change', $1)", [payload]);

--- a/src/lib/database/repositories/deploy-repository.ts
+++ b/src/lib/database/repositories/deploy-repository.ts
@@ -1,5 +1,5 @@
 import type { Pool } from 'pg';
-import type { DeployAction, DeployPostSuccess, DeployRecord, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
+import type { DeployAction, DeployChangeOutcome, DeployPostSuccess, DeployRecord, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
 import { truncateDeployMessage } from '@/lib/stacks/deploy-outcome-toast';
 
 export interface StuckDeployRow {
@@ -14,15 +14,6 @@ export interface PostSuccessDeployRow {
   id: number;
   stack: string;
   host: string;
-}
-
-/** Outcome attached to a deploy_change NOTIFY so subscribers can render a toast without a follow-up query. */
-export interface DeployChangeOutcome {
-  deployId: number;
-  status: DeployStatus;
-  action: DeployAction;
-  trigger: DeployTrigger;
-  message?: string;
 }
 
 interface InsertDeployParams {

--- a/src/lib/database/repositories/deploy-repository.ts
+++ b/src/lib/database/repositories/deploy-repository.ts
@@ -5,12 +5,45 @@ export interface StuckDeployRow {
   id: number;
   stack: string;
   host: string;
+  action: DeployAction;
+  trigger: DeployTrigger;
 }
 
 export interface PostSuccessDeployRow {
   id: number;
   stack: string;
   host: string;
+}
+
+/** Outcome attached to a deploy_change NOTIFY so subscribers can render a toast without a follow-up query. */
+export interface DeployChangeOutcome {
+  deployId: number;
+  status: DeployStatus;
+  action: DeployAction;
+  trigger: DeployTrigger;
+  message?: string;
+}
+
+const MAX_DEPLOY_MESSAGE_LENGTH = 200;
+
+/**
+ * Sanitize a deploy outcome message for the NOTIFY payload: take the first
+ * line, strip control characters (including embedded nulls), and truncate to
+ * 200 chars without splitting a UTF-16 surrogate pair.
+ */
+function sanitizeDeployMessage(message: string): string {
+  const firstLine = message.split(/\r?\n/)[0] ?? '';
+  const stripped = Array.from(firstLine)
+    .filter((ch) => {
+      const code = ch.codePointAt(0) ?? 0;
+      return code > 0x1f && code !== 0x7f;
+    })
+    .join('');
+  if (stripped.length <= MAX_DEPLOY_MESSAGE_LENGTH) return stripped;
+  let end = MAX_DEPLOY_MESSAGE_LENGTH;
+  const boundary = stripped.charCodeAt(end - 1);
+  if (boundary >= 0xd800 && boundary <= 0xdbff) end -= 1;
+  return stripped.slice(0, end);
 }
 
 interface InsertDeployParams {
@@ -209,8 +242,19 @@ export class DeployRepository {
     }));
   }
 
-  async notifyStackChange(stack: string, host: string): Promise<void> {
-    const payload = JSON.stringify({ type: 'deploy_changed', stack, host });
+  async notifyStackChange(stack: string, host: string, outcome?: DeployChangeOutcome): Promise<void> {
+    const payload = JSON.stringify({
+      type: 'deploy_changed',
+      stack,
+      host,
+      ...(outcome ? {
+        deployId: outcome.deployId,
+        status: outcome.status,
+        action: outcome.action,
+        trigger: outcome.trigger,
+        ...(outcome.message ? { message: sanitizeDeployMessage(outcome.message) } : {}),
+      } : {}),
+    });
     await this.pool.query("SELECT pg_notify('deploy_change', $1)", [payload]);
   }
 
@@ -225,7 +269,7 @@ export class DeployRepository {
       `UPDATE deploy_history
        SET status = 'failed', logs = $1
        WHERE status IN ('pending', 'in_progress')
-       RETURNING id, stack, host`,
+       RETURNING id, stack, host, action, trigger`,
       [logMessage],
     );
     return result.rows.map(toStuckDeployRow);
@@ -246,7 +290,7 @@ export class DeployRepository {
        SET status = 'failed', logs = $2
        WHERE status = 'in_progress'
          AND COALESCE(started_at, created_at) < NOW() - make_interval(mins => $1)
-       RETURNING id, stack, host`,
+       RETURNING id, stack, host, action, trigger`,
       [thresholdMinutes, logMessage],
     );
     return result.rows.map(toStuckDeployRow);
@@ -258,6 +302,8 @@ function toStuckDeployRow(row: Record<string, unknown>): StuckDeployRow {
     id: Number(row.id),
     stack: row.stack as string,
     host: row.host as string,
+    action: (row.action as DeployAction) ?? 'deploy',
+    trigger: row.trigger as DeployTrigger,
   };
 }
 

--- a/src/lib/database/repositories/deploy-repository.ts
+++ b/src/lib/database/repositories/deploy-repository.ts
@@ -1,5 +1,6 @@
 import type { Pool } from 'pg';
 import type { DeployAction, DeployPostSuccess, DeployRecord, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
+import { truncateDeployMessage } from '@/lib/stacks/deploy-outcome-toast';
 
 export interface StuckDeployRow {
   id: number;
@@ -22,28 +23,6 @@ export interface DeployChangeOutcome {
   action: DeployAction;
   trigger: DeployTrigger;
   message?: string;
-}
-
-const MAX_DEPLOY_MESSAGE_LENGTH = 200;
-
-/**
- * Sanitize a deploy outcome message for the NOTIFY payload: take the first
- * line, strip control characters (including embedded nulls), and truncate to
- * 200 chars without splitting a UTF-16 surrogate pair.
- */
-function sanitizeDeployMessage(message: string): string {
-  const firstLine = message.split(/\r?\n/)[0] ?? '';
-  const stripped = Array.from(firstLine)
-    .filter((ch) => {
-      const code = ch.codePointAt(0) ?? 0;
-      return code > 0x1f && code !== 0x7f;
-    })
-    .join('');
-  if (stripped.length <= MAX_DEPLOY_MESSAGE_LENGTH) return stripped;
-  let end = MAX_DEPLOY_MESSAGE_LENGTH;
-  const boundary = stripped.charCodeAt(end - 1);
-  if (boundary >= 0xd800 && boundary <= 0xdbff) end -= 1;
-  return stripped.slice(0, end);
 }
 
 interface InsertDeployParams {
@@ -252,7 +231,7 @@ export class DeployRepository {
         status: outcome.status,
         action: outcome.action,
         trigger: outcome.trigger,
-        ...(outcome.message ? { message: sanitizeDeployMessage(outcome.message) } : {}),
+        ...(outcome.message ? { message: truncateDeployMessage(outcome.message) } : {}),
       } : {}),
     });
     await this.pool.query("SELECT pg_notify('deploy_change', $1)", [payload]);
@@ -302,7 +281,7 @@ function toStuckDeployRow(row: Record<string, unknown>): StuckDeployRow {
     id: Number(row.id),
     stack: row.stack as string,
     host: row.host as string,
-    action: (row.action as DeployAction) ?? 'deploy',
+    action: row.action as DeployAction,
     trigger: row.trigger as DeployTrigger,
   };
 }

--- a/src/lib/deploy/__tests__/deploy-watchdog.test.ts
+++ b/src/lib/deploy/__tests__/deploy-watchdog.test.ts
@@ -107,10 +107,10 @@ describe('DeployWatchdog', () => {
       expect(message).toContain('watchdog');
     });
 
-    it('notifies each timed-out row on stack_change', async () => {
+    it('notifies each timed-out row on stack_change with a failed outcome', async () => {
       const rows = [
-        { id: 1, stack: 'plex', host: 'homeserver' },
-        { id: 2, stack: 'traefik', host: 'homeserver' },
+        { id: 1, stack: 'plex', host: 'homeserver', action: 'deploy', trigger: 'git_push' },
+        { id: 2, stack: 'traefik', host: 'homeserver', action: 'teardown', trigger: 'ui' },
       ];
       const timeoutStuckDeploys = mock().mockResolvedValue(rows);
       const notifyStackChange = mock().mockResolvedValue(undefined);
@@ -123,8 +123,16 @@ describe('DeployWatchdog', () => {
       await w.tick(repo);
 
       expect(notifyStackChange).toHaveBeenCalledTimes(2);
-      expect(notifyStackChange.mock.calls[0]).toEqual(['plex', 'homeserver']);
-      expect(notifyStackChange.mock.calls[1]).toEqual(['traefik', 'homeserver']);
+      expect(notifyStackChange.mock.calls[0]).toEqual([
+        'plex',
+        'homeserver',
+        { deployId: 1, status: 'failed', action: 'deploy', trigger: 'git_push', message: expect.stringContaining('30 minutes') },
+      ]);
+      expect(notifyStackChange.mock.calls[1]).toEqual([
+        'traefik',
+        'homeserver',
+        { deployId: 2, status: 'failed', action: 'teardown', trigger: 'ui', message: expect.stringContaining('30 minutes') },
+      ]);
     });
 
     it('does not call notifyStackChange when no deploys are stuck', async () => {
@@ -141,8 +149,8 @@ describe('DeployWatchdog', () => {
 
     it('swallows notify errors so one bad row does not break the sweep', async () => {
       const rows = [
-        { id: 1, stack: 'a', host: 'h' },
-        { id: 2, stack: 'b', host: 'h' },
+        { id: 1, stack: 'a', host: 'h', action: 'deploy', trigger: 'git_push' },
+        { id: 2, stack: 'b', host: 'h', action: 'deploy', trigger: 'git_push' },
       ];
       const notifyStackChange = mock()
         .mockRejectedValueOnce(new Error('notify blew up'))
@@ -156,8 +164,10 @@ describe('DeployWatchdog', () => {
       const w = new DeployWatchdog({ intervalMs: 1000, thresholdMinutes: 30 });
       await expect(w.tick(repo)).resolves.toBeUndefined();
       expect(notifyStackChange).toHaveBeenCalledTimes(2);
-      expect(notifyStackChange.mock.calls[0]).toEqual(['a', 'h']);
-      expect(notifyStackChange.mock.calls[1]).toEqual(['b', 'h']);
+      expect(notifyStackChange.mock.calls[0][0]).toBe('a');
+      expect(notifyStackChange.mock.calls[0][1]).toBe('h');
+      expect(notifyStackChange.mock.calls[1][0]).toBe('b');
+      expect(notifyStackChange.mock.calls[1][1]).toBe('h');
       expect(errSpy).toHaveBeenCalled();
       errSpy.mockRestore();
     });
@@ -244,7 +254,7 @@ describe('DeployWatchdog', () => {
 
   describe('interval firing', () => {
     it('invokes tick when the interval callback runs', async () => {
-      const rows = [{ id: 9, stack: 'a', host: 'h' }];
+      const rows = [{ id: 9, stack: 'a', host: 'h', action: 'deploy', trigger: 'git_push' }];
       const timeoutStuckDeploys = mock().mockResolvedValue(rows);
       const notifyStackChange = mock().mockResolvedValue(undefined);
       const repo = createRepoMock({
@@ -260,7 +270,13 @@ describe('DeployWatchdog', () => {
       await new Promise((r) => setTimeout(r, 0));
 
       expect(timeoutStuckDeploys).toHaveBeenCalledTimes(1);
-      expect(notifyStackChange).toHaveBeenCalledWith('a', 'h');
+      expect(notifyStackChange).toHaveBeenCalledWith('a', 'h', {
+        deployId: 9,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: expect.stringContaining('5 minutes'),
+      });
       w.stop();
     });
   });

--- a/src/lib/deploy/__tests__/pipeline.test.ts
+++ b/src/lib/deploy/__tests__/pipeline.test.ts
@@ -122,6 +122,12 @@ describe('DeployPipeline', () => {
       expect(result.logs).toBe('deployed ok');
       expect(deployRepo.insertDeployIfNoActive).toHaveBeenCalledTimes(1);
       expect(deployRepo.updateStatus).toHaveBeenCalledTimes(2); // in_progress + succeeded
+      expect(deployRepo.notifyStackChange).toHaveBeenCalledWith('plex', 'homeserver', {
+        deployId: 1,
+        status: 'succeeded',
+        action: 'deploy',
+        trigger: 'git_push',
+      });
     });
 
     it('returns no_change when compose and env are unchanged', async () => {
@@ -159,6 +165,12 @@ describe('DeployPipeline', () => {
 
       const result = await pipeline.execute(testRequest);
       expect(result.status).toBe('no_change');
+      expect(deployRepo.notifyStackChange).toHaveBeenCalledWith('plex', 'homeserver', {
+        deployId: 1,
+        status: 'no_change',
+        action: 'deploy',
+        trigger: 'git_push',
+      });
     });
 
     it('fails validation when host is not found', async () => {
@@ -217,6 +229,13 @@ describe('DeployPipeline', () => {
 
       const result = await pipeline.execute(testRequest);
       expect(result.status).toBe('failed');
+      expect(deployRepo.notifyStackChange).toHaveBeenCalledWith('plex', 'homeserver', {
+        deployId: 1,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: 'deploy failed',
+      });
     });
 
     it('handles teardown action', async () => {
@@ -226,6 +245,12 @@ describe('DeployPipeline', () => {
       expect(result.status).toBe('succeeded');
       const agent = agentClientFactory.mock.results[0].value;
       expect(agent.teardown).toHaveBeenCalled();
+      expect(deployRepo.notifyStackChange).toHaveBeenCalledWith('plex', 'homeserver', {
+        deployId: 1,
+        status: 'succeeded',
+        action: 'teardown',
+        trigger: 'git_push',
+      });
     });
 
     it('resolves secrets and builds env content', async () => {
@@ -351,6 +376,13 @@ describe('DeployPipeline', () => {
       expect(result.status).toBe('failed');
       expect(result.logs).toBe('connection refused');
       expect(deployRepo.updateStatus).toHaveBeenCalledWith(1, 'failed', 'connection refused');
+      expect(deployRepo.notifyStackChange).toHaveBeenCalledWith('plex', 'homeserver', {
+        deployId: 1,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: 'connection refused',
+      });
     });
 
     it('handles non-Error throw in dispatch', async () => {
@@ -539,6 +571,13 @@ describe('DeployPipeline', () => {
         'failed',
         expect.stringContaining('manifest delete failed'),
       );
+      expect(deployRepo.notifyStackChange).toHaveBeenCalledWith('plex', 'homeserver', {
+        deployId: 1,
+        status: 'failed',
+        action: 'teardown',
+        trigger: 'ui',
+        message: 'git corrupted',
+      });
     });
 
     it('does NOT invoke removeStackFromManifest when deploy fails', async () => {
@@ -642,6 +681,13 @@ describe('DeployPipeline', () => {
       expect(result.status).toBe('failed');
       expect(result.logs).toContain('Secret resolution failed');
       expect(deployRepo.updateStatus).toHaveBeenCalledWith(42, 'failed', expect.stringContaining('vault unreachable'));
+      expect(deployRepo.notifyStackChange).toHaveBeenCalledWith('plex', 'homeserver', {
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: expect.stringContaining('vault unreachable'),
+      });
     });
 
     it('records failure when agent dispatch fails during resume', async () => {

--- a/src/lib/deploy/__tests__/startup-recovery.test.ts
+++ b/src/lib/deploy/__tests__/startup-recovery.test.ts
@@ -68,10 +68,10 @@ describe('performStartupRecovery', () => {
     expect(msg).toContain('verify');
   });
 
-  it('notifies each recovered row on stack_change with correct args', async () => {
+  it('notifies each recovered row on stack_change with a failed outcome', async () => {
     const recovered = [
-      { id: 1, stack: 'plex', host: 'home' },
-      { id: 2, stack: 'traefik', host: 'home' },
+      { id: 1, stack: 'plex', host: 'home', action: 'deploy', trigger: 'git_push' },
+      { id: 2, stack: 'traefik', host: 'home', action: 'teardown', trigger: 'ui' },
     ];
     const notifyStackChange = mock().mockResolvedValue(undefined);
     const repo = createRepo({
@@ -82,14 +82,22 @@ describe('performStartupRecovery', () => {
     await performStartupRecovery(repo, createWatchdog());
 
     expect(notifyStackChange).toHaveBeenCalledTimes(2);
-    expect(notifyStackChange.mock.calls[0]).toEqual(['plex', 'home']);
-    expect(notifyStackChange.mock.calls[1]).toEqual(['traefik', 'home']);
+    expect(notifyStackChange.mock.calls[0]).toEqual([
+      'plex',
+      'home',
+      { deployId: 1, status: 'failed', action: 'deploy', trigger: 'git_push', message: expect.stringContaining('server restarted') },
+    ]);
+    expect(notifyStackChange.mock.calls[1]).toEqual([
+      'traefik',
+      'home',
+      { deployId: 2, status: 'failed', action: 'teardown', trigger: 'ui', message: expect.stringContaining('server restarted') },
+    ]);
   });
 
   it('swallows per-row notify errors and continues the loop', async () => {
     const recovered = [
-      { id: 1, stack: 'a', host: 'h' },
-      { id: 2, stack: 'b', host: 'h' },
+      { id: 1, stack: 'a', host: 'h', action: 'deploy', trigger: 'git_push' },
+      { id: 2, stack: 'b', host: 'h', action: 'deploy', trigger: 'git_push' },
     ];
     const notifyStackChange = mock()
       .mockRejectedValueOnce(new Error('notify blew up'))
@@ -104,7 +112,8 @@ describe('performStartupRecovery', () => {
     await performStartupRecovery(repo, watchdog);
 
     expect(notifyStackChange).toHaveBeenCalledTimes(2);
-    expect(notifyStackChange.mock.calls[1]).toEqual(['b', 'h']);
+    expect(notifyStackChange.mock.calls[1][0]).toBe('b');
+    expect(notifyStackChange.mock.calls[1][1]).toBe('h');
     expect(watchdog.startMock).toHaveBeenCalledTimes(1);
     errSpy.mockRestore();
   });

--- a/src/lib/deploy/deploy-watchdog.ts
+++ b/src/lib/deploy/deploy-watchdog.ts
@@ -94,7 +94,13 @@ export class DeployWatchdog {
       );
       for (const row of timedOut) {
         try {
-          await deployRepo.notifyStackChange(row.stack, row.host);
+          await deployRepo.notifyStackChange(row.stack, row.host, {
+            deployId: row.id,
+            status: 'failed',
+            action: row.action,
+            trigger: row.trigger,
+            message,
+          });
         } catch (err) {
           console.error(
             `[DeployWatchdog] Failed to notify stack change for ${row.stack}/${row.host}:`,

--- a/src/lib/deploy/pipeline.ts
+++ b/src/lib/deploy/pipeline.ts
@@ -110,7 +110,13 @@ export class DeployPipeline {
               console.error('[Pipeline] Failed to record postSuccess failure status:', updateErr);
             }
             try {
-              await this.deployRepo.notifyStackChange(request.stack, request.host);
+              await this.deployRepo.notifyStackChange(request.stack, request.host, {
+                deployId,
+                status: 'failed',
+                action: request.action,
+                trigger: request.trigger,
+                message: errMsg,
+              });
             } catch (notifyErr) {
               console.error(`Failed to notify stack change for "${request.stack}":`, notifyErr);
             }
@@ -119,7 +125,14 @@ export class DeployPipeline {
         }
 
         try {
-          await this.deployRepo.notifyStackChange(request.stack, request.host);
+          // deployId is always set here: the only early return above (insertDeploy
+          // failure) happens inside the try/catch before this point.
+          await this.deployRepo.notifyStackChange(request.stack, request.host, {
+            deployId: deployId as number,
+            status: 'no_change',
+            action: request.action,
+            trigger: request.trigger,
+          });
         } catch (err) {
           console.error(`Failed to notify stack change for "${request.stack}":`, err);
         }
@@ -197,7 +210,13 @@ export class DeployPipeline {
         console.error(`Failed to record deploy failure for deploy ${deployId}:`, dbErr);
       }
       try {
-        await this.deployRepo.notifyStackChange(request.stack, request.host);
+        await this.deployRepo.notifyStackChange(request.stack, request.host, {
+          deployId,
+          status: 'failed',
+          action: request.action,
+          trigger: request.trigger,
+          message: errorMsg,
+        });
       } catch (notifyErr) {
         console.error(`Failed to notify stack change for deploy ${deployId} ("${request.stack}" on "${request.host}"):`, notifyErr);
       }
@@ -251,7 +270,13 @@ export class DeployPipeline {
         console.error(`Failed to record deploy failure for deploy ${deployId}:`, dbErr);
       }
       try {
-        await this.deployRepo.notifyStackChange(request.stack, host.name);
+        await this.deployRepo.notifyStackChange(request.stack, host.name, {
+          deployId,
+          status: 'failed',
+          action: request.action,
+          trigger: request.trigger,
+          message: errorMsg,
+        });
       } catch (notifyErr) {
         console.error(`Failed to notify stack change for deploy ${deployId} ("${request.stack}" on "${host.name}"):`, notifyErr);
       }
@@ -292,7 +317,13 @@ export class DeployPipeline {
           console.error('[Pipeline] Failed to record postSuccess failure status:', updateErr);
         }
         try {
-          await this.deployRepo.notifyStackChange(request.stack, host.name);
+          await this.deployRepo.notifyStackChange(request.stack, host.name, {
+            deployId,
+            status: 'failed',
+            action: request.action,
+            trigger: request.trigger,
+            message: errMsg,
+          });
         } catch (notifyErr) {
           console.error(`Failed to notify stack change for "${request.stack}":`, notifyErr);
         }
@@ -301,7 +332,13 @@ export class DeployPipeline {
     }
 
     try {
-      await this.deployRepo.notifyStackChange(request.stack, host.name);
+      await this.deployRepo.notifyStackChange(request.stack, host.name, {
+        deployId,
+        status: finalStatus,
+        action: request.action,
+        trigger: request.trigger,
+        ...(finalStatus === 'failed' ? { message: result.logs } : {}),
+      });
     } catch (err) {
       console.error(`Failed to notify stack change for "${request.stack}":`, err);
     }

--- a/src/lib/deploy/startup-recovery.ts
+++ b/src/lib/deploy/startup-recovery.ts
@@ -63,7 +63,13 @@ export async function performStartupRecovery(
       console.info(`[Server] Recovered ${recovered.length} stuck deploy(s) on startup`);
       for (const r of recovered) {
         try {
-          await repo.notifyStackChange(r.stack, r.host);
+          await repo.notifyStackChange(r.stack, r.host, {
+            deployId: r.id,
+            status: 'failed',
+            action: r.action,
+            trigger: r.trigger,
+            message: STARTUP_RECOVERY_MESSAGE,
+          });
         } catch (err) {
           console.error(`[Server] Failed to notify stack change for ${r.stack}/${r.host}:`, err);
         }

--- a/src/lib/deploy/types.ts
+++ b/src/lib/deploy/types.ts
@@ -1,13 +1,35 @@
-export type DeployAction = 'deploy' | 'teardown';
+import { z } from 'zod';
 
-export type DeployStatus =
-  | 'pending'
-  | 'in_progress'
-  | 'succeeded'
-  | 'failed'
-  | 'no_change';
+export const DEPLOY_ACTION_VALUES = ['deploy', 'teardown'] as const;
+export type DeployAction = (typeof DEPLOY_ACTION_VALUES)[number];
 
-export type DeployTrigger = 'git_push' | 'ui' | 'manual_rollback';
+export const DEPLOY_STATUS_VALUES = [
+  'pending',
+  'in_progress',
+  'succeeded',
+  'failed',
+  'no_change',
+] as const;
+export type DeployStatus = (typeof DEPLOY_STATUS_VALUES)[number];
+
+export const DEPLOY_TRIGGER_VALUES = ['git_push', 'ui', 'manual_rollback'] as const;
+export type DeployTrigger = (typeof DEPLOY_TRIGGER_VALUES)[number];
+
+/**
+ * Wire shape for a deploy lifecycle outcome, broadcast over the `deploy_change`
+ * NOTIFY channel and forwarded on the stack-status SSE stream. Single source of
+ * truth for both the server-side broadcast parse and the client-side channel
+ * schema, so the two can't drift.
+ */
+export const zDeployChangeOutcome = z.object({
+  deployId: z.number().int().positive(),
+  status: z.enum(DEPLOY_STATUS_VALUES),
+  action: z.enum(DEPLOY_ACTION_VALUES),
+  trigger: z.enum(DEPLOY_TRIGGER_VALUES),
+  message: z.string().optional(),
+});
+
+export type DeployChangeOutcome = z.infer<typeof zDeployChangeOutcome>;
 
 /**
  * Action to run inside the pipeline after a deploy reaches a terminal-success

--- a/src/lib/mock/functions/stacks.functions.tsx
+++ b/src/lib/mock/functions/stacks.functions.tsx
@@ -1,4 +1,4 @@
-import type { StackSummary, StackDetail, StackDeployRecord, UIDeployRequest } from '@/types/stacks';
+import type { StackSummary, StackDetail, StackDeployRecord, UIDeployRequest, DeployStatus } from '@/types/stacks';
 
 const MOCK_STACKS: StackSummary[] = [
   // nas01
@@ -302,16 +302,16 @@ export async function getStackDetail(opts: {
 
 export async function triggerDeploy(_opts: {
   data: UIDeployRequest;
-}): Promise<{ deployId: number }> {
+}): Promise<{ deployId: number; status: DeployStatus; logs: string }> {
   // Simulate a short delay
   await new Promise((resolve) => setTimeout(resolve, 500));
-  return { deployId: MOCK_DEPLOY_HISTORY.length + 1 };
+  return { deployId: MOCK_DEPLOY_HISTORY.length + 1, status: 'succeeded', logs: '' };
 }
 
 export async function resumeDeploy(opts: {
   data: { deployId: number };
-}): Promise<{ deployId: number }> {
-  return { deployId: opts.data.deployId };
+}): Promise<{ deployId: number; status: DeployStatus; logs: string }> {
+  return { deployId: opts.data.deployId, status: 'succeeded', logs: '' };
 }
 
 export async function rejectDeploy(opts: {

--- a/src/lib/sse/channels/__tests__/stack-status.test.ts
+++ b/src/lib/sse/channels/__tests__/stack-status.test.ts
@@ -20,31 +20,63 @@ describe('stackStatusChannel', () => {
     expect(result.success).toBe(true);
   });
 
-  it('validates a deploy_changed frame without outcome fields (legacy payload)', () => {
+  it('validates a deploy_changed frame without an outcome (legacy payload)', () => {
     const result = stackStatusChannel.schema.safeParse({ type: 'deploy_changed', stack: 'plex', host: 'server1' });
     expect(result.success).toBe(true);
   });
 
-  it('validates a deploy_changed frame with outcome fields', () => {
+  it('validates a deploy_changed frame with a complete outcome', () => {
     const result = stackStatusChannel.schema.safeParse({
       type: 'deploy_changed',
       stack: 'plex',
       host: 'server1',
-      deployId: 42,
-      status: 'failed',
-      action: 'deploy',
-      trigger: 'git_push',
-      message: 'agent unreachable',
+      outcome: {
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: 'agent unreachable',
+      },
     });
     expect(result.success).toBe(true);
   });
 
-  it('rejects a deploy_changed frame with an invalid status', () => {
+  it('validates a deploy_changed frame with an outcome that omits the optional message', () => {
     const result = stackStatusChannel.schema.safeParse({
       type: 'deploy_changed',
       stack: 'plex',
       host: 'server1',
-      status: 'bogus',
+      outcome: { deployId: 42, status: 'succeeded', action: 'deploy', trigger: 'ui' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an outcome with an invalid status', () => {
+    const result = stackStatusChannel.schema.safeParse({
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      outcome: { deployId: 42, status: 'bogus', action: 'deploy', trigger: 'ui' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an outcome missing a required field (deployId), the core contract this schema enforces', () => {
+    const result = stackStatusChannel.schema.safeParse({
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      outcome: { status: 'failed', action: 'deploy', trigger: 'git_push' },
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects an outcome missing trigger', () => {
+    const result = stackStatusChannel.schema.safeParse({
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      outcome: { deployId: 42, status: 'failed', action: 'deploy' },
     });
     expect(result.success).toBe(false);
   });
@@ -71,23 +103,25 @@ describe('serializeStackStatusEvent', () => {
     expect(serializeStackStatusEvent(event)).toBe(`data: ${JSON.stringify(event.entries)}\n\n`);
   });
 
-  it('serializes a legacy deploy_changed event without outcome fields', () => {
+  it('serializes a legacy deploy_changed event without an outcome', () => {
     const event: StackBroadcastEvent = { type: 'deploy_changed', stack: 'plex', host: 'server1' };
     const frame = serializeStackStatusEvent(event);
     const payload = JSON.parse(frame.slice('data: '.length).trim());
     expect(payload).toEqual({ type: 'deploy_changed', stack: 'plex', host: 'server1' });
   });
 
-  it('serializes an enriched deploy_changed event with all outcome fields', () => {
+  it('serializes an enriched deploy_changed event with the outcome nested as one object', () => {
     const event: StackBroadcastEvent = {
       type: 'deploy_changed',
       stack: 'plex',
       host: 'server1',
-      deployId: 42,
-      status: 'failed',
-      action: 'deploy',
-      trigger: 'git_push',
-      message: 'agent unreachable',
+      outcome: {
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: 'agent unreachable',
+      },
     };
     const frame = serializeStackStatusEvent(event);
     const payload = JSON.parse(frame.slice('data: '.length).trim());
@@ -95,11 +129,13 @@ describe('serializeStackStatusEvent', () => {
       type: 'deploy_changed',
       stack: 'plex',
       host: 'server1',
-      deployId: 42,
-      status: 'failed',
-      action: 'deploy',
-      trigger: 'git_push',
-      message: 'agent unreachable',
+      outcome: {
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: 'agent unreachable',
+      },
     });
   });
 });

--- a/src/lib/sse/channels/__tests__/stack-status.test.ts
+++ b/src/lib/sse/channels/__tests__/stack-status.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'bun:test';
-import { stackStatusChannel } from '../stack-status';
+import { stackStatusChannel, serializeStackStatusEvent } from '../stack-status';
+import type { StackBroadcastEvent } from '@/lib/stacks/stack-status-broadcast-service';
 
 describe('stackStatusChannel', () => {
   it('exposes the url and errorEvent used by the route and the client', () => {
@@ -58,5 +59,47 @@ describe('stackStatusChannel', () => {
   it('revive is the identity (no Date fields on the wire)', () => {
     const message = [{ stack: 'plex', host: 'server1', containers: [], updated_at: '2026-03-21T00:00:00Z' }];
     expect(stackStatusChannel.revive!(message)).toBe(message);
+  });
+});
+
+describe('serializeStackStatusEvent', () => {
+  it('serializes a status event as the bare entries array', () => {
+    const event: StackBroadcastEvent = {
+      type: 'status',
+      entries: [{ stack: 'plex', host: 'server1', containers: [], updated_at: '2026-03-21T00:00:00Z' }],
+    };
+    expect(serializeStackStatusEvent(event)).toBe(`data: ${JSON.stringify(event.entries)}\n\n`);
+  });
+
+  it('serializes a legacy deploy_changed event without outcome fields', () => {
+    const event: StackBroadcastEvent = { type: 'deploy_changed', stack: 'plex', host: 'server1' };
+    const frame = serializeStackStatusEvent(event);
+    const payload = JSON.parse(frame.slice('data: '.length).trim());
+    expect(payload).toEqual({ type: 'deploy_changed', stack: 'plex', host: 'server1' });
+  });
+
+  it('serializes an enriched deploy_changed event with all outcome fields', () => {
+    const event: StackBroadcastEvent = {
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      deployId: 42,
+      status: 'failed',
+      action: 'deploy',
+      trigger: 'git_push',
+      message: 'agent unreachable',
+    };
+    const frame = serializeStackStatusEvent(event);
+    const payload = JSON.parse(frame.slice('data: '.length).trim());
+    expect(payload).toEqual({
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      deployId: 42,
+      status: 'failed',
+      action: 'deploy',
+      trigger: 'git_push',
+      message: 'agent unreachable',
+    });
   });
 });

--- a/src/lib/sse/channels/__tests__/stack-status.test.ts
+++ b/src/lib/sse/channels/__tests__/stack-status.test.ts
@@ -19,9 +19,33 @@ describe('stackStatusChannel', () => {
     expect(result.success).toBe(true);
   });
 
-  it('validates a deploy_changed frame', () => {
+  it('validates a deploy_changed frame without outcome fields (legacy payload)', () => {
     const result = stackStatusChannel.schema.safeParse({ type: 'deploy_changed', stack: 'plex', host: 'server1' });
     expect(result.success).toBe(true);
+  });
+
+  it('validates a deploy_changed frame with outcome fields', () => {
+    const result = stackStatusChannel.schema.safeParse({
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      deployId: 42,
+      status: 'failed',
+      action: 'deploy',
+      trigger: 'git_push',
+      message: 'agent unreachable',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects a deploy_changed frame with an invalid status', () => {
+    const result = stackStatusChannel.schema.safeParse({
+      type: 'deploy_changed',
+      stack: 'plex',
+      host: 'server1',
+      status: 'bogus',
+    });
+    expect(result.success).toBe(false);
   });
 
   it('rejects a container missing required fields', () => {

--- a/src/lib/sse/channels/stack-status.ts
+++ b/src/lib/sse/channels/stack-status.ts
@@ -1,8 +1,7 @@
 import { z } from 'zod';
 import { defineSseChannel } from '@/lib/sse/define-sse-channel';
 import type { StackStatusEntry } from '@/types/stacks';
-import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
-import type { DeployChangeOutcome } from '@/lib/database/repositories/deploy-repository';
+import { zDeployChangeOutcome, type DeployChangeOutcome } from '@/lib/deploy/types';
 import type { StackBroadcastEvent } from '@/lib/stacks/stack-status-broadcast-service';
 
 /** Discriminated union for stack-status SSE messages (the wire shape has no Date fields, so `revive` is the identity). */
@@ -23,22 +22,6 @@ const zStackStatusEntry = z.object({
   host: z.string(),
   containers: z.array(zStackContainer),
   updated_at: z.string(),
-});
-
-const DEPLOY_STATUS_VALUES = ['pending', 'in_progress', 'succeeded', 'failed', 'no_change'] as const satisfies readonly DeployStatus[];
-const DEPLOY_ACTION_VALUES = ['deploy', 'teardown'] as const satisfies readonly DeployAction[];
-const DEPLOY_TRIGGER_VALUES = ['git_push', 'ui', 'manual_rollback'] as const satisfies readonly DeployTrigger[];
-
-const zDeployStatus = z.enum(DEPLOY_STATUS_VALUES);
-const zDeployAction = z.enum(DEPLOY_ACTION_VALUES);
-const zDeployTrigger = z.enum(DEPLOY_TRIGGER_VALUES);
-
-const zDeployChangeOutcome = z.object({
-  deployId: z.number(),
-  status: zDeployStatus,
-  action: zDeployAction,
-  trigger: zDeployTrigger,
-  message: z.string().optional(),
 });
 
 const zStackStatusWireMessage = z.union([

--- a/src/lib/sse/channels/stack-status.ts
+++ b/src/lib/sse/channels/stack-status.ts
@@ -2,21 +2,13 @@ import { z } from 'zod';
 import { defineSseChannel } from '@/lib/sse/define-sse-channel';
 import type { StackStatusEntry } from '@/types/stacks';
 import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
+import type { DeployChangeOutcome } from '@/lib/database/repositories/deploy-repository';
 import type { StackBroadcastEvent } from '@/lib/stacks/stack-status-broadcast-service';
 
 /** Discriminated union for stack-status SSE messages (the wire shape has no Date fields, so `revive` is the identity). */
 export type StackSSEMessage =
   | StackStatusEntry[]
-  | {
-      type: 'deploy_changed';
-      stack: string;
-      host: string;
-      deployId?: number;
-      status?: DeployStatus;
-      action?: DeployAction;
-      trigger?: DeployTrigger;
-      message?: string;
-    };
+  | { type: 'deploy_changed'; stack: string; host: string; outcome?: DeployChangeOutcome };
 
 const zStackContainer = z.object({
   id: z.string(),
@@ -41,17 +33,21 @@ const zDeployStatus = z.enum(DEPLOY_STATUS_VALUES);
 const zDeployAction = z.enum(DEPLOY_ACTION_VALUES);
 const zDeployTrigger = z.enum(DEPLOY_TRIGGER_VALUES);
 
+const zDeployChangeOutcome = z.object({
+  deployId: z.number(),
+  status: zDeployStatus,
+  action: zDeployAction,
+  trigger: zDeployTrigger,
+  message: z.string().optional(),
+});
+
 const zStackStatusWireMessage = z.union([
   z.array(zStackStatusEntry),
   z.object({
     type: z.literal('deploy_changed'),
     stack: z.string(),
     host: z.string(),
-    deployId: z.number().optional(),
-    status: zDeployStatus.optional(),
-    action: zDeployAction.optional(),
-    trigger: zDeployTrigger.optional(),
-    message: z.string().optional(),
+    outcome: zDeployChangeOutcome.optional(),
   }),
 ]);
 
@@ -62,18 +58,14 @@ export const stackStatusChannel = defineSseChannel({
   revive: (message): StackSSEMessage => message,
 });
 
-/** Drops unset outcome fields instead of sending them as null/undefined. */
+/** Omits `outcome` entirely rather than sending it as null/undefined when absent. */
 export function serializeStackStatusEvent(event: StackBroadcastEvent): string {
   if (event.type === 'deploy_changed') {
     const payload = {
       type: 'deploy_changed',
       stack: event.stack,
       host: event.host,
-      ...(event.deployId !== undefined ? { deployId: event.deployId } : {}),
-      ...(event.status !== undefined ? { status: event.status } : {}),
-      ...(event.action !== undefined ? { action: event.action } : {}),
-      ...(event.trigger !== undefined ? { trigger: event.trigger } : {}),
-      ...(event.message !== undefined ? { message: event.message } : {}),
+      ...(event.outcome !== undefined ? { outcome: event.outcome } : {}),
     };
     return `data: ${JSON.stringify(payload)}\n\n`;
   }

--- a/src/lib/sse/channels/stack-status.ts
+++ b/src/lib/sse/channels/stack-status.ts
@@ -1,11 +1,21 @@
 import { z } from 'zod';
 import { defineSseChannel } from '@/lib/sse/define-sse-channel';
 import type { StackStatusEntry } from '@/types/stacks';
+import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
 
 /** Discriminated union for stack-status SSE messages (the wire shape has no Date fields, so `revive` is the identity). */
 export type StackSSEMessage =
   | StackStatusEntry[]
-  | { type: 'deploy_changed'; stack: string; host: string };
+  | {
+      type: 'deploy_changed';
+      stack: string;
+      host: string;
+      deployId?: number;
+      status?: DeployStatus;
+      action?: DeployAction;
+      trigger?: DeployTrigger;
+      message?: string;
+    };
 
 const zStackContainer = z.object({
   id: z.string(),
@@ -22,9 +32,22 @@ const zStackStatusEntry = z.object({
   updated_at: z.string(),
 });
 
+const zDeployStatus = z.enum(['pending', 'in_progress', 'succeeded', 'failed', 'no_change']);
+const zDeployAction = z.enum(['deploy', 'teardown']);
+const zDeployTrigger = z.enum(['git_push', 'ui', 'manual_rollback']);
+
 const zStackStatusWireMessage = z.union([
   z.array(zStackStatusEntry),
-  z.object({ type: z.literal('deploy_changed'), stack: z.string(), host: z.string() }),
+  z.object({
+    type: z.literal('deploy_changed'),
+    stack: z.string(),
+    host: z.string(),
+    deployId: z.number().optional(),
+    status: zDeployStatus.optional(),
+    action: zDeployAction.optional(),
+    trigger: zDeployTrigger.optional(),
+    message: z.string().optional(),
+  }),
 ]);
 
 export const stackStatusChannel = defineSseChannel({

--- a/src/lib/sse/channels/stack-status.ts
+++ b/src/lib/sse/channels/stack-status.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { defineSseChannel } from '@/lib/sse/define-sse-channel';
 import type { StackStatusEntry } from '@/types/stacks';
 import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
+import type { StackBroadcastEvent } from '@/lib/stacks/stack-status-broadcast-service';
 
 /** Discriminated union for stack-status SSE messages (the wire shape has no Date fields, so `revive` is the identity). */
 export type StackSSEMessage =
@@ -32,9 +33,13 @@ const zStackStatusEntry = z.object({
   updated_at: z.string(),
 });
 
-const zDeployStatus = z.enum(['pending', 'in_progress', 'succeeded', 'failed', 'no_change']);
-const zDeployAction = z.enum(['deploy', 'teardown']);
-const zDeployTrigger = z.enum(['git_push', 'ui', 'manual_rollback']);
+const DEPLOY_STATUS_VALUES = ['pending', 'in_progress', 'succeeded', 'failed', 'no_change'] as const satisfies readonly DeployStatus[];
+const DEPLOY_ACTION_VALUES = ['deploy', 'teardown'] as const satisfies readonly DeployAction[];
+const DEPLOY_TRIGGER_VALUES = ['git_push', 'ui', 'manual_rollback'] as const satisfies readonly DeployTrigger[];
+
+const zDeployStatus = z.enum(DEPLOY_STATUS_VALUES);
+const zDeployAction = z.enum(DEPLOY_ACTION_VALUES);
+const zDeployTrigger = z.enum(DEPLOY_TRIGGER_VALUES);
 
 const zStackStatusWireMessage = z.union([
   z.array(zStackStatusEntry),
@@ -56,3 +61,21 @@ export const stackStatusChannel = defineSseChannel({
   schema: zStackStatusWireMessage,
   revive: (message): StackSSEMessage => message,
 });
+
+/** Drops unset outcome fields instead of sending them as null/undefined. */
+export function serializeStackStatusEvent(event: StackBroadcastEvent): string {
+  if (event.type === 'deploy_changed') {
+    const payload = {
+      type: 'deploy_changed',
+      stack: event.stack,
+      host: event.host,
+      ...(event.deployId !== undefined ? { deployId: event.deployId } : {}),
+      ...(event.status !== undefined ? { status: event.status } : {}),
+      ...(event.action !== undefined ? { action: event.action } : {}),
+      ...(event.trigger !== undefined ? { trigger: event.trigger } : {}),
+      ...(event.message !== undefined ? { message: event.message } : {}),
+    };
+    return `data: ${JSON.stringify(payload)}\n\n`;
+  }
+  return `data: ${JSON.stringify(event.entries)}\n\n`;
+}

--- a/src/lib/stacks/__tests__/deploy-outcome-toast.test.ts
+++ b/src/lib/stacks/__tests__/deploy-outcome-toast.test.ts
@@ -125,6 +125,14 @@ describe('truncateDeployMessage', () => {
     expect(truncateDeployMessage('first line\nsecond line\nthird line')).toBe('first line');
   });
 
+  test('stops at a bare carriage return (compose progress output uses \\r without \\n)', () => {
+    expect(truncateDeployMessage('pulling 50%\rpulling 100%\rdone')).toBe('pulling 50%');
+  });
+
+  test('stops at the first line of CRLF-delimited text', () => {
+    expect(truncateDeployMessage('first line\r\nsecond line')).toBe('first line');
+  });
+
   test('strips control characters including embedded nulls', () => {
     const raw = 'bad' + String.fromCharCode(0) + 'value' + String.fromCharCode(1) + 'here';
     expect(truncateDeployMessage(raw)).toBe('badvaluehere');
@@ -172,6 +180,19 @@ describe('createDeployToastGate', () => {
     const gate = createDeployToastGate();
     expect(gate.claim(5)).toBe(true);
     expect(gate.shouldToast(5)).toBe(false);
+  });
+
+  test('release undoes a claim so a later shouldToast can fire again', () => {
+    const gate = createDeployToastGate();
+    expect(gate.claim(7)).toBe(true);
+    gate.release(7);
+    expect(gate.shouldToast(7)).toBe(true);
+  });
+
+  test('release of an unknown deployId is a no-op', () => {
+    const gate = createDeployToastGate();
+    gate.release(99);
+    expect(gate.shouldToast(99)).toBe(true);
   });
 
   test('factory instances are independent of each other and of the singleton', () => {

--- a/src/lib/stacks/__tests__/deploy-outcome-toast.test.ts
+++ b/src/lib/stacks/__tests__/deploy-outcome-toast.test.ts
@@ -1,0 +1,183 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  createDeployToastGate,
+  formatDeployOutcome,
+  truncateDeployMessage,
+} from '@/lib/stacks/deploy-outcome-toast';
+
+describe('formatDeployOutcome', () => {
+  test('returns null for pending status', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'pending', trigger: 'ui' })).toBeNull();
+  });
+
+  test('returns null for in_progress status', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'in_progress', trigger: 'ui' })).toBeNull();
+  });
+
+  test('returns null for no_change with a git_push trigger', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'no_change', trigger: 'git_push' })).toBeNull();
+  });
+
+  test('returns null for no_change with a manual_rollback trigger', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'no_change', trigger: 'manual_rollback' })).toBeNull();
+  });
+
+  test('returns an info toast for no_change with a ui trigger', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'no_change', trigger: 'ui' })).toEqual({
+      message: 'No changes detected for plex',
+      severity: 'info',
+    });
+  });
+
+  test('formats a successful ui deploy', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'succeeded', trigger: 'ui' })).toEqual({
+      message: 'Deploy of plex succeeded',
+      severity: 'success',
+    });
+  });
+
+  test('formats a successful teardown', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'teardown', status: 'succeeded', trigger: 'ui' })).toEqual({
+      message: 'Teardown of plex succeeded',
+      severity: 'success',
+    });
+  });
+
+  test('formats a successful rollback', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'succeeded', trigger: 'manual_rollback' })).toEqual({
+      message: 'Rollback of plex succeeded',
+      severity: 'success',
+    });
+  });
+
+  test('formats a successful git-push deploy with the "(git push)" suffix', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'succeeded', trigger: 'git_push' })).toEqual({
+      message: 'Deploy of plex (git push) succeeded',
+      severity: 'success',
+    });
+  });
+
+  test('formats a failed ui deploy without a message', () => {
+    expect(formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'failed', trigger: 'ui' })).toEqual({
+      message: 'Deploy of plex failed',
+      severity: 'error',
+    });
+  });
+
+  test('formats a failed ui deploy with a message', () => {
+    expect(formatDeployOutcome({
+      stack: 'plex', action: 'deploy', status: 'failed', trigger: 'ui', message: 'image not found',
+    })).toEqual({
+      message: 'Deploy of plex failed: image not found',
+      severity: 'error',
+    });
+  });
+
+  test('formats a failed rollback with a message', () => {
+    expect(formatDeployOutcome({
+      stack: 'plex', action: 'deploy', status: 'failed', trigger: 'manual_rollback', message: 'agent unreachable',
+    })).toEqual({
+      message: 'Rollback of plex failed: agent unreachable',
+      severity: 'error',
+    });
+  });
+
+  test('formats a failed teardown with a message', () => {
+    expect(formatDeployOutcome({
+      stack: 'plex', action: 'teardown', status: 'failed', trigger: 'ui', message: 'compose down failed',
+    })).toEqual({
+      message: 'Teardown of plex failed: compose down failed',
+      severity: 'error',
+    });
+  });
+
+  test('formats a failed git-push deploy with the "(git push)" suffix and a message', () => {
+    expect(formatDeployOutcome({
+      stack: 'plex', action: 'deploy', status: 'failed', trigger: 'git_push', message: 'image not found',
+    })).toEqual({
+      message: 'Deploy of plex (git push) failed: image not found',
+      severity: 'error',
+    });
+  });
+
+  test('treats a null message the same as no message', () => {
+    expect(formatDeployOutcome({
+      stack: 'plex', action: 'deploy', status: 'failed', trigger: 'ui', message: null,
+    })).toEqual({
+      message: 'Deploy of plex failed',
+      severity: 'error',
+    });
+  });
+
+  test('truncates the message to the first line and 200 chars', () => {
+    const raw = 'x'.repeat(250) + '\nsecond line';
+    const result = formatDeployOutcome({ stack: 'plex', action: 'deploy', status: 'failed', trigger: 'ui', message: raw });
+    expect(result?.message).toBe(`Deploy of plex failed: ${'x'.repeat(200)}`);
+  });
+});
+
+describe('truncateDeployMessage', () => {
+  test('returns short messages unchanged', () => {
+    expect(truncateDeployMessage('short message')).toBe('short message');
+  });
+
+  test('takes only the first line', () => {
+    expect(truncateDeployMessage('first line\nsecond line\nthird line')).toBe('first line');
+  });
+
+  test('strips control characters including embedded nulls', () => {
+    const raw = 'bad' + String.fromCharCode(0) + 'value' + String.fromCharCode(1) + 'here';
+    expect(truncateDeployMessage(raw)).toBe('badvaluehere');
+  });
+
+  test('truncates to 200 chars', () => {
+    const result = truncateDeployMessage('x'.repeat(300));
+    expect(result).toHaveLength(200);
+    expect(result).toBe('x'.repeat(200));
+  });
+
+  test('does not split a surrogate pair at the 200-char boundary', () => {
+    const raw = 'x'.repeat(199) + '\u{1F600}' + 'y'.repeat(10);
+    expect(truncateDeployMessage(raw)).toBe('x'.repeat(199));
+  });
+
+  test('is idempotent for an already-truncated message', () => {
+    const once = truncateDeployMessage('x'.repeat(300));
+    expect(truncateDeployMessage(once)).toBe(once);
+  });
+});
+
+describe('createDeployToastGate', () => {
+  test('shouldToast returns true the first time a deployId is seen', () => {
+    const gate = createDeployToastGate();
+    expect(gate.shouldToast(1)).toBe(true);
+  });
+
+  test('shouldToast returns false on subsequent calls for the same deployId', () => {
+    const gate = createDeployToastGate();
+    expect(gate.shouldToast(1)).toBe(true);
+    expect(gate.shouldToast(1)).toBe(false);
+    expect(gate.shouldToast(1)).toBe(false);
+  });
+
+  test('tracks each deployId independently', () => {
+    const gate = createDeployToastGate();
+    expect(gate.shouldToast(1)).toBe(true);
+    expect(gate.shouldToast(2)).toBe(true);
+    expect(gate.shouldToast(1)).toBe(false);
+    expect(gate.shouldToast(2)).toBe(false);
+  });
+
+  test('claim is an alias for shouldToast: pre-claiming suppresses a later shouldToast call', () => {
+    const gate = createDeployToastGate();
+    expect(gate.claim(5)).toBe(true);
+    expect(gate.shouldToast(5)).toBe(false);
+  });
+
+  test('factory instances are independent of each other and of the singleton', () => {
+    const gateA = createDeployToastGate();
+    const gateB = createDeployToastGate();
+    expect(gateA.shouldToast(1)).toBe(true);
+    expect(gateB.shouldToast(1)).toBe(true);
+  });
+});

--- a/src/lib/stacks/__tests__/stack-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-service.test.ts
@@ -145,7 +145,7 @@ describe('handleTriggerDeploy', () => {
         autoApproved: true,
         envContent: '',
       })),
-      executePipeline: mock(() => Promise.resolve({ deployId: 42 })),
+      executePipeline: mock(() => Promise.resolve({ deployId: 42, status: 'succeeded' as const, logs: 'deployed ok' })),
       ...overrides,
     };
   }
@@ -154,6 +154,8 @@ describe('handleTriggerDeploy', () => {
     const deps = mockDeps();
     const result = await handleTriggerDeploy(deps, { stack: 'myapp', host: 'server1', action: 'deploy' });
     expect(result.deployId).toBe(42);
+    expect(result.status).toBe('succeeded');
+    expect(result.logs).toBe('deployed ok');
     expect(deps.readCompose).toHaveBeenCalledWith('myapp');
     expect(deps.getCommitSha).toHaveBeenCalledTimes(1);
     expect(deps.buildRequest).toHaveBeenCalledTimes(1);
@@ -179,7 +181,7 @@ describe('handleTriggerDeploy', () => {
 
   test('throws when pipeline returns no deployId', async () => {
     const deps = mockDeps({
-      executePipeline: mock(() => Promise.resolve({})),
+      executePipeline: mock(() => Promise.resolve({ status: 'failed' as const, logs: 'no active host' })),
     });
     await expect(
       handleTriggerDeploy(deps, { stack: 'myapp', host: 'server1', action: 'deploy' })
@@ -222,7 +224,7 @@ describe('triggerStackDeploy', () => {
       repoName: 'test',
       repoPath,
     });
-    executeMock = mock(() => Promise.resolve({ deployId: 42 }));
+    executeMock = mock(() => Promise.resolve({ deployId: 42, status: 'succeeded' as const, logs: 'deployed ok' }));
     createDeployPipelineSpy = spyOn(pipelineFactory, 'createDeployPipeline').mockResolvedValue({
       pipeline: { execute: (request: DeployRequest) => executeMock(request) } as unknown as DeployPipeline,
       deployRepo: {} as never,
@@ -241,6 +243,8 @@ describe('triggerStackDeploy', () => {
     const result = await freshTriggerStackDeploy({ stack: 'plex', host: 'homeserver', action: 'deploy' });
 
     expect(result.deployId).toBe(42);
+    expect(result.status).toBe('succeeded');
+    expect(result.logs).toBe('deployed ok');
     expect(executeMock).toHaveBeenCalledWith({
       stack: 'plex',
       host: 'homeserver',
@@ -516,5 +520,123 @@ describe('resolveDeleteStack', () => {
     expect(triggerDeploy).not.toHaveBeenCalled();
     expect(commitRemove).toHaveBeenCalledWith('plex');
     expect(result).toEqual({ status: 'removed', commitSha: 'sha-xyz' });
+  });
+});
+
+describe('resumePendingDeploy / rejectPendingDeploy', () => {
+  let testDir: string;
+  let repoPath: string;
+  let loadGitConfigSpy: ReturnType<typeof spyOn>;
+  let createDeployPipelineSpy: ReturnType<typeof spyOn>;
+  let commitSha: string;
+  let pendingRecord: DeployRecord;
+  let mockResumePending: ReturnType<typeof mock>;
+
+  const mockGetById = mock(() => Promise.resolve(pendingRecord));
+  const mockFindByName = mock(() => Promise.resolve({ name: 'homeserver', agentUrl: 'http://agent:9090' }));
+  const mockRejectPending = mock(() => Promise.resolve(true));
+  const mockNotifyStackChange = mock(() => Promise.resolve(undefined));
+
+  beforeEach(async () => {
+    // Re-registered every test (not just once at collection time): mock.module
+    // replacements for these paths persist across describes in this file, so
+    // each block must reassert its own before importing stack-service fresh.
+    mock.module('@/lib/clients/database-client', () => ({
+      databaseConnectionManager: {
+        getClient: mock(() => Promise.resolve({ getPool: () => ({}) })),
+      },
+    }));
+    mock.module('@/lib/config/database-config', () => ({
+      loadDatabaseConfig: mock(() => ({})),
+    }));
+    mock.module('@/lib/database/repositories/deploy-repository', () => ({
+      DeployRepository: class {
+        getById = mockGetById;
+        rejectPending = mockRejectPending;
+        notifyStackChange = mockNotifyStackChange;
+      },
+    }));
+    mock.module('@/lib/database/repositories/host-repository', () => ({
+      HostRepository: class {
+        findByName = mockFindByName;
+      },
+    }));
+
+    testDir = mkdtempSync(join(getTestTmpDir(), 'resume-reject-deploy-'));
+    repoPath = join(testDir, 'test.git');
+    await initBareRepo(repoPath);
+    commitSha = await commitFiles(repoPath, () => ({
+      files: [{ path: composePath('plex'), content: 'services:\n  plex:\n    image: plex' }],
+      message: 'add plex compose',
+      author: { name: 'test', email: 'test@test.com' },
+    }));
+
+    loadGitConfigSpy = spyOn(gitConfig, 'loadGitConfig').mockReturnValue({
+      reposDir: testDir,
+      repoName: 'test',
+      repoPath,
+    });
+
+    pendingRecord = {
+      id: 42,
+      stack: 'plex',
+      host: 'homeserver',
+      commitSha,
+      composeHash: '',
+      envHash: '',
+      status: 'pending',
+      trigger: 'git_push',
+      action: 'deploy',
+      forceRecreate: false,
+      logs: null,
+      createdAt: new Date(),
+      postSuccess: null,
+    };
+
+    mockResumePending = mock(() => Promise.resolve({ status: 'succeeded' as const, logs: 'ok', deployId: 42 }));
+    createDeployPipelineSpy = spyOn(pipelineFactory, 'createDeployPipeline').mockResolvedValue({
+      pipeline: { resumePending: (id: number, host: unknown, req: unknown) => mockResumePending(id, host, req) } as unknown as DeployPipeline,
+      deployRepo: {} as never,
+      stackRepoWriter: {} as never,
+    });
+
+    mockGetById.mockClear();
+    mockFindByName.mockClear();
+    mockRejectPending.mockClear();
+    mockNotifyStackChange.mockClear();
+  });
+
+  afterEach(() => {
+    loadGitConfigSpy.mockRestore();
+    createDeployPipelineSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  test('resumePendingDeploy returns succeeded status without throwing', async () => {
+    const { resumePendingDeploy } = await import('@/lib/stacks/stack-service');
+    const result = await resumePendingDeploy(42);
+    expect(result).toEqual({ deployId: 42, status: 'succeeded', logs: 'ok' });
+  });
+
+  test('resumePendingDeploy returns failed status instead of throwing', async () => {
+    mockResumePending.mockImplementationOnce(() =>
+      Promise.resolve({ status: 'failed' as const, logs: 'agent down', deployId: 42 }),
+    );
+    const { resumePendingDeploy } = await import('@/lib/stacks/stack-service');
+    const result = await resumePendingDeploy(42);
+    expect(result).toEqual({ deployId: 42, status: 'failed', logs: 'agent down' });
+  });
+
+  test('rejectPendingDeploy passes a failed outcome with action/trigger/message to notifyStackChange', async () => {
+    const { rejectPendingDeploy } = await import('@/lib/stacks/stack-service');
+    const result = await rejectPendingDeploy(42);
+    expect(result).toEqual({ deployId: 42 });
+    expect(mockNotifyStackChange).toHaveBeenCalledWith('plex', 'homeserver', {
+      deployId: 42,
+      status: 'failed',
+      action: 'deploy',
+      trigger: 'git_push',
+      message: 'Manually rejected',
+    });
   });
 });

--- a/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
@@ -421,6 +421,50 @@ describe('StackStatusBroadcastService', () => {
     }
   });
 
+  it('drops an outcome with an invalid enum value but still forwards the frame', async () => {
+    const received: StackBroadcastEvent[] = [];
+    service.subscribe((e) => received.push(e));
+    await waitForCondition(() => received.length > 0);
+
+    poolClient.emit('notification', {
+      channel: 'deploy_change',
+      payload: JSON.stringify({
+        type: 'deploy_changed',
+        stack: 'media',
+        host: 'server1',
+        outcome: { deployId: 42, status: 'bogus', action: 'deploy', trigger: 'ui' },
+      }),
+    });
+
+    const deployEvent = received.find((e) => e.type === 'deploy_changed');
+    expect(deployEvent).toBeDefined();
+    if (deployEvent?.type === 'deploy_changed') {
+      expect(deployEvent.outcome).toBeUndefined();
+    }
+  });
+
+  it('drops an outcome with a non-positive deployId', async () => {
+    const received: StackBroadcastEvent[] = [];
+    service.subscribe((e) => received.push(e));
+    await waitForCondition(() => received.length > 0);
+
+    poolClient.emit('notification', {
+      channel: 'deploy_change',
+      payload: JSON.stringify({
+        type: 'deploy_changed',
+        stack: 'media',
+        host: 'server1',
+        outcome: { deployId: 0, status: 'succeeded', action: 'deploy', trigger: 'ui' },
+      }),
+    });
+
+    const deployEvent = received.find((e) => e.type === 'deploy_changed');
+    expect(deployEvent).toBeDefined();
+    if (deployEvent?.type === 'deploy_changed') {
+      expect(deployEvent.outcome).toBeUndefined();
+    }
+  });
+
   it('swallows malformed deploy_change payload without crashing', async () => {
     const consoleSpy = spyOn(console, 'error').mockImplementation(() => {});
 

--- a/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
@@ -361,12 +361,11 @@ describe('StackStatusBroadcastService', () => {
     if (deployEvent?.type === 'deploy_changed') {
       expect(deployEvent.stack).toBe('media');
       expect(deployEvent.host).toBe('server1');
-      expect(deployEvent.deployId).toBeUndefined();
-      expect(deployEvent.status).toBeUndefined();
+      expect(deployEvent.outcome).toBeUndefined();
     }
   });
 
-  it('forwards outcome fields from an enriched deploy_change NOTIFY', async () => {
+  it('forwards a nested outcome object from an enriched deploy_change NOTIFY', async () => {
     const received: StackBroadcastEvent[] = [];
     service.subscribe((e) => received.push(e));
     await waitForCondition(() => received.length > 0);
@@ -377,22 +376,48 @@ describe('StackStatusBroadcastService', () => {
         type: 'deploy_changed',
         stack: 'media',
         host: 'server1',
-        deployId: 42,
-        status: 'failed',
-        action: 'deploy',
-        trigger: 'git_push',
-        message: 'agent unreachable',
+        outcome: {
+          deployId: 42,
+          status: 'failed',
+          action: 'deploy',
+          trigger: 'git_push',
+          message: 'agent unreachable',
+        },
       }),
     });
 
     const deployEvent = received.find((e) => e.type === 'deploy_changed');
     expect(deployEvent).toBeDefined();
     if (deployEvent?.type === 'deploy_changed') {
-      expect(deployEvent.deployId).toBe(42);
-      expect(deployEvent.status).toBe('failed');
-      expect(deployEvent.action).toBe('deploy');
-      expect(deployEvent.trigger).toBe('git_push');
-      expect(deployEvent.message).toBe('agent unreachable');
+      expect(deployEvent.outcome).toEqual({
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: 'agent unreachable',
+      });
+    }
+  });
+
+  it('drops an outcome object missing a required field instead of forwarding it partially', async () => {
+    const received: StackBroadcastEvent[] = [];
+    service.subscribe((e) => received.push(e));
+    await waitForCondition(() => received.length > 0);
+
+    poolClient.emit('notification', {
+      channel: 'deploy_change',
+      payload: JSON.stringify({
+        type: 'deploy_changed',
+        stack: 'media',
+        host: 'server1',
+        outcome: { deployId: 42, status: 'failed', action: 'deploy' },
+      }),
+    });
+
+    const deployEvent = received.find((e) => e.type === 'deploy_changed');
+    expect(deployEvent).toBeDefined();
+    if (deployEvent?.type === 'deploy_changed') {
+      expect(deployEvent.outcome).toBeUndefined();
     }
   });
 

--- a/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
@@ -361,6 +361,38 @@ describe('StackStatusBroadcastService', () => {
     if (deployEvent?.type === 'deploy_changed') {
       expect(deployEvent.stack).toBe('media');
       expect(deployEvent.host).toBe('server1');
+      expect(deployEvent.deployId).toBeUndefined();
+      expect(deployEvent.status).toBeUndefined();
+    }
+  });
+
+  it('forwards outcome fields from an enriched deploy_change NOTIFY', async () => {
+    const received: StackBroadcastEvent[] = [];
+    service.subscribe((e) => received.push(e));
+    await waitForCondition(() => received.length > 0);
+
+    poolClient.emit('notification', {
+      channel: 'deploy_change',
+      payload: JSON.stringify({
+        type: 'deploy_changed',
+        stack: 'media',
+        host: 'server1',
+        deployId: 42,
+        status: 'failed',
+        action: 'deploy',
+        trigger: 'git_push',
+        message: 'agent unreachable',
+      }),
+    });
+
+    const deployEvent = received.find((e) => e.type === 'deploy_changed');
+    expect(deployEvent).toBeDefined();
+    if (deployEvent?.type === 'deploy_changed') {
+      expect(deployEvent.deployId).toBe(42);
+      expect(deployEvent.status).toBe('failed');
+      expect(deployEvent.action).toBe('deploy');
+      expect(deployEvent.trigger).toBe('git_push');
+      expect(deployEvent.message).toBe('agent unreachable');
     }
   });
 

--- a/src/lib/stacks/deploy-outcome-toast.ts
+++ b/src/lib/stacks/deploy-outcome-toast.ts
@@ -16,13 +16,7 @@ export interface DeployOutcomeToast {
 
 const MAX_MESSAGE_LENGTH = 200;
 
-/**
- * Take the first line of a raw message, strip control characters, and
- * truncate to 200 chars without splitting a UTF-16 surrogate pair. Mirrors
- * deploy-repository.ts's sanitizeDeployMessage so the SSE path (already
- * truncated server-side) and the mutation path (raw logs) render identical
- * copy regardless of which one wins the toast race.
- */
+/** Takes the first line, strips control characters, and truncates to 200 chars without splitting a UTF-16 surrogate pair. */
 export function truncateDeployMessage(message: string): string {
   const firstLine = message.split(/\r?\n/)[0] ?? '';
   const stripped = Array.from(firstLine)

--- a/src/lib/stacks/deploy-outcome-toast.ts
+++ b/src/lib/stacks/deploy-outcome-toast.ts
@@ -18,7 +18,7 @@ const MAX_MESSAGE_LENGTH = 200;
 
 /** Takes the first line, strips control characters, and truncates to 200 chars without splitting a UTF-16 surrogate pair. */
 export function truncateDeployMessage(message: string): string {
-  const firstLine = message.split(/\r?\n/)[0] ?? '';
+  const firstLine = message.split(/\r\n?|\n/)[0] ?? '';
   const stripped = Array.from(firstLine)
     .filter((ch) => {
       const code = ch.codePointAt(0) ?? 0;
@@ -70,6 +70,8 @@ export interface DeployToastGate {
   shouldToast(deployId: number): boolean;
   /** Alias for shouldToast, used at mutation onMutate time to pre-claim a deployId before the SSE outcome can arrive. */
   claim(deployId: number): boolean;
+  /** Undo a claim so a later SSE outcome can still toast; used when the mutation that pre-claimed fails client-side. */
+  release(deployId: number): void;
 }
 
 /** Factory for tests; production code uses the singleton `deployToastGate` below. */
@@ -80,7 +82,10 @@ export function createDeployToastGate(): DeployToastGate {
     seen.add(deployId);
     return true;
   }
-  return { shouldToast, claim: shouldToast };
+  function release(deployId: number): void {
+    seen.delete(deployId);
+  }
+  return { shouldToast, claim: shouldToast, release };
 }
 
 export const deployToastGate = createDeployToastGate();

--- a/src/lib/stacks/deploy-outcome-toast.ts
+++ b/src/lib/stacks/deploy-outcome-toast.ts
@@ -1,0 +1,92 @@
+import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
+import type { ToastSeverity } from '@/hooks/toastAtom';
+
+export interface DeployOutcomeEvent {
+  stack: string;
+  action: DeployAction;
+  status: DeployStatus;
+  trigger: DeployTrigger;
+  message?: string | null;
+}
+
+export interface DeployOutcomeToast {
+  message: string;
+  severity: ToastSeverity;
+}
+
+const MAX_MESSAGE_LENGTH = 200;
+
+/**
+ * Take the first line of a raw message, strip control characters, and
+ * truncate to 200 chars without splitting a UTF-16 surrogate pair. Mirrors
+ * deploy-repository.ts's sanitizeDeployMessage so the SSE path (already
+ * truncated server-side) and the mutation path (raw logs) render identical
+ * copy regardless of which one wins the toast race.
+ */
+export function truncateDeployMessage(message: string): string {
+  const firstLine = message.split(/\r?\n/)[0] ?? '';
+  const stripped = Array.from(firstLine)
+    .filter((ch) => {
+      const code = ch.codePointAt(0) ?? 0;
+      return code > 0x1f && code !== 0x7f;
+    })
+    .join('');
+  if (stripped.length <= MAX_MESSAGE_LENGTH) return stripped;
+  let end = MAX_MESSAGE_LENGTH;
+  const boundary = stripped.charCodeAt(end - 1);
+  if (boundary >= 0xd800 && boundary <= 0xdbff) end -= 1;
+  return stripped.slice(0, end);
+}
+
+function deployNoun(action: DeployAction, trigger: DeployTrigger): string {
+  if (action === 'teardown') return 'Teardown';
+  if (trigger === 'manual_rollback') return 'Rollback';
+  return 'Deploy';
+}
+
+function deploySuffix(action: DeployAction, trigger: DeployTrigger): string {
+  return action === 'deploy' && trigger === 'git_push' ? ' (git push)' : '';
+}
+
+/**
+ * Map a deploy outcome to toast copy. Returns null for non-terminal statuses
+ * ('pending', 'in_progress') and for 'no_change' outside a UI-triggered
+ * deploy (git-push/rollback no_change events are routine and would spam).
+ */
+export function formatDeployOutcome(evt: DeployOutcomeEvent): DeployOutcomeToast | null {
+  if (evt.status === 'pending' || evt.status === 'in_progress') return null;
+
+  if (evt.status === 'no_change') {
+    if (evt.trigger !== 'ui') return null;
+    return { message: `No changes detected for ${evt.stack}`, severity: 'info' };
+  }
+
+  const base = `${deployNoun(evt.action, evt.trigger)} of ${evt.stack}${deploySuffix(evt.action, evt.trigger)}`;
+
+  if (evt.status === 'succeeded') {
+    return { message: `${base} succeeded`, severity: 'success' };
+  }
+
+  const detail = evt.message ? `: ${truncateDeployMessage(evt.message)}` : '';
+  return { message: `${base} failed${detail}`, severity: 'error' };
+}
+
+export interface DeployToastGate {
+  /** Atomic test-and-set: true (and marks seen) the first time a deployId is passed, false on every later call. */
+  shouldToast(deployId: number): boolean;
+  /** Alias for shouldToast, used at mutation onMutate time to pre-claim a deployId before the SSE outcome can arrive. */
+  claim(deployId: number): boolean;
+}
+
+/** Factory for tests; production code uses the singleton `deployToastGate` below. */
+export function createDeployToastGate(): DeployToastGate {
+  const seen = new Set<number>();
+  function shouldToast(deployId: number): boolean {
+    if (seen.has(deployId)) return false;
+    seen.add(deployId);
+    return true;
+  }
+  return { shouldToast, claim: shouldToast };
+}
+
+export const deployToastGate = createDeployToastGate();

--- a/src/lib/stacks/stack-mappers.ts
+++ b/src/lib/stacks/stack-mappers.ts
@@ -5,7 +5,7 @@
  */
 
 import type { StackSummary, StackDetail, StackDeployRecord, SyncStatus } from '@/types/stacks';
-import type { DeployAction, DeployRecord, DeployRequest } from '@/lib/deploy/types';
+import type { DeployAction, DeployRecord, DeployRequest, DeployStatus } from '@/lib/deploy/types';
 import type { StackEntry } from '@/lib/git/manifest';
 
 /**
@@ -90,14 +90,14 @@ export interface DeployDeps {
   readCompose: (stack: string) => Promise<string>;
   getCommitSha: () => Promise<string>;
   buildRequest: (input: { stack: string; host: string; composeContent: string; commitSha: string; action: DeployAction; forceRecreate?: boolean }) => DeployRequest;
-  executePipeline: (request: DeployRequest) => Promise<{ deployId?: number; logs?: string }>;
+  executePipeline: (request: DeployRequest) => Promise<{ deployId?: number; logs: string; status: DeployStatus }>;
 }
 
 /** Testable deploy handler: takes deps instead of importing them. */
 export async function handleTriggerDeploy(
   deps: DeployDeps,
   params: { stack: string; host: string; action: DeployAction; forceRecreate?: boolean },
-): Promise<{ deployId: number }> {
+): Promise<{ deployId: number; status: DeployStatus; logs: string }> {
   let composeContent = '';
   try {
     composeContent = await deps.readCompose(params.stack);
@@ -122,5 +122,5 @@ export async function handleTriggerDeploy(
   if (result.deployId === undefined) {
     throw new Error(`Deploy could not be queued: ${result.logs}`);
   }
-  return { deployId: result.deployId };
+  return { deployId: result.deployId, status: result.status, logs: result.logs };
 }

--- a/src/lib/stacks/stack-service.ts
+++ b/src/lib/stacks/stack-service.ts
@@ -4,7 +4,7 @@
  */
 
 import type { StackSummary, StackDetail, StackDeployRecord } from '@/types/stacks';
-import type { DeployAction, DeployRecord, DeployRequest } from '@/lib/deploy/types';
+import type { DeployAction, DeployRecord, DeployRequest, DeployStatus } from '@/lib/deploy/types';
 import type { AgentClient, StackControlRequest } from '@/lib/clients/agent-client';
 import { loadGitConfig } from '@/lib/config/git-config';
 import { readFileFromRepo, commitFiles, FileNotFoundError } from '@/lib/git/repo';
@@ -117,7 +117,7 @@ export async function triggerStackDeploy(params: {
   commitSha?: string;
   forceRecreate?: boolean;
   postSuccess?: 'removeFromManifest';
-}): Promise<{ deployId: number }> {
+}): Promise<{ deployId: number; status: DeployStatus; logs: string }> {
   const repoPath = getRepoPath();
 
   const { default: git } = await import('isomorphic-git');
@@ -174,7 +174,7 @@ export async function triggerStackDeploy(params: {
  * Rebuilds the `DeployRequest` from the stored deploy record, reading the compose
  * file at the record's commitSha so the exact configuration that was pending is what gets deployed.
  */
-export async function resumePendingDeploy(deployId: number): Promise<{ deployId: number }> {
+export async function resumePendingDeploy(deployId: number): Promise<{ deployId: number; status: DeployStatus; logs: string }> {
   const { databaseConnectionManager } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
   const { DeployRepository } = await import('@/lib/database/repositories/deploy-repository');
@@ -204,12 +204,9 @@ export async function resumePendingDeploy(deployId: number): Promise<{ deployId:
   const { pipeline } = await createDeployPipeline();
   const result = await pipeline.resumePending(deployId, host, request);
   // resumePending returns failed (instead of throwing) when claimPending loses a
-  // race or the dispatch fails. Surface either case to the caller so the UI
-  // shows an error toast instead of a misleading "Deploy approved" success.
-  if (result.status === 'failed') {
-    throw new Error(result.logs);
-  }
-  return { deployId: result.deployId ?? deployId };
+  // race or the dispatch fails. The caller toasts the outcome from the returned
+  // status rather than treating every non-throw as success.
+  return { deployId: result.deployId ?? deployId, status: result.status, logs: result.logs };
 }
 
 /**
@@ -238,7 +235,13 @@ export async function rejectPendingDeploy(deployId: number): Promise<{ deployId:
     throw new Error(`Deploy ${deployId} is no longer pending (approved or rejected by another client)`);
   }
   try {
-    await deployRepo.notifyStackChange(deploy.stack, deploy.host);
+    await deployRepo.notifyStackChange(deploy.stack, deploy.host, {
+      deployId,
+      status: 'failed',
+      action: deploy.action,
+      trigger: deploy.trigger,
+      message: 'Manually rejected',
+    });
   } catch (err) {
     console.error(`Failed to notify stack change after rejecting deploy ${deployId}:`, err);
   }

--- a/src/lib/stacks/stack-status-broadcast-service.ts
+++ b/src/lib/stacks/stack-status-broadcast-service.ts
@@ -2,6 +2,7 @@ import type { PoolClient } from 'pg';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
 import type { StackContainer, StackStatusEntry } from '@/types/stacks';
 import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
+import type { DeployChangeOutcome } from '@/lib/database/repositories/deploy-repository';
 import type {
   DockerContainerEventRow,
   DockerContainerEventUpsertRow,
@@ -12,16 +13,7 @@ import { backoffDelayMs } from '@/lib/utils/backoff';
 /** Discriminated union for events sent to SSE subscribers. */
 export type StackBroadcastEvent =
   | { type: 'status'; entries: StackStatusEntry[] }
-  | {
-      type: 'deploy_changed';
-      stack: string;
-      host: string;
-      deployId?: number;
-      status?: DeployStatus;
-      action?: DeployAction;
-      trigger?: DeployTrigger;
-      message?: string;
-    };
+  | { type: 'deploy_changed'; stack: string; host: string; outcome?: DeployChangeOutcome };
 
 type StackBroadcastCallback = (event: StackBroadcastEvent) => void;
 
@@ -61,6 +53,22 @@ function toStackEntry(host: string, stack: string, containers: DockerInventorySn
  */
 function stackKey(host: string, composeProject: string): string {
   return `${host}/${composeProject}`;
+}
+
+/** A partial outcome (missing a required field) is not forwarded rather than sent half-populated. */
+function parseDeployChangeOutcome(raw: unknown): DeployChangeOutcome | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+  const o = raw as Record<string, unknown>;
+  if (typeof o.deployId !== 'number' || typeof o.status !== 'string' || typeof o.action !== 'string' || typeof o.trigger !== 'string') {
+    return undefined;
+  }
+  return {
+    deployId: o.deployId,
+    status: o.status as DeployStatus,
+    action: o.action as DeployAction,
+    trigger: o.trigger as DeployTrigger,
+    ...(typeof o.message === 'string' ? { message: o.message } : {}),
+  };
 }
 
 async function defaultGetPoolClient(): Promise<PoolClient> {
@@ -392,15 +400,12 @@ export class StackStatusBroadcastService {
       if (typeof stack !== 'string' || typeof host !== 'string') {
         throw new Error('Invalid deploy_change payload: missing stack or host');
       }
+      const outcome = parseDeployChangeOutcome(parsed.outcome);
       const event: StackBroadcastEvent = {
         type: 'deploy_changed',
         stack,
         host,
-        ...(typeof parsed.deployId === 'number' ? { deployId: parsed.deployId } : {}),
-        ...(typeof parsed.status === 'string' ? { status: parsed.status as DeployStatus } : {}),
-        ...(typeof parsed.action === 'string' ? { action: parsed.action as DeployAction } : {}),
-        ...(typeof parsed.trigger === 'string' ? { trigger: parsed.trigger as DeployTrigger } : {}),
-        ...(typeof parsed.message === 'string' ? { message: parsed.message } : {}),
+        ...(outcome ? { outcome } : {}),
       };
       for (const cb of this.subscribers) {
         try {

--- a/src/lib/stacks/stack-status-broadcast-service.ts
+++ b/src/lib/stacks/stack-status-broadcast-service.ts
@@ -1,8 +1,7 @@
 import type { PoolClient } from 'pg';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
 import type { StackContainer, StackStatusEntry } from '@/types/stacks';
-import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
-import type { DeployChangeOutcome } from '@/lib/database/repositories/deploy-repository';
+import { zDeployChangeOutcome, type DeployChangeOutcome } from '@/lib/deploy/types';
 import type {
   DockerContainerEventRow,
   DockerContainerEventUpsertRow,
@@ -55,20 +54,10 @@ function stackKey(host: string, composeProject: string): string {
   return `${host}/${composeProject}`;
 }
 
-/** A partial outcome (missing a required field) is not forwarded rather than sent half-populated. */
+/** A malformed or partial outcome is dropped rather than forwarded half-populated. */
 function parseDeployChangeOutcome(raw: unknown): DeployChangeOutcome | undefined {
-  if (typeof raw !== 'object' || raw === null) return undefined;
-  const o = raw as Record<string, unknown>;
-  if (typeof o.deployId !== 'number' || typeof o.status !== 'string' || typeof o.action !== 'string' || typeof o.trigger !== 'string') {
-    return undefined;
-  }
-  return {
-    deployId: o.deployId,
-    status: o.status as DeployStatus,
-    action: o.action as DeployAction,
-    trigger: o.trigger as DeployTrigger,
-    ...(typeof o.message === 'string' ? { message: o.message } : {}),
-  };
+  const parsed = zDeployChangeOutcome.safeParse(raw);
+  return parsed.success ? parsed.data : undefined;
 }
 
 async function defaultGetPoolClient(): Promise<PoolClient> {

--- a/src/lib/stacks/stack-status-broadcast-service.ts
+++ b/src/lib/stacks/stack-status-broadcast-service.ts
@@ -1,6 +1,7 @@
 import type { PoolClient } from 'pg';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
 import type { StackContainer, StackStatusEntry } from '@/types/stacks';
+import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
 import type {
   DockerContainerEventRow,
   DockerContainerEventUpsertRow,
@@ -11,7 +12,16 @@ import { backoffDelayMs } from '@/lib/utils/backoff';
 /** Discriminated union for events sent to SSE subscribers. */
 export type StackBroadcastEvent =
   | { type: 'status'; entries: StackStatusEntry[] }
-  | { type: 'deploy_changed'; stack: string; host: string };
+  | {
+      type: 'deploy_changed';
+      stack: string;
+      host: string;
+      deployId?: number;
+      status?: DeployStatus;
+      action?: DeployAction;
+      trigger?: DeployTrigger;
+      message?: string;
+    };
 
 type StackBroadcastCallback = (event: StackBroadcastEvent) => void;
 
@@ -382,9 +392,19 @@ export class StackStatusBroadcastService {
       if (typeof stack !== 'string' || typeof host !== 'string') {
         throw new Error('Invalid deploy_change payload: missing stack or host');
       }
+      const event: StackBroadcastEvent = {
+        type: 'deploy_changed',
+        stack,
+        host,
+        ...(typeof parsed.deployId === 'number' ? { deployId: parsed.deployId } : {}),
+        ...(typeof parsed.status === 'string' ? { status: parsed.status as DeployStatus } : {}),
+        ...(typeof parsed.action === 'string' ? { action: parsed.action as DeployAction } : {}),
+        ...(typeof parsed.trigger === 'string' ? { trigger: parsed.trigger as DeployTrigger } : {}),
+        ...(typeof parsed.message === 'string' ? { message: parsed.message } : {}),
+      };
       for (const cb of this.subscribers) {
         try {
-          cb({ type: 'deploy_changed', stack, host });
+          cb(event);
         } catch (err) {
           console.error('[StackStatusBroadcastService] Subscriber callback failed:', err);
         }

--- a/src/routes/api/stack-status.ts
+++ b/src/routes/api/stack-status.ts
@@ -1,6 +1,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import { createBroadcastSseHandler } from '@/lib/sse/create-broadcast-sse-handler';
-import { stackStatusChannel } from '@/lib/sse/channels/stack-status';
+import { stackStatusChannel, serializeStackStatusEvent } from '@/lib/sse/channels/stack-status';
 import type { StackBroadcastEvent } from '@/lib/stacks/stack-status-broadcast-service';
 
 export const Route = createFileRoute('/api/stack-status')({
@@ -14,22 +14,7 @@ export const Route = createFileRoute('/api/stack-status')({
           );
           return (cb) => stackStatusBroadcastService.subscribe(cb);
         },
-        serialize: (event) => {
-          if (event.type === 'deploy_changed') {
-            const payload = {
-              type: 'deploy_changed',
-              stack: event.stack,
-              host: event.host,
-              ...(event.deployId !== undefined ? { deployId: event.deployId } : {}),
-              ...(event.status !== undefined ? { status: event.status } : {}),
-              ...(event.action !== undefined ? { action: event.action } : {}),
-              ...(event.trigger !== undefined ? { trigger: event.trigger } : {}),
-              ...(event.message !== undefined ? { message: event.message } : {}),
-            };
-            return `data: ${JSON.stringify(payload)}\n\n`;
-          }
-          return `data: ${JSON.stringify(event.entries)}\n\n`;
-        },
+        serialize: serializeStackStatusEvent,
         errorEvent: stackStatusChannel.errorEvent,
       }),
     },

--- a/src/routes/api/stack-status.ts
+++ b/src/routes/api/stack-status.ts
@@ -16,7 +16,16 @@ export const Route = createFileRoute('/api/stack-status')({
         },
         serialize: (event) => {
           if (event.type === 'deploy_changed') {
-            const payload = { type: 'deploy_changed', stack: event.stack, host: event.host };
+            const payload = {
+              type: 'deploy_changed',
+              stack: event.stack,
+              host: event.host,
+              ...(event.deployId !== undefined ? { deployId: event.deployId } : {}),
+              ...(event.status !== undefined ? { status: event.status } : {}),
+              ...(event.action !== undefined ? { action: event.action } : {}),
+              ...(event.trigger !== undefined ? { trigger: event.trigger } : {}),
+              ...(event.message !== undefined ? { message: event.message } : {}),
+            };
             return `data: ${JSON.stringify(payload)}\n\n`;
           }
           return `data: ${JSON.stringify(event.entries)}\n\n`;


### PR DESCRIPTION
## Why

The deploy server function awaits the entire pipeline, including the agent's `docker compose up`, and receives the final status and logs, then returns only `{ deployId }`. A deploy that dispatched and failed still resolved the mutation and toasted "deploy triggered successfully". Async paths (git push deploys, watchdog timeouts, delete-teardown, other tabs) produced no outcome signal at all; the user had to open deploy history to learn what happened.

## What

Two layers, deduplicated by a deployId-keyed gate:

**Real status from server functions.** `triggerDeploy`/`resumeDeploy` return `{ deployId, status, logs }`. `resumePendingDeploy` no longer throws on a failed dispatch; it returns the status for the caller to toast. The UI toasts the actual outcome ("Deploy of plex succeeded" / "Deploy of plex failed: <first line of logs>"), which works even with SSE disconnected.

**Enriched `deploy_change` NOTIFY.** The payload gains optional `deployId`/`status`/`action`/`trigger`/`message` (sanitized: first line, control chars stripped, surrogate-safe 200-char truncation), threaded through the broadcast service, the route's serialize whitelist, and the zod wire schema (all optional, so version skew is safe). `useStackStatus` toasts terminal outcomes while any stacks route is mounted. This covers git push deploys, watchdog-failed deploys, startup recovery, delete-teardown after navigation, and deploys from other sessions. Outcomes ride only on live NOTIFY forwards, never init snapshots, so page loads cannot replay old toasts.

**Dedup and races.** A singleton atomic test-and-set gate keyed by deployId ensures one toast regardless of which source lands first. Approve/reject claim the gate in `onMutate` (their deployId is the mutation argument), so their local toast deterministically beats the SSE echo; without that, rejecting a deploy could show an error-styled "Deploy failed: Manually rejected" toast. Both paths share one formatter with identical truncation so copy never differs by race winner. Suppressed: `pending`, `in_progress`, and `no_change` from non-UI triggers.

Delete-with-teardown now shows a neutral "Teardown started" info toast (the client navigates away; the outcome arrives via SSE on the stacks list). Also fixed the stale doc comment claiming `deleteStack` "returns immediately" (it awaits the teardown server-side).

## Tests

New formatter matrix + gate semantics suite; updates across deploy-repository (payload shape, sanitization, RETURNING columns), pipeline (outcome per branch), watchdog, startup recovery, broadcast service, SSE schema, stack-service/mappers, functions, useStackStatus (toast-once, duplicate-suppressed, legacy-payload-no-toast, init-never-toasts), StackEditorForm, and DeployHistoryList/Row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq

---
_Generated by [Claude Code](https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Deployment, approval, and rollback notifications now show outcome-specific success or failure messages.
  * Failure notifications include helpful, sanitized details when available.
  * Live deployment updates now include structured outcome information and avoid duplicate notifications.

* **Bug Fixes**
  * Improved reporting for failed deployments, approvals, rollbacks, recoveries, and timed-out operations.
  * Removed duplicate teardown notifications when completion is reported through live updates.
  * Pending deployment resumes now surface their actual result instead of hiding failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->