### PR TITLE
feat(docker): show container ports and mounts in the detail panel

### DIFF
--- a/migrations/026_container_events_ports_mounts.sql
+++ b/migrations/026_container_events_ports_mounts.sql
@@ -1,0 +1,72 @@
+ALTER TABLE docker_container_events
+  ADD COLUMN IF NOT EXISTS ports JSONB NOT NULL DEFAULT '[]'::jsonb,
+  ADD COLUMN IF NOT EXISTS mounts JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE OR REPLACE FUNCTION notify_docker_container_event() RETURNS trigger AS $$
+DECLARE
+  payload TEXT;
+BEGIN
+  -- labels/mounts excluded from NOTIFY payload: PG NOTIFY has an 8 kB cap and both are
+  -- unbounded; consumers re-fetch them from the init snapshot when needed.
+  payload := json_build_object(
+    'at', NEW.at,
+    'host', NEW.host,
+    'container_id', NEW.container_id,
+    'event_type', NEW.event_type,
+    'state', NEW.state,
+    'name', NEW.name,
+    'image', NEW.image,
+    'compose_project', NEW.compose_project,
+    'service_key', NEW.service_key,
+    'started_at', NEW.started_at,
+    'finished_at', NEW.finished_at,
+    'exit_code', NEW.exit_code,
+    'ports', NEW.ports
+  )::text;
+
+  -- ports is bounded in practice but not by schema; guard against a pathological
+  -- container blowing the 8 kB pg_notify cap (a failing pg_notify aborts the INSERT).
+  IF octet_length(payload) > 7500 THEN
+    payload := json_build_object(
+      'at', NEW.at,
+      'host', NEW.host,
+      'container_id', NEW.container_id,
+      'event_type', NEW.event_type,
+      'state', NEW.state,
+      'name', NEW.name,
+      'image', NEW.image,
+      'compose_project', NEW.compose_project,
+      'service_key', NEW.service_key,
+      'started_at', NEW.started_at,
+      'finished_at', NEW.finished_at,
+      'exit_code', NEW.exit_code,
+      'ports', '[]'::json
+    )::text;
+  END IF;
+
+  PERFORM pg_notify('docker_container_change', payload);
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Rollback:
+-- CREATE OR REPLACE FUNCTION notify_docker_container_event() RETURNS trigger AS $$
+-- BEGIN
+--   PERFORM pg_notify('docker_container_change', json_build_object(
+--     'at', NEW.at,
+--     'host', NEW.host,
+--     'container_id', NEW.container_id,
+--     'event_type', NEW.event_type,
+--     'state', NEW.state,
+--     'name', NEW.name,
+--     'image', NEW.image,
+--     'compose_project', NEW.compose_project,
+--     'service_key', NEW.service_key,
+--     'started_at', NEW.started_at,
+--     'finished_at', NEW.finished_at,
+--     'exit_code', NEW.exit_code
+--   )::text);
+--   RETURN NEW;
+-- END;
+-- $$ LANGUAGE plpgsql;
+-- ALTER TABLE docker_container_events DROP COLUMN IF EXISTS ports, DROP COLUMN IF EXISTS mounts;

--- a/migrations/026_container_events_ports_mounts.sql
+++ b/migrations/026_container_events_ports_mounts.sql
@@ -26,6 +26,7 @@ BEGIN
 
   -- ports is bounded in practice but not by schema; guard against a pathological
   -- container blowing the 8 kB pg_notify cap (a failing pg_notify aborts the INSERT).
+  -- NULL (not []) keeps the fallback distinguishable from a real empty port list.
   IF octet_length(payload) > 7500 THEN
     payload := json_build_object(
       'at', NEW.at,
@@ -40,7 +41,7 @@ BEGIN
       'started_at', NEW.started_at,
       'finished_at', NEW.finished_at,
       'exit_code', NEW.exit_code,
-      'ports', '[]'::json
+      'ports', NULL
     )::text;
   END IF;
 

--- a/src/components/docker/ContainerDetailPanel.tsx
+++ b/src/components/docker/ContainerDetailPanel.tsx
@@ -8,6 +8,7 @@ import ContainerMetricsChart, { type MetricKey } from '@/components/docker/Conta
 import ContainerModal, { type ModalTab } from '@/components/docker/ContainerModal';
 import ContainerActionButtons from '@/components/docker/ContainerActionButtons';
 import IconPickerDialog from '@/components/docker/IconPickerDialog';
+import ContainerPortsMounts from '@/components/docker/ContainerPortsMounts';
 import { useToast } from '@/hooks/toastAtom';
 import type { ChartDataPoint } from '@/hooks/useContainerChartData';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
@@ -260,6 +261,8 @@ export default memo(function ContainerDetailPanel({
         onAction={openModal}
         onIconClick={() => setIconPickerOpen(true)}
       />
+
+      <ContainerPortsMounts ports={inventory.ports} mounts={inventory.mounts} />
 
       <div className="grid gap-3 p-3 [grid-template-rows:200px] lg:h-[232px] lg:grid-cols-2 lg:[grid-template-rows:none]">
         <ContainerMetricsChart

--- a/src/components/docker/ContainerDetailPanel.tsx
+++ b/src/components/docker/ContainerDetailPanel.tsx
@@ -262,7 +262,9 @@ export default memo(function ContainerDetailPanel({
         onIconClick={() => setIconPickerOpen(true)}
       />
 
-      <ContainerPortsMounts ports={inventory.ports} mounts={inventory.mounts} />
+      {(inventory.ports.length > 0 || inventory.mounts.length > 0) && (
+        <ContainerPortsMounts ports={inventory.ports} mounts={inventory.mounts} />
+      )}
 
       <div className="grid gap-3 p-3 [grid-template-rows:200px] lg:h-[232px] lg:grid-cols-2 lg:[grid-template-rows:none]">
         <ContainerMetricsChart

--- a/src/components/docker/ContainerPortsMounts.tsx
+++ b/src/components/docker/ContainerPortsMounts.tsx
@@ -45,8 +45,6 @@ interface ContainerPortsMountsProps {
 }
 
 export default function ContainerPortsMounts({ ports, mounts }: Readonly<ContainerPortsMountsProps>) {
-  if (ports.length === 0 && mounts.length === 0) return null;
-
   const dedupedPorts = dedupeWildcardPorts(ports);
 
   return (

--- a/src/components/docker/ContainerPortsMounts.tsx
+++ b/src/components/docker/ContainerPortsMounts.tsx
@@ -1,0 +1,105 @@
+import { Badge } from '@/components/ui/badge';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import type { ContainerPort, ContainerMount } from '@/types/docker-inventory';
+
+const WILDCARD_HOST_IPS = new Set(['0.0.0.0', '::']);
+const VOLUME_PATH_RE = /^\/var\/lib\/docker\/volumes\/([^/]+)\/_data$/;
+
+/** Collapses the same (containerPort, protocol, hostPort) published on both 0.0.0.0 and :: into one entry. */
+export function dedupeWildcardPorts(ports: ContainerPort[]): ContainerPort[] {
+  const seenWildcards = new Set<string>();
+  const result: ContainerPort[] = [];
+  for (const port of ports) {
+    const isWildcard = port.hostPort !== null && port.hostIp !== null && WILDCARD_HOST_IPS.has(port.hostIp);
+    if (isWildcard) {
+      const key = `${port.containerPort}/${port.protocol}/${port.hostPort}`;
+      if (seenWildcards.has(key)) continue;
+      seenWildcards.add(key);
+    }
+    result.push(port);
+  }
+  return result;
+}
+
+/** `docker ps`-style mapping text: drops the wildcard IP prefix, keeps specific bind IPs, shows unpublished ports without an arrow. */
+export function formatPortMapping(port: ContainerPort): string {
+  if (port.hostPort === null) {
+    return `${port.containerPort}/${port.protocol}`;
+  }
+  const showHostIp = port.hostIp !== null && !WILDCARD_HOST_IPS.has(port.hostIp);
+  const prefix = showHostIp ? `${port.hostIp}:` : '';
+  return `${prefix}${port.hostPort}->${port.containerPort}/${port.protocol}`;
+}
+
+/** Strips the `/var/lib/docker/volumes/<name>/_data` wrapper off a named-volume source, otherwise passes it through. */
+export function formatMountSource(source: string, type: string): { display: string; isVolume: boolean } {
+  const isVolume = type === 'volume';
+  if (!isVolume) return { display: source, isVolume };
+  const match = VOLUME_PATH_RE.exec(source);
+  return { display: match ? match[1] : source, isVolume };
+}
+
+interface ContainerPortsMountsProps {
+  ports: ContainerPort[];
+  mounts: ContainerMount[];
+}
+
+export default function ContainerPortsMounts({ ports, mounts }: Readonly<ContainerPortsMountsProps>) {
+  if (ports.length === 0 && mounts.length === 0) return null;
+
+  const dedupedPorts = dedupeWildcardPorts(ports);
+
+  return (
+    <div className="flex flex-col gap-2 px-3 py-2 border-b border-(--border)">
+      {dedupedPorts.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {dedupedPorts.map((port, idx) => {
+            const published = port.hostPort !== null;
+            return (
+              <span
+                key={`${port.containerPort}/${port.protocol}/${port.hostIp ?? ''}/${port.hostPort ?? ''}/${idx}`}
+                className={`font-mono text-xs px-1.5 py-0.5 rounded bg-(--chart-bg) ${published ? 'text-foreground' : 'text-(--muted-foreground)'}`}
+              >
+                {formatPortMapping(port)}
+              </span>
+            );
+          })}
+        </div>
+      )}
+
+      {mounts.length > 0 && (
+        <div className="flex flex-col gap-1">
+          {mounts.map((mount, idx) => (
+            <MountRow key={`${mount.destination}/${idx}`} mount={mount} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MountRow({ mount }: { mount: ContainerMount }) {
+  const { display, isVolume } = formatMountSource(mount.source, mount.type);
+  const fullMapping = `${mount.source} -> ${mount.destination}`;
+
+  const row = (
+    <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 min-w-0 text-xs">
+      <span className="truncate max-w-[45%] min-w-0 font-mono text-foreground">{display}</span>
+      {isVolume && <span className="shrink-0 text-(--muted-foreground)">(volume)</span>}
+      <span className="shrink-0 text-(--muted-foreground)">-&gt;</span>
+      <span className="truncate max-w-[45%] min-w-0 font-mono text-foreground">{mount.destination}</span>
+      {!mount.rw && (
+        <Badge variant="outline" className="h-4 rounded-sm px-1 text-[10px] border-(--warning) text-(--warning) shrink-0">
+          ro
+        </Badge>
+      )}
+    </div>
+  );
+
+  return (
+    <Tooltip>
+      <TooltipTrigger render={row} />
+      <TooltipContent side="top">{fullMapping}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/src/components/docker/__tests__/ContainerDetailPanel.test.tsx
+++ b/src/components/docker/__tests__/ContainerDetailPanel.test.tsx
@@ -61,6 +61,8 @@ const sampleInventory: DockerInventorySnapshotContainer = {
   finishedAt: null,
   exitCode: null,
   labels: {},
+  ports: [],
+  mounts: [],
   updatedAt: new Date('2024-01-01T00:00:00Z'),
 };
 
@@ -129,6 +131,25 @@ describe('ContainerDetailPanel', () => {
     screen.getByText('137');
     screen.getByText('Finished');
     screen.getByText('Exit');
+  });
+
+  it('does not render the ports/mounts strip when both are empty', () => {
+    renderPanel();
+    expect(screen.queryByText('->')).toBeNull();
+  });
+
+  it('renders port and mount details between the status strip and the charts', () => {
+    renderPanel({
+      inventory: {
+        ...sampleInventory,
+        ports: [{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: 8080 }],
+        mounts: [{ type: 'bind', source: '/srv/data', destination: '/data', rw: true }],
+      },
+    });
+
+    screen.getByText('8080->80/tcp');
+    screen.getByText('/srv/data');
+    screen.getByText('/data');
   });
 
 });

--- a/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
+++ b/src/components/docker/__tests__/ContainerLogsTerminalPanel.test.tsx
@@ -56,6 +56,8 @@ const runningInventory: DockerInventorySnapshotContainer = {
   finishedAt: null,
   exitCode: null,
   labels: {},
+  ports: [],
+  mounts: [],
   updatedAt: new Date(),
 };
 

--- a/src/components/docker/__tests__/ContainerModal.test.tsx
+++ b/src/components/docker/__tests__/ContainerModal.test.tsx
@@ -47,6 +47,8 @@ const sampleInventory: DockerInventorySnapshotContainer = {
   finishedAt: null,
   exitCode: null,
   labels: {},
+  ports: [],
+  mounts: [],
   updatedAt: new Date('2024-01-01T00:00:00Z'),
 };
 

--- a/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
+++ b/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
@@ -1,12 +1,23 @@
-import { describe, it, expect } from 'bun:test';
-import { render, screen, fireEvent } from '@testing-library/react';
-import ContainerPortsMounts, {
+import { describe, it, expect, mock } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import type { ReactElement, ReactNode } from 'react';
+import {
   dedupeWildcardPorts,
   formatPortMapping,
   formatMountSource,
 } from '../ContainerPortsMounts';
-import { TooltipProvider } from '@/components/ui/tooltip';
 import type { ContainerPort, ContainerMount } from '@/types/docker-inventory';
+
+// Tooltip open state is Base UI's own hover/delay machinery, not this component's
+// logic; mock it to render children unconditionally so tests assert on content, not
+// on simulating pointer hover through happy-dom.
+mock.module('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipTrigger: ({ render: el }: { render: ReactElement }) => el,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+const { default: ContainerPortsMounts } = await import('../ContainerPortsMounts');
 
 describe('formatPortMapping', () => {
   it('formats a published port with a wildcard bind IP without the IP prefix', () => {
@@ -107,8 +118,8 @@ describe('ContainerPortsMounts', () => {
     ];
     render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
 
-    expect(screen.getByText('/home/user/media')).not.toBeNull();
-    expect(screen.getByText('/media')).not.toBeNull();
+    expect(screen.getAllByText('/home/user/media').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('/media').length).toBeGreaterThan(0);
   });
 
   it('shows an ro badge for a read-only mount and hides it for a read-write mount', () => {
@@ -127,25 +138,16 @@ describe('ContainerPortsMounts', () => {
     ];
     render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
 
-    expect(screen.getByText('app-data')).not.toBeNull();
+    expect(screen.getAllByText('app-data').length).toBeGreaterThan(0);
     expect(screen.getByText('(volume)')).not.toBeNull();
   });
 
-  it('reveals the full source -> destination mapping in a tooltip on hover', async () => {
+  it('exposes the full source -> destination mapping as the tooltip content', () => {
     const mounts: ContainerMount[] = [
       { type: 'bind', source: '/very/long/path/to/some/data/directory', destination: '/data', rw: true },
     ];
-    render(
-      <TooltipProvider delay={0}>
-        <ContainerPortsMounts ports={[]} mounts={mounts} />
-      </TooltipProvider>,
-    );
+    render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
 
-    const trigger = screen.getByText('/data');
-    fireEvent.pointerEnter(trigger);
-    fireEvent.mouseEnter(trigger);
-
-    const tooltip = await screen.findByText('/very/long/path/to/some/data/directory -> /data');
-    expect(tooltip).not.toBeNull();
+    expect(screen.getByText('/very/long/path/to/some/data/directory -> /data')).not.toBeNull();
   });
 });

--- a/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
+++ b/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
@@ -8,9 +8,7 @@ import {
 } from '../ContainerPortsMounts';
 import type { ContainerPort, ContainerMount } from '@/types/docker-inventory';
 
-// Tooltip open state is Base UI's own hover/delay machinery, not this component's
-// logic; mock it to render children unconditionally so tests assert on content, not
-// on simulating pointer hover through happy-dom.
+// Mock so content renders unconditionally; simulating real hover through happy-dom to open a Base UI tooltip is unreliable.
 mock.module('@/components/ui/tooltip', () => ({
   Tooltip: ({ children }: { children: ReactNode }) => children,
   TooltipTrigger: ({ render: el }: { render: ReactElement }) => el,

--- a/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
+++ b/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
@@ -5,7 +5,7 @@ import {
   dedupeWildcardPorts,
   formatPortMapping,
   formatMountSource,
-} from '../ContainerPortsMounts';
+} from '@/components/docker/ContainerPortsMounts';
 import type { ContainerPort, ContainerMount } from '@/types/docker-inventory';
 
 // Mock so content renders unconditionally; simulating real hover through happy-dom to open a Base UI tooltip is unreliable.
@@ -15,7 +15,7 @@ mock.module('@/components/ui/tooltip', () => ({
   TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
-const { default: ContainerPortsMounts } = await import('../ContainerPortsMounts');
+const { default: ContainerPortsMounts } = await import('@/components/docker/ContainerPortsMounts');
 
 describe('formatPortMapping', () => {
   it('formats a published port with a wildcard bind IP without the IP prefix', () => {
@@ -92,11 +92,6 @@ describe('formatMountSource', () => {
 });
 
 describe('ContainerPortsMounts', () => {
-  it('renders nothing when both ports and mounts are empty', () => {
-    const { container } = render(<ContainerPortsMounts ports={[]} mounts={[]} />);
-    expect(container.firstChild).toBeNull();
-  });
-
   it('renders port chips, dimming unpublished ports', () => {
     const ports: ContainerPort[] = [
       { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 },

--- a/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
+++ b/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'bun:test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import ContainerPortsMounts, {
+  dedupeWildcardPorts,
+  formatPortMapping,
+  formatMountSource,
+} from '../ContainerPortsMounts';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { ContainerPort, ContainerMount } from '@/types/docker-inventory';
+
+describe('formatPortMapping', () => {
+  it('formats a published port with a wildcard bind IP without the IP prefix', () => {
+    const port: ContainerPort = { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 };
+    expect(formatPortMapping(port)).toBe('8080->80/tcp');
+  });
+
+  it('formats a published port with no bind IP without a prefix', () => {
+    const port: ContainerPort = { containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: 8080 };
+    expect(formatPortMapping(port)).toBe('8080->80/tcp');
+  });
+
+  it('keeps a specific bind IP prefix', () => {
+    const port: ContainerPort = { containerPort: 5432, protocol: 'tcp', hostIp: '127.0.0.1', hostPort: 5432 };
+    expect(formatPortMapping(port)).toBe('127.0.0.1:5432->5432/tcp');
+  });
+
+  it('formats an unpublished exposed port without an arrow', () => {
+    const port: ContainerPort = { containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: null };
+    expect(formatPortMapping(port)).toBe('80/tcp');
+  });
+});
+
+describe('dedupeWildcardPorts', () => {
+  it('collapses the same port published on both 0.0.0.0 and :: into one entry', () => {
+    const ports: ContainerPort[] = [
+      { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 },
+      { containerPort: 80, protocol: 'tcp', hostIp: '::', hostPort: 8080 },
+    ];
+    expect(dedupeWildcardPorts(ports)).toHaveLength(1);
+  });
+
+  it('keeps a single IPv4-only wildcard port unchanged', () => {
+    const ports: ContainerPort[] = [
+      { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 },
+    ];
+    expect(dedupeWildcardPorts(ports)).toHaveLength(1);
+    expect(dedupeWildcardPorts(ports)[0]).toEqual(ports[0]);
+  });
+
+  it('keeps distinct ports and specific bind IPs untouched', () => {
+    const ports: ContainerPort[] = [
+      { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 },
+      { containerPort: 443, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8443 },
+      { containerPort: 5432, protocol: 'tcp', hostIp: '127.0.0.1', hostPort: 5432 },
+    ];
+    expect(dedupeWildcardPorts(ports)).toHaveLength(3);
+  });
+
+  it('does not collapse unpublished exposed ports', () => {
+    const ports: ContainerPort[] = [
+      { containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: null },
+      { containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: null },
+    ];
+    expect(dedupeWildcardPorts(ports)).toHaveLength(2);
+  });
+});
+
+describe('formatMountSource', () => {
+  it('extracts the volume name from the standard docker volume path', () => {
+    const result = formatMountSource('/var/lib/docker/volumes/plex-config/_data', 'volume');
+    expect(result).toEqual({ display: 'plex-config', isVolume: true });
+  });
+
+  it('passes through a non-standard volume source unchanged', () => {
+    const result = formatMountSource('some-external-driver-source', 'volume');
+    expect(result).toEqual({ display: 'some-external-driver-source', isVolume: true });
+  });
+
+  it('passes through a bind mount source unchanged', () => {
+    const result = formatMountSource('/home/user/media', 'bind');
+    expect(result).toEqual({ display: '/home/user/media', isVolume: false });
+  });
+});
+
+describe('ContainerPortsMounts', () => {
+  it('renders nothing when both ports and mounts are empty', () => {
+    const { container } = render(<ContainerPortsMounts ports={[]} mounts={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders port chips, dimming unpublished ports', () => {
+    const ports: ContainerPort[] = [
+      { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8080 },
+      { containerPort: 9000, protocol: 'tcp', hostIp: null, hostPort: null },
+    ];
+    render(<ContainerPortsMounts ports={ports} mounts={[]} />);
+
+    const published = screen.getByText('8080->80/tcp');
+    const unpublished = screen.getByText('9000/tcp');
+    expect(published.className).not.toContain('muted-foreground');
+    expect(unpublished.className).toContain('muted-foreground');
+  });
+
+  it('renders a mount row with source, arrow, and destination', () => {
+    const mounts: ContainerMount[] = [
+      { type: 'bind', source: '/home/user/media', destination: '/media', rw: true },
+    ];
+    render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
+
+    expect(screen.getByText('/home/user/media')).not.toBeNull();
+    expect(screen.getByText('/media')).not.toBeNull();
+  });
+
+  it('shows an ro badge for a read-only mount and hides it for a read-write mount', () => {
+    const mounts: ContainerMount[] = [
+      { type: 'bind', source: '/a', destination: '/a-dest', rw: false },
+      { type: 'bind', source: '/b', destination: '/b-dest', rw: true },
+    ];
+    render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
+
+    expect(screen.getAllByText('ro')).toHaveLength(1);
+  });
+
+  it('shows the volume name with a muted "(volume)" suffix for volume mounts', () => {
+    const mounts: ContainerMount[] = [
+      { type: 'volume', source: '/var/lib/docker/volumes/app-data/_data', destination: '/data', rw: true },
+    ];
+    render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
+
+    expect(screen.getByText('app-data')).not.toBeNull();
+    expect(screen.getByText('(volume)')).not.toBeNull();
+  });
+
+  it('reveals the full source -> destination mapping in a tooltip on hover', async () => {
+    const mounts: ContainerMount[] = [
+      { type: 'bind', source: '/very/long/path/to/some/data/directory', destination: '/data', rw: true },
+    ];
+    render(
+      <TooltipProvider delay={0}>
+        <ContainerPortsMounts ports={[]} mounts={mounts} />
+      </TooltipProvider>,
+    );
+
+    const trigger = screen.getByText('/data');
+    fireEvent.pointerEnter(trigger);
+    fireEvent.mouseEnter(trigger);
+
+    const tooltip = await screen.findByText('/very/long/path/to/some/data/directory -> /data');
+    expect(tooltip).not.toBeNull();
+  });
+});

--- a/src/components/docker/__tests__/ContainerTable.test.tsx
+++ b/src/components/docker/__tests__/ContainerTable.test.tsx
@@ -106,6 +106,8 @@ function makeInventory(
     finishedAt: null,
     exitCode: null,
     labels: {},
+    ports: [],
+    mounts: [],
     updatedAt: baseDate,
   };
 }

--- a/src/components/docker/__tests__/DockerStatusSummary.test.tsx
+++ b/src/components/docker/__tests__/DockerStatusSummary.test.tsx
@@ -14,6 +14,8 @@ function makeContainer(overrides: Partial<DockerInventorySnapshotContainer> & { 
     finishedAt: null,
     exitCode: null,
     labels: {},
+    ports: [],
+    mounts: [],
     updatedAt: new Date(),
     ...overrides,
   };

--- a/src/hooks/__tests__/useDockerInventory.test.ts
+++ b/src/hooks/__tests__/useDockerInventory.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { renderHook, act } from '@testing-library/react';
 import { MockEventSource } from '@/lib/test/mock-event-source';
-import { useDockerInventory } from '../useDockerInventory';
-import type { DockerInventoryBroadcastEvent } from '@/types/docker-inventory';
+import { useDockerInventory, mergeUpsert } from '../useDockerInventory';
+import type {
+  DockerInventoryBroadcastEvent,
+  DockerInventorySnapshotContainer,
+  DockerInventoryUpdateContainer,
+} from '@/types/docker-inventory';
 
 const originalEventSource = globalThis.EventSource;
 
@@ -64,6 +68,8 @@ describe('useDockerInventory', () => {
             finishedAt: null,
             exitCode: null,
             labels: { 'com.docker.compose.project': 'media' },
+            ports: [{ containerPort: 32400, protocol: 'tcp', hostIp: null, hostPort: 32400 }],
+            mounts: [{ type: 'volume', source: 'plex-config', destination: '/config', rw: true }],
             updatedAt: new Date('2026-04-16T10:00:00Z'),
           },
         ],
@@ -96,6 +102,8 @@ describe('useDockerInventory', () => {
             finishedAt: new Date('2026-04-16T11:00:00Z'),
             exitCode: 0,
             labels: {},
+            ports: [],
+            mounts: [],
             updatedAt: new Date('2026-04-16T11:00:00Z'),
           },
         ],
@@ -130,6 +138,7 @@ describe('useDockerInventory', () => {
           startedAt: new Date('2026-04-16T10:00:00Z'),
           finishedAt: null,
           exitCode: null,
+          ports: [],
           updatedAt: new Date('2026-04-16T10:00:00Z'),
         },
       });
@@ -162,6 +171,8 @@ describe('useDockerInventory', () => {
             finishedAt: null,
             exitCode: null,
             labels: {},
+            ports: [],
+            mounts: [],
             updatedAt: new Date(),
           },
         ],
@@ -184,6 +195,8 @@ describe('useDockerInventory', () => {
             finishedAt: null,
             exitCode: null,
             labels: {},
+            ports: [],
+            mounts: [],
             updatedAt: new Date(),
           },
         ],
@@ -218,6 +231,7 @@ describe('useDockerInventory', () => {
           startedAt: null,
           finishedAt: null,
           exitCode: null,
+          ports: [],
           updatedAt: new Date(),
         },
       });
@@ -250,6 +264,8 @@ describe('useDockerInventory', () => {
             finishedAt: null,
             exitCode: null,
             labels: {},
+            ports: [],
+            mounts: [],
             updatedAt: new Date('2026-04-16T10:00:00Z'),
           },
         ],
@@ -270,6 +286,7 @@ describe('useDockerInventory', () => {
           startedAt: null,
           finishedAt: new Date('2026-04-16T11:00:00Z'),
           exitCode: 0,
+          ports: [],
           updatedAt,
         },
       });
@@ -302,6 +319,8 @@ describe('useDockerInventory', () => {
             finishedAt: null,
             exitCode: null,
             labels: {},
+            ports: [],
+            mounts: [],
             updatedAt: new Date(),
           },
         ],
@@ -404,6 +423,8 @@ describe('useDockerInventory', () => {
             finishedAt: null,
             exitCode: null,
             labels: {},
+            ports: [],
+            mounts: [],
             updatedAt: new Date(),
           },
           {
@@ -418,6 +439,8 @@ describe('useDockerInventory', () => {
             finishedAt: null,
             exitCode: null,
             labels: {},
+            ports: [],
+            mounts: [],
             updatedAt: new Date(),
           },
         ],
@@ -441,5 +464,177 @@ describe('useDockerInventory', () => {
     act(() => { sendEvent(es, { type: 'init', containers: [] }); });
 
     expect(result.current.error).toBeNull();
+  });
+
+  it('preserves the previous entry mounts on upsert', () => {
+    const { result } = renderHook(() => useDockerInventory());
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.onopen?.();
+      sendEvent(es, {
+        type: 'init',
+        containers: [
+          {
+            host: 'server1',
+            containerId: 'abc123',
+            name: 'plex',
+            image: 'img',
+            state: 'running',
+            composeProject: null,
+            serviceKey: '',
+            startedAt: null,
+            finishedAt: null,
+            exitCode: null,
+            labels: {},
+            ports: [],
+            mounts: [{ type: 'volume', source: 'plex-config', destination: '/config', rw: true }],
+            updatedAt: new Date(),
+          },
+        ],
+      });
+    });
+
+    act(() => {
+      sendEvent(es, {
+        type: 'upsert',
+        container: {
+          host: 'server1',
+          containerId: 'abc123',
+          name: 'plex',
+          image: 'img',
+          state: 'exited',
+          composeProject: null,
+          serviceKey: '',
+          startedAt: null,
+          finishedAt: null,
+          exitCode: 0,
+          ports: [],
+          updatedAt: new Date(),
+        },
+      });
+    });
+
+    const entry = result.current.inventory.get('server1/abc123');
+    expect(entry?.mounts).toEqual([{ type: 'volume', source: 'plex-config', destination: '/config', rw: true }]);
+  });
+
+  it('takes ports from the upsert payload rather than the previous entry', () => {
+    const { result } = renderHook(() => useDockerInventory());
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.onopen?.();
+      sendEvent(es, {
+        type: 'init',
+        containers: [
+          {
+            host: 'server1',
+            containerId: 'abc123',
+            name: 'plex',
+            image: 'img',
+            state: 'running',
+            composeProject: null,
+            serviceKey: '',
+            startedAt: null,
+            finishedAt: null,
+            exitCode: null,
+            labels: {},
+            ports: [{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: 8080 }],
+            mounts: [],
+            updatedAt: new Date(),
+          },
+        ],
+      });
+    });
+
+    act(() => {
+      sendEvent(es, {
+        type: 'upsert',
+        container: {
+          host: 'server1',
+          containerId: 'abc123',
+          name: 'plex',
+          image: 'img',
+          state: 'running',
+          composeProject: null,
+          serviceKey: '',
+          startedAt: null,
+          finishedAt: null,
+          exitCode: null,
+          ports: [{ containerPort: 443, protocol: 'tcp', hostIp: null, hostPort: 8443 }],
+          updatedAt: new Date(),
+        },
+      });
+    });
+
+    const entry = result.current.inventory.get('server1/abc123');
+    expect(entry?.ports).toEqual([{ containerPort: 443, protocol: 'tcp', hostIp: null, hostPort: 8443 }]);
+  });
+});
+
+describe('mergeUpsert', () => {
+  const baseUpdate: DockerInventoryUpdateContainer = {
+    host: 'server1',
+    containerId: 'abc123',
+    name: 'plex',
+    image: 'img',
+    state: 'running',
+    composeProject: null,
+    serviceKey: '',
+    startedAt: null,
+    finishedAt: null,
+    exitCode: null,
+    ports: [{ containerPort: 443, protocol: 'tcp', hostIp: null, hostPort: 8443 }],
+    updatedAt: new Date(),
+  };
+
+  const basePrev: DockerInventorySnapshotContainer = {
+    host: 'server1',
+    containerId: 'abc123',
+    name: 'plex',
+    image: 'img',
+    state: 'running',
+    composeProject: null,
+    serviceKey: '',
+    startedAt: null,
+    finishedAt: null,
+    exitCode: null,
+    labels: { app: 'plex' },
+    ports: [{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: 8080 }],
+    mounts: [{ type: 'volume', source: 'plex-config', destination: '/config', rw: true }],
+    updatedAt: new Date(),
+  };
+
+  it('preserves the previous entry labels and mounts', () => {
+    const merged = mergeUpsert(basePrev, baseUpdate);
+    expect(merged.labels).toEqual(basePrev.labels);
+    expect(merged.mounts).toEqual(basePrev.mounts);
+  });
+
+  it('takes ports from the upsert payload rather than the previous entry', () => {
+    const merged = mergeUpsert(basePrev, baseUpdate);
+    expect(merged.ports).toEqual(baseUpdate.ports);
+  });
+
+  it('falls back to the previous entry ports when the payload field is absent (version skew)', () => {
+    const { ports: _ports, ...updateWithoutPorts } = baseUpdate;
+    void _ports;
+    const merged = mergeUpsert(basePrev, updateWithoutPorts as unknown as DockerInventoryUpdateContainer);
+    expect(merged.ports).toEqual(basePrev.ports);
+  });
+
+  it('defaults labels, ports, and mounts to empty for a container not yet seen', () => {
+    const merged = mergeUpsert(undefined, baseUpdate);
+    expect(merged.labels).toEqual({});
+    expect(merged.mounts).toEqual([]);
+    expect(merged.ports).toEqual(baseUpdate.ports);
+  });
+
+  it('defaults ports to empty when both the payload and the previous entry omit them', () => {
+    const { ports: _ports, ...updateWithoutPorts } = baseUpdate;
+    void _ports;
+    const merged = mergeUpsert(undefined, updateWithoutPorts as unknown as DockerInventoryUpdateContainer);
+    expect(merged.ports).toEqual([]);
   });
 });

--- a/src/hooks/__tests__/useDockerInventory.test.ts
+++ b/src/hooks/__tests__/useDockerInventory.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { renderHook, act } from '@testing-library/react';
 import { MockEventSource } from '@/lib/test/mock-event-source';
 import { useDockerInventory, mergeUpsert } from '../useDockerInventory';
+import { dockerInventoryChannel } from '@/lib/sse/channels/docker-inventory';
 import type {
   DockerInventoryBroadcastEvent,
   DockerInventorySnapshotContainer,
@@ -571,24 +572,63 @@ describe('useDockerInventory', () => {
     const entry = result.current.inventory.get('server1/abc123');
     expect(entry?.ports).toEqual([{ containerPort: 443, protocol: 'tcp', hostIp: null, hostPort: 8443 }]);
   });
+
+  it('preserves init-known ports across an upsert whose payload had ports dropped by the size guard', () => {
+    const { result } = renderHook(() => useDockerInventory());
+    const es = MockEventSource.instances[0];
+    const initialPorts = [{ containerPort: 32400, protocol: 'tcp', hostIp: null, hostPort: 32400 }];
+
+    act(() => {
+      es.onopen?.();
+      sendEvent(es, {
+        type: 'init',
+        containers: [
+          {
+            host: 'server1',
+            containerId: 'abc123',
+            name: 'plex',
+            image: 'img',
+            state: 'running',
+            composeProject: null,
+            serviceKey: '',
+            startedAt: null,
+            finishedAt: null,
+            exitCode: null,
+            labels: {},
+            ports: initialPorts,
+            mounts: [],
+            updatedAt: new Date(),
+          },
+        ],
+      });
+    });
+
+    act(() => {
+      sendEvent(es, {
+        type: 'upsert',
+        container: {
+          host: 'server1',
+          containerId: 'abc123',
+          name: 'plex',
+          image: 'img',
+          state: 'exited',
+          composeProject: null,
+          serviceKey: '',
+          startedAt: null,
+          finishedAt: null,
+          exitCode: 137,
+          updatedAt: new Date(),
+        },
+      });
+    });
+
+    const entry = result.current.inventory.get('server1/abc123');
+    expect(entry?.state).toBe('exited');
+    expect(entry?.ports).toEqual(initialPorts);
+  });
 });
 
 describe('mergeUpsert', () => {
-  const baseUpdate: DockerInventoryUpdateContainer = {
-    host: 'server1',
-    containerId: 'abc123',
-    name: 'plex',
-    image: 'img',
-    state: 'running',
-    composeProject: null,
-    serviceKey: '',
-    startedAt: null,
-    finishedAt: null,
-    exitCode: null,
-    ports: [{ containerPort: 443, protocol: 'tcp', hostIp: null, hostPort: 8443 }],
-    updatedAt: new Date(),
-  };
-
   const basePrev: DockerInventorySnapshotContainer = {
     host: 'server1',
     containerId: 'abc123',
@@ -606,35 +646,63 @@ describe('mergeUpsert', () => {
     updatedAt: new Date(),
   };
 
+  /** Parses a raw wire payload (as the server would send it) into a DockerInventoryUpdateContainer, so an omitted `ports` key exercises the real .optional() schema instead of a manual cast. */
+  function parseUpdateContainer(overrides: Record<string, unknown> = {}): DockerInventoryUpdateContainer {
+    const parsed = dockerInventoryChannel.schema.parse({
+      type: 'upsert',
+      container: {
+        host: 'server1',
+        containerId: 'abc123',
+        name: 'plex',
+        image: 'img',
+        state: 'running',
+        composeProject: null,
+        serviceKey: '',
+        startedAt: null,
+        finishedAt: null,
+        exitCode: null,
+        updatedAt: new Date().toISOString(),
+        ...overrides,
+      },
+    });
+    const revived = dockerInventoryChannel.revive!(parsed);
+    if (revived.type !== 'upsert') throw new Error('expected upsert');
+    return revived.container;
+  }
+
+  const newPorts = [{ containerPort: 443, protocol: 'tcp', hostIp: null, hostPort: 8443 }];
+
   it('preserves the previous entry labels and mounts', () => {
-    const merged = mergeUpsert(basePrev, baseUpdate);
+    const update = parseUpdateContainer({ ports: newPorts });
+    const merged = mergeUpsert(basePrev, update);
     expect(merged.labels).toEqual(basePrev.labels);
     expect(merged.mounts).toEqual(basePrev.mounts);
   });
 
   it('takes ports from the upsert payload rather than the previous entry', () => {
-    const merged = mergeUpsert(basePrev, baseUpdate);
-    expect(merged.ports).toEqual(baseUpdate.ports);
+    const update = parseUpdateContainer({ ports: newPorts });
+    const merged = mergeUpsert(basePrev, update);
+    expect(merged.ports).toEqual(newPorts);
   });
 
-  it('falls back to the previous entry ports when the payload field is absent (version skew)', () => {
-    const { ports: _ports, ...updateWithoutPorts } = baseUpdate;
-    void _ports;
-    const merged = mergeUpsert(basePrev, updateWithoutPorts as unknown as DockerInventoryUpdateContainer);
+  it('falls back to the previous entry ports when the wire payload omits the field', () => {
+    const update = parseUpdateContainer();
+    expect('ports' in update).toBe(false);
+    const merged = mergeUpsert(basePrev, update);
     expect(merged.ports).toEqual(basePrev.ports);
   });
 
   it('defaults labels, ports, and mounts to empty for a container not yet seen', () => {
-    const merged = mergeUpsert(undefined, baseUpdate);
+    const update = parseUpdateContainer({ ports: newPorts });
+    const merged = mergeUpsert(undefined, update);
     expect(merged.labels).toEqual({});
     expect(merged.mounts).toEqual([]);
-    expect(merged.ports).toEqual(baseUpdate.ports);
+    expect(merged.ports).toEqual(newPorts);
   });
 
   it('defaults ports to empty when both the payload and the previous entry omit them', () => {
-    const { ports: _ports, ...updateWithoutPorts } = baseUpdate;
-    void _ports;
-    const merged = mergeUpsert(undefined, updateWithoutPorts as unknown as DockerInventoryUpdateContainer);
+    const update = parseUpdateContainer();
+    const merged = mergeUpsert(undefined, update);
     expect(merged.ports).toEqual([]);
   });
 });

--- a/src/hooks/useDockerInventory.ts
+++ b/src/hooks/useDockerInventory.ts
@@ -13,12 +13,21 @@ export interface UseDockerInventoryResult {
   error: Error | null;
 }
 
-/** Upsert frames omit labels; preserve the existing entry's labels, or empty for a container not yet seen. */
-function mergeUpsert(
+/**
+ * Upsert frames omit labels and mounts; preserve the existing entry's values, or empty for a
+ * container not yet seen. Ports are carried on the upsert frame itself, falling back to the
+ * previous entry's ports only for version skew against an older server build.
+ */
+export function mergeUpsert(
   prev: DockerInventorySnapshotContainer | undefined,
   update: DockerInventoryUpdateContainer,
 ): DockerInventorySnapshotContainer {
-  return { ...update, labels: prev?.labels ?? {} };
+  return {
+    ...update,
+    labels: prev?.labels ?? {},
+    ports: update.ports ?? prev?.ports ?? [],
+    mounts: prev?.mounts ?? [],
+  };
 }
 
 export function useDockerInventory(): UseDockerInventoryResult {

--- a/src/hooks/useDockerInventory.ts
+++ b/src/hooks/useDockerInventory.ts
@@ -15,8 +15,9 @@ export interface UseDockerInventoryResult {
 
 /**
  * Upsert frames omit labels and mounts; preserve the existing entry's values, or empty for a
- * container not yet seen. Ports are carried on the upsert frame itself, falling back to the
- * previous entry's ports only for version skew against an older server build.
+ * container not yet seen. Ports are carried on the upsert frame itself, but the field is
+ * absent (not []) when the trigger dropped it for an oversized payload or an older server
+ * omitted it, so falling back to the previous entry's ports avoids clobbering real data.
  */
 export function mergeUpsert(
   prev: DockerInventorySnapshotContainer | undefined,

--- a/src/lib/database/repositories/__tests__/docker-container-event-repository.test.ts
+++ b/src/lib/database/repositories/__tests__/docker-container-event-repository.test.ts
@@ -12,6 +12,8 @@ const baseEvent: NewContainerEvent = {
   name: 'plex',
   image: 'plexinc/pms-docker:latest',
   labels: { 'com.docker.compose.project': 'media', 'com.docker.compose.service': 'plex' },
+  ports: [{ containerPort: 32400, protocol: 'tcp', hostIp: null, hostPort: 32400 }],
+  mounts: [{ type: 'volume', source: 'plex-config', destination: '/config', rw: true }],
   serviceKey: 'media/plex',
   startedAt: new Date('2026-04-16T09:50:00Z'),
   finishedAt: null,
@@ -27,6 +29,8 @@ const dbRow = {
   name: 'plex',
   image: 'plexinc/pms-docker:latest',
   labels: { 'com.docker.compose.project': 'media', 'com.docker.compose.service': 'plex' },
+  ports: [{ containerPort: 32400, protocol: 'tcp', hostIp: null, hostPort: 32400 }],
+  mounts: [{ type: 'volume', source: 'plex-config', destination: '/config', rw: true }],
   compose_project: 'media',
   service_key: 'media/plex',
   started_at: new Date('2026-04-16T09:50:00Z'),
@@ -61,6 +65,8 @@ describe('DockerContainerEventRepository', () => {
         'plex',
         'plexinc/pms-docker:latest',
         JSON.stringify(baseEvent.labels),
+        JSON.stringify(baseEvent.ports),
+        JSON.stringify(baseEvent.mounts),
         'media/plex',
         baseEvent.startedAt,
         null,
@@ -77,6 +83,8 @@ describe('DockerContainerEventRepository', () => {
       expect(result.startedAt).toEqual(new Date('2026-04-16T09:50:00Z'));
       expect(result.finishedAt).toBeNull();
       expect(result.exitCode).toBeNull();
+      expect(result.ports).toEqual(baseEvent.ports);
+      expect(result.mounts).toEqual(baseEvent.mounts);
     });
 
     it('inserts a destroy event with null fields', async () => {
@@ -104,7 +112,7 @@ describe('DockerContainerEventRepository', () => {
         containerId: 'abc123',
         eventType: 'destroy',
       };
-      mock.pushResult([{ ...dbRow, event_type: 'destroy', state: null, name: null, image: null, labels: {}, compose_project: null, service_key: null, started_at: null }]);
+      mock.pushResult([{ ...dbRow, event_type: 'destroy', state: null, name: null, image: null, labels: {}, ports: [], mounts: [], compose_project: null, service_key: null, started_at: null }]);
 
       await repo.insert(destroyEvent);
 
@@ -112,10 +120,12 @@ describe('DockerContainerEventRepository', () => {
       expect(params[4]).toBeNull();  // state
       expect(params[5]).toBeNull();  // name
       expect(params[6]).toBeNull();  // image
-      expect(params[8]).toBeNull();  // service_key
-      expect(params[9]).toBeNull();  // started_at
-      expect(params[10]).toBeNull(); // finished_at
-      expect(params[11]).toBeNull(); // exit_code
+      expect(params[8]).toBe('[]');  // ports
+      expect(params[9]).toBe('[]');  // mounts
+      expect(params[10]).toBeNull(); // service_key
+      expect(params[11]).toBeNull(); // started_at
+      expect(params[12]).toBeNull(); // finished_at
+      expect(params[13]).toBeNull(); // exit_code
     });
 
     it('stores labels as JSON string parameter', async () => {
@@ -213,6 +223,24 @@ describe('DockerContainerEventRepository', () => {
       const row = rows[0];
       if (row.eventType !== 'upsert') throw new Error('expected upsert row');
       expect(row.exitCode).toBe(1);
+    });
+
+    it('defaults null ports and mounts to empty arrays', async () => {
+      mock.pushResult([{ ...dbRow, ports: null, mounts: null }]);
+      const rows = await repo.getCurrentSnapshot();
+      const row = rows[0];
+      if (row.eventType !== 'upsert') throw new Error('expected upsert row');
+      expect(row.ports).toEqual([]);
+      expect(row.mounts).toEqual([]);
+    });
+
+    it('passes through ports and mounts from the row', async () => {
+      mock.pushResult([dbRow]);
+      const rows = await repo.getCurrentSnapshot();
+      const row = rows[0];
+      if (row.eventType !== 'upsert') throw new Error('expected upsert row');
+      expect(row.ports).toEqual(dbRow.ports);
+      expect(row.mounts).toEqual(dbRow.mounts);
     });
   });
 });

--- a/src/lib/database/repositories/docker-container-event-repository.ts
+++ b/src/lib/database/repositories/docker-container-event-repository.ts
@@ -1,5 +1,5 @@
 import type { Pool } from 'pg';
-import type { ContainerState } from '@/types/docker-inventory';
+import type { ContainerState, ContainerPort, ContainerMount } from '@/types/docker-inventory';
 
 export type NewContainerEvent =
   | {
@@ -11,6 +11,8 @@ export type NewContainerEvent =
       name: string;
       image: string;
       labels: Record<string, string>;
+      ports: ContainerPort[];
+      mounts: ContainerMount[];
       serviceKey: string | null;
       startedAt: Date | null;
       finishedAt: Date | null;
@@ -32,6 +34,8 @@ export interface DockerContainerEventUpsertRow {
   name: string;
   image: string;
   labels: Record<string, string>;
+  ports: ContainerPort[];
+  mounts: ContainerMount[];
   composeProject: string | null;
   serviceKey: string | null;
   startedAt: Date | null;
@@ -67,6 +71,8 @@ function rowToEventRow(row: Record<string, unknown>): DockerContainerEventRow {
     name: row.name as string,
     image: row.image as string,
     labels: (row.labels as Record<string, string>) ?? {},
+    ports: (row.ports as ContainerPort[]) ?? [],
+    mounts: (row.mounts as ContainerMount[]) ?? [],
     composeProject: (row.compose_project as string | null) ?? null,
     serviceKey: (row.service_key as string | null) ?? null,
     startedAt: (row.started_at as Date | null) ?? null,
@@ -83,11 +89,11 @@ export class DockerContainerEventRepository {
     const isUpsert = event.eventType === 'upsert';
     const { rows } = await this.pool.query(
       `INSERT INTO docker_container_events
-         (at, host, container_id, event_type, state, name, image, labels, service_key,
-          started_at, finished_at, exit_code)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+         (at, host, container_id, event_type, state, name, image, labels, ports, mounts,
+          service_key, started_at, finished_at, exit_code)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
        RETURNING
-         at, host, container_id, event_type, state, name, image, labels,
+         at, host, container_id, event_type, state, name, image, labels, ports, mounts,
          compose_project, service_key, started_at, finished_at, exit_code`,
       [
         event.at,
@@ -98,6 +104,8 @@ export class DockerContainerEventRepository {
         isUpsert ? event.name : null,
         isUpsert ? event.image : null,
         JSON.stringify(isUpsert ? event.labels : {}),
+        JSON.stringify(isUpsert ? event.ports : []),
+        JSON.stringify(isUpsert ? event.mounts : []),
         isUpsert ? event.serviceKey : null,
         isUpsert ? event.startedAt : null,
         isUpsert ? event.finishedAt : null,
@@ -111,7 +119,7 @@ export class DockerContainerEventRepository {
   async getCurrentSnapshot(): Promise<DockerContainerEventRow[]> {
     const { rows } = await this.pool.query(
       `SELECT DISTINCT ON (host, container_id)
-         at, host, container_id, event_type, state, name, image, labels,
+         at, host, container_id, event_type, state, name, image, labels, ports, mounts,
          compose_project, service_key, started_at, finished_at, exit_code
        FROM docker_container_events
        ORDER BY host, container_id, at DESC`,

--- a/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
+++ b/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
@@ -60,6 +60,8 @@ const container1: DockerInventorySnapshotContainer = {
   finishedAt: null,
   exitCode: null,
   labels: { 'com.docker.compose.project': 'media' },
+  ports: [{ containerPort: 32400, protocol: 'tcp', hostIp: null, hostPort: 32400 }],
+  mounts: [{ type: 'volume', source: 'plex-config', destination: '/config', rw: true }],
   updatedAt: new Date('2026-04-16T10:00:00Z'),
 };
 
@@ -75,6 +77,8 @@ const container2: DockerInventorySnapshotContainer = {
   finishedAt: new Date('2026-04-16T09:00:00Z'),
   exitCode: 1,
   labels: {},
+  ports: [],
+  mounts: [],
   updatedAt: new Date('2026-04-16T09:00:00Z'),
 };
 
@@ -454,6 +458,8 @@ describe('rowToInventory', () => {
     name: 'plex',
     image: 'plexinc/pms-docker:latest',
     labels: { 'com.docker.compose.project': 'media' },
+    ports: [{ containerPort: 32400, protocol: 'tcp', hostIp: null, hostPort: 32400 }],
+    mounts: [{ type: 'volume', source: 'plex-config', destination: '/config', rw: true }],
     composeProject: 'media',
     serviceKey: 'media/plex',
     startedAt: new Date('2026-04-16T09:50:00Z'),
@@ -479,6 +485,8 @@ describe('rowToInventory', () => {
     expect(result.finishedAt).toBeNull();
     expect(result.exitCode).toBeNull();
     expect(result.labels).toEqual({ 'com.docker.compose.project': 'media' });
+    expect(result.ports).toEqual(baseRow.ports);
+    expect(result.mounts).toEqual(baseRow.mounts);
     expect(result.updatedAt).toEqual(new Date('2026-04-16T10:00:00Z'));
   });
 
@@ -492,6 +500,14 @@ describe('rowToInventory', () => {
       asUpsert({ ...baseRow, labels: null as unknown as Record<string, string> }),
     );
     expect(result.labels).toEqual({});
+  });
+
+  it('defaults null ports and mounts to empty arrays', () => {
+    const result = rowToInventory(
+      asUpsert({ ...baseRow, ports: null as unknown as typeof baseRow.ports, mounts: null as unknown as typeof baseRow.mounts }),
+    );
+    expect(result.ports).toEqual([]);
+    expect(result.mounts).toEqual([]);
   });
 });
 
@@ -509,6 +525,7 @@ describe('notifyPayloadToInventory', () => {
     started_at: '2026-04-16T10:00:00Z',
     finished_at: null,
     exit_code: null,
+    ports: [{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: 8080 }],
   };
 
   it('maps all fields from a NOTIFY payload', () => {
@@ -524,6 +541,23 @@ describe('notifyPayloadToInventory', () => {
     expect(result.exitCode).toBeNull();
     expect(result.labels).toEqual({});
     expect(result.updatedAt).toEqual(new Date('2026-04-16T11:00:00Z'));
+  });
+
+  it('maps ports when present in the payload', () => {
+    const result = notifyPayloadToInventory(basePayload);
+    expect(result.ports).toEqual(basePayload.ports);
+  });
+
+  it('defaults ports to an empty array when absent from the payload', () => {
+    const { ports: _ports, ...withoutPorts } = basePayload;
+    void _ports;
+    const result = notifyPayloadToInventory(withoutPorts);
+    expect(result.ports).toEqual([]);
+  });
+
+  it('always returns empty mounts (NOTIFY payloads never carry mounts)', () => {
+    const result = notifyPayloadToInventory(basePayload);
+    expect(result.mounts).toEqual([]);
   });
 
   it('defaults null nullable fields to empty values', () => {

--- a/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
+++ b/src/lib/docker/__tests__/docker-inventory-broadcast-service.test.ts
@@ -543,16 +543,21 @@ describe('notifyPayloadToInventory', () => {
     expect(result.updatedAt).toEqual(new Date('2026-04-16T11:00:00Z'));
   });
 
-  it('maps ports when present in the payload', () => {
+  it('maps a single-entry ports array to that entry', () => {
     const result = notifyPayloadToInventory(basePayload);
     expect(result.ports).toEqual(basePayload.ports);
   });
 
-  it('defaults ports to an empty array when absent from the payload', () => {
+  it('leaves ports undefined (not []) when the field is absent from the payload', () => {
     const { ports: _ports, ...withoutPorts } = basePayload;
     void _ports;
     const result = notifyPayloadToInventory(withoutPorts);
-    expect(result.ports).toEqual([]);
+    expect(result.ports).toBeUndefined();
+  });
+
+  it('leaves ports undefined (not []) when the payload carries ports: null (oversized-payload guard)', () => {
+    const result = notifyPayloadToInventory({ ...basePayload, ports: null });
+    expect(result.ports).toBeUndefined();
   });
 
   it('always returns empty mounts (NOTIFY payloads never carry mounts)', () => {

--- a/src/lib/docker/docker-inventory-broadcast-service.ts
+++ b/src/lib/docker/docker-inventory-broadcast-service.ts
@@ -22,6 +22,8 @@ export function rowToInventory(row: DockerContainerEventUpsertRow): DockerInvent
     finishedAt: row.finishedAt,
     exitCode: row.exitCode,
     labels: row.labels ?? {},
+    ports: row.ports ?? [],
+    mounts: row.mounts ?? [],
     updatedAt: row.at,
   };
 }
@@ -61,6 +63,8 @@ export function notifyPayloadToInventory(payload: Record<string, unknown>): Dock
     finishedAt: payload.finished_at ? new Date(payload.finished_at as string) : null,
     exitCode: (payload.exit_code as number | null) ?? null,
     labels: {},
+    ports: (payload.ports as DockerInventorySnapshotContainer['ports'] | undefined) ?? [],
+    mounts: [],
     updatedAt: new Date(at),
   };
 }

--- a/src/lib/docker/docker-inventory-broadcast-service.ts
+++ b/src/lib/docker/docker-inventory-broadcast-service.ts
@@ -51,6 +51,12 @@ export function notifyPayloadToInventory(payload: Record<string, unknown>): Dock
     throw new Error(`[DockerInventoryBroadcastService] NOTIFY payload missing required field 'at': ${JSON.stringify(payload)}`);
   }
 
+  // The trigger sends 'ports', NULL when it dropped ports for the size guard; that must stay
+  // absent (not []) so the client's mergeUpsert falls back to the previously known ports.
+  const ports = Array.isArray(payload.ports)
+    ? (payload.ports as DockerInventorySnapshotContainer['ports'])
+    : undefined;
+
   return {
     host,
     containerId,
@@ -63,7 +69,7 @@ export function notifyPayloadToInventory(payload: Record<string, unknown>): Dock
     finishedAt: payload.finished_at ? new Date(payload.finished_at as string) : null,
     exitCode: (payload.exit_code as number | null) ?? null,
     labels: {},
-    ports: (payload.ports as DockerInventorySnapshotContainer['ports'] | undefined) ?? [],
+    ports: ports as DockerInventorySnapshotContainer['ports'],
     mounts: [],
     updatedAt: new Date(at),
   };

--- a/src/lib/mock/generators/__tests__/docker.test.ts
+++ b/src/lib/mock/generators/__tests__/docker.test.ts
@@ -146,6 +146,31 @@ describe('generateDockerInventorySnapshot', () => {
       expect(c.startedAt!.getTime()).toBeLessThan(now.getTime());
     }
   });
+
+  it('gives every container an array for ports and mounts', () => {
+    const containers = generateDockerInventorySnapshot(now);
+    for (const c of containers) {
+      expect(Array.isArray(c.ports)).toBe(true);
+      expect(Array.isArray(c.mounts)).toBe(true);
+    }
+  });
+
+  it('gives known demo containers plausible, non-empty ports and mounts', () => {
+    const containers = generateDockerInventorySnapshot(now);
+    const plex = containers.find((c) => c.name === 'plex')!;
+    expect(plex.ports.length).toBeGreaterThan(0);
+    expect(plex.mounts.length).toBeGreaterThan(0);
+    expect(plex.ports[0]).toEqual({ containerPort: 32400, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 32400 });
+  });
+
+  it('parses successfully against the wire schema for every demo container', async () => {
+    const { zDockerInventorySnapshotContainer } = await import('@/types/docker-inventory');
+    const containers = generateDockerInventorySnapshot(now);
+    for (const c of containers) {
+      const result = zDockerInventorySnapshotContainer.safeParse(c);
+      expect(result.success).toBe(true);
+    }
+  });
 });
 
 describe('generateDockerHistory', () => {

--- a/src/lib/mock/generators/__tests__/docker.test.ts
+++ b/src/lib/mock/generators/__tests__/docker.test.ts
@@ -157,7 +157,7 @@ describe('generateDockerInventorySnapshot', () => {
 
   it('gives known demo containers plausible, non-empty ports and mounts', () => {
     const containers = generateDockerInventorySnapshot(now);
-    const plex = containers.find((c) => c.name === 'plex')!;
+    const plex = containers.find((c) => `${c.host}/${c.containerId}` === '192.168.1.10/b2c3d4e5f6a7')!;
     expect(plex.ports.length).toBeGreaterThan(0);
     expect(plex.mounts.length).toBeGreaterThan(0);
     expect(plex.ports[0]).toEqual({ containerPort: 32400, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 32400 });

--- a/src/lib/mock/generators/__tests__/docker.test.ts
+++ b/src/lib/mock/generators/__tests__/docker.test.ts
@@ -163,7 +163,7 @@ describe('generateDockerInventorySnapshot', () => {
     expect(plex.ports[0]).toEqual({ containerPort: 32400, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 32400 });
   });
 
-  it('parses successfully against the wire schema for every demo container', async () => {
+  it('parses successfully against the canonical schema for every demo container', async () => {
     const { zDockerInventorySnapshotContainer } = await import('@/types/docker-inventory');
     const containers = generateDockerInventorySnapshot(now);
     for (const c of containers) {

--- a/src/lib/mock/generators/docker.ts
+++ b/src/lib/mock/generators/docker.ts
@@ -1,8 +1,75 @@
 import type { DockerStatsRow } from '@/types/docker';
-import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
+import type { ContainerPort, ContainerMount, DockerInventorySnapshotContainer } from '@/types/docker-inventory';
 import { generateSimplexMetric, spike } from '@/lib/mock/patterns';
 import { DOCKER_ENTITIES, type DockerEntityDef } from '@/lib/mock/entities';
 import { mulberry32, hashCode } from '@/lib/mock/prng';
+
+/** Plausible ports/mounts per demo container, keyed by containerName, so the demo build exercises the ports/mounts UI. */
+const DEMO_PORTS_MOUNTS: Record<string, { ports: ContainerPort[]; mounts: ContainerMount[] }> = {
+  'nginx-proxy': {
+    ports: [
+      { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 80 },
+      { containerPort: 443, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 443 },
+    ],
+    mounts: [
+      { type: 'bind', source: '/opt/nginx/conf.d', destination: '/etc/nginx/conf.d', rw: false },
+      { type: 'volume', source: '/var/lib/docker/volumes/nginx-cache/_data', destination: '/var/cache/nginx', rw: true },
+    ],
+  },
+  plex: {
+    ports: [{ containerPort: 32400, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 32400 }],
+    mounts: [
+      { type: 'volume', source: '/var/lib/docker/volumes/plex-config/_data', destination: '/config', rw: true },
+      { type: 'bind', source: '/mnt/media', destination: '/media', rw: false },
+    ],
+  },
+  homeassistant: {
+    ports: [{ containerPort: 8123, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8123 }],
+    mounts: [{ type: 'volume', source: '/var/lib/docker/volumes/ha-config/_data', destination: '/config', rw: true }],
+  },
+  postgres: {
+    ports: [{ containerPort: 5432, protocol: 'tcp', hostIp: '127.0.0.1', hostPort: 5432 }],
+    mounts: [{ type: 'volume', source: '/var/lib/docker/volumes/postgres-data/_data', destination: '/var/lib/postgresql/data', rw: true }],
+  },
+  grafana: {
+    ports: [{ containerPort: 3000, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 3000 }],
+    mounts: [{ type: 'volume', source: '/var/lib/docker/volumes/grafana-data/_data', destination: '/var/lib/grafana', rw: true }],
+  },
+  traefik: {
+    ports: [
+      { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 80 },
+      { containerPort: 443, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 443 },
+      { containerPort: 8080, protocol: 'tcp', hostIp: null, hostPort: null },
+    ],
+    mounts: [{ type: 'bind', source: '/opt/traefik/traefik.yml', destination: '/etc/traefik/traefik.yml', rw: false }],
+  },
+  jellyfin: {
+    ports: [{ containerPort: 8096, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8096 }],
+    mounts: [
+      { type: 'volume', source: '/var/lib/docker/volumes/jellyfin-config/_data', destination: '/config', rw: true },
+      { type: 'bind', source: '/mnt/media', destination: '/media', rw: false },
+    ],
+  },
+  vaultwarden: {
+    ports: [{ containerPort: 80, protocol: 'tcp', hostIp: '127.0.0.1', hostPort: 8080 }],
+    mounts: [{ type: 'volume', source: '/var/lib/docker/volumes/vaultwarden-data/_data', destination: '/data', rw: true }],
+  },
+  pihole: {
+    ports: [
+      { containerPort: 53, protocol: 'udp', hostIp: '0.0.0.0', hostPort: 53 },
+      { containerPort: 80, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 8081 },
+    ],
+    mounts: [{ type: 'volume', source: '/var/lib/docker/volumes/pihole-config/_data', destination: '/etc/pihole', rw: true }],
+  },
+  portainer: {
+    ports: [{ containerPort: 9000, protocol: 'tcp', hostIp: '0.0.0.0', hostPort: 9000 }],
+    mounts: [{ type: 'volume', source: '/var/lib/docker/volumes/portainer-data/_data', destination: '/data', rw: true }],
+  },
+};
+
+function getDemoPortsAndMounts(containerName: string): { ports: ContainerPort[]; mounts: ContainerMount[] } {
+  return DEMO_PORTS_MOUNTS[containerName] ?? { ports: [], mounts: [] };
+}
 
 type DemoContainerState = DockerInventorySnapshotContainer['state'];
 
@@ -90,6 +157,7 @@ export function generateDockerInventorySnapshot(now: Date): DockerInventorySnaps
       finishedAt,
       exitCode: state === 'exited' ? DEMO_EXITED_EXIT_CODE : null,
       labels: {},
+      ...getDemoPortsAndMounts(e.containerName),
       updatedAt: startedAt,
     };
   });

--- a/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-status-broadcast-service.test.ts
@@ -60,6 +60,8 @@ const composeContainer1: DockerInventorySnapshotContainer = {
   finishedAt: null,
   exitCode: null,
   labels: { 'com.docker.compose.project': 'media' },
+  ports: [],
+  mounts: [],
   updatedAt: new Date('2026-04-16T10:00:00Z'),
 };
 
@@ -75,6 +77,8 @@ const composeContainer2: DockerInventorySnapshotContainer = {
   finishedAt: null,
   exitCode: null,
   labels: { 'com.docker.compose.project': 'media' },
+  ports: [],
+  mounts: [],
   updatedAt: new Date('2026-04-16T10:01:00Z'),
 };
 
@@ -91,6 +95,8 @@ const nonComposeContainer: DockerInventorySnapshotContainer = {
   finishedAt: null,
   exitCode: null,
   labels: {},
+  ports: [],
+  mounts: [],
   updatedAt: new Date('2026-04-16T09:00:00Z'),
 };
 
@@ -106,6 +112,8 @@ const otherStackContainer: DockerInventorySnapshotContainer = {
   finishedAt: null,
   exitCode: null,
   labels: { 'com.docker.compose.project': 'proxy' },
+  ports: [],
+  mounts: [],
   updatedAt: new Date('2026-04-16T08:00:00Z'),
 };
 
@@ -692,6 +700,8 @@ describe('StackStatusBroadcastService', () => {
       finishedAt: null,
       exitCode: null,
       labels: { 'com.docker.compose.project': 'media' },
+      ports: [],
+      mounts: [],
       updatedAt: new Date('2026-04-16T10:00:00Z'),
     };
     const containerY: DockerInventorySnapshotContainer = {
@@ -706,6 +716,8 @@ describe('StackStatusBroadcastService', () => {
       finishedAt: null,
       exitCode: null,
       labels: { 'com.docker.compose.project': 'media' },
+      ports: [],
+      mounts: [],
       updatedAt: new Date('2026-04-16T11:00:00Z'),
     };
 

--- a/src/lib/utils/__tests__/docker-hierarchy-builder.test.ts
+++ b/src/lib/utils/__tests__/docker-hierarchy-builder.test.ts
@@ -133,6 +133,8 @@ function makeInventory(
     finishedAt: null,
     exitCode: null,
     labels: {},
+    ports: [],
+    mounts: [],
     updatedAt: baseDate,
     ...overrides,
   };

--- a/src/types/docker-inventory.ts
+++ b/src/types/docker-inventory.ts
@@ -68,17 +68,17 @@ const zInventoryContainerBase = z.object({
   startedAt: z.date().nullable(),
   finishedAt: z.date().nullable(),
   exitCode: z.number().nullable(),
-  ports: z.array(zContainerPortWeb).default([]),
   /** Timestamp of the last state-change event. */
   updatedAt: z.date(),
 });
 
 /**
  * Snapshot shape emitted on `type: 'init'`. Populated from the DB via
- * `getCurrentSnapshot()`; labels and mounts reflect the container's real values.
+ * `getCurrentSnapshot()`; labels, ports, and mounts reflect the container's real values.
  */
 export const zDockerInventorySnapshotContainer = zInventoryContainerBase.extend({
   labels: z.record(z.string(), z.string()),
+  ports: z.array(zContainerPortWeb).default([]),
   mounts: z.array(zContainerMountWeb).default([]),
 });
 export type DockerInventorySnapshotContainer = z.infer<typeof zDockerInventorySnapshotContainer>;
@@ -87,9 +87,13 @@ export type DockerInventorySnapshotContainer = z.infer<typeof zDockerInventorySn
  * Update shape emitted on `type: 'upsert'`. Labels and mounts are intentionally absent:
  * the NOTIFY trigger in migration 026 omits them (8 kB cap on PG NOTIFY, mount paths
  * are unbounded). Consumers that need them must narrow to the snapshot shape and fetch
- * from the init / DB path.
+ * from the init / DB path. `ports` is `.optional()` (no default): the trigger also drops
+ * ports on the rare oversized-payload path, and that must stay distinguishable from a
+ * genuinely empty port list so the client falls back to the last known value.
  */
-export const zDockerInventoryUpdateContainer = zInventoryContainerBase;
+export const zDockerInventoryUpdateContainer = zInventoryContainerBase.extend({
+  ports: z.array(zContainerPortWeb).optional(),
+});
 export type DockerInventoryUpdateContainer = z.infer<typeof zDockerInventoryUpdateContainer>;
 
 /** Events fanned out from `DockerInventoryBroadcastService` to SSE subscribers. */

--- a/src/types/docker-inventory.ts
+++ b/src/types/docker-inventory.ts
@@ -39,6 +39,24 @@ const zContainerStateWeb = z.enum([
   'unknown',
 ]);
 
+/** Duplicated from the agent protocol's `zContainerPort` to keep agent zod out of the client bundle. */
+const zContainerPortWeb = z.object({
+  containerPort: z.number(),
+  protocol: z.string(),
+  hostIp: z.string().nullable(),
+  hostPort: z.number().nullable(),
+});
+export type ContainerPort = z.infer<typeof zContainerPortWeb>;
+
+/** Duplicated from the agent protocol's `zContainerMount` to keep agent zod out of the client bundle. */
+const zContainerMountWeb = z.object({
+  type: z.string(),
+  source: z.string(),
+  destination: z.string(),
+  rw: z.boolean(),
+});
+export type ContainerMount = z.infer<typeof zContainerMountWeb>;
+
 const zInventoryContainerBase = z.object({
   host: z.string(),
   containerId: z.string(),
@@ -50,24 +68,26 @@ const zInventoryContainerBase = z.object({
   startedAt: z.date().nullable(),
   finishedAt: z.date().nullable(),
   exitCode: z.number().nullable(),
+  ports: z.array(zContainerPortWeb).default([]),
   /** Timestamp of the last state-change event. */
   updatedAt: z.date(),
 });
 
 /**
  * Snapshot shape emitted on `type: 'init'`. Populated from the DB via
- * `getCurrentSnapshot()`; labels reflect the container's real label map.
+ * `getCurrentSnapshot()`; labels and mounts reflect the container's real values.
  */
 export const zDockerInventorySnapshotContainer = zInventoryContainerBase.extend({
   labels: z.record(z.string(), z.string()),
+  mounts: z.array(zContainerMountWeb).default([]),
 });
 export type DockerInventorySnapshotContainer = z.infer<typeof zDockerInventorySnapshotContainer>;
 
 /**
- * Update shape emitted on `type: 'upsert'`. Labels are intentionally absent:
- * the NOTIFY trigger in migration 018 omits them (8 kB cap on PG NOTIFY).
- * Consumers that need labels must narrow to the snapshot shape and fetch from
- * the init / DB path.
+ * Update shape emitted on `type: 'upsert'`. Labels and mounts are intentionally absent:
+ * the NOTIFY trigger in migration 026 omits them (8 kB cap on PG NOTIFY, mount paths
+ * are unbounded). Consumers that need them must narrow to the snapshot shape and fetch
+ * from the init / DB path.
  */
 export const zDockerInventoryUpdateContainer = zInventoryContainerBase;
 export type DockerInventoryUpdateContainer = z.infer<typeof zDockerInventoryUpdateContainer>;

--- a/src/worker/collectors/__tests__/container-inventory-collector.test.ts
+++ b/src/worker/collectors/__tests__/container-inventory-collector.test.ts
@@ -32,6 +32,8 @@ function makeRow(overrides: Partial<DockerContainerEventRow> = {}): DockerContai
     name: 'plex',
     image: 'plexinc/pms-docker:latest',
     labels: {},
+    ports: [],
+    mounts: [],
     composeProject: null,
     serviceKey: 'plex',
     startedAt: null,
@@ -48,6 +50,8 @@ function makeContainer(overrides: Record<string, unknown> = {}) {
     image: 'plexinc/pms-docker:latest',
     state: 'running' as const,
     labels: {},
+    ports: [],
+    mounts: [],
     startedAt: null,
     finishedAt: null,
     exitCode: null,
@@ -162,6 +166,132 @@ describe('ContainerInventoryCollector: state-change dedup', () => {
 
     expect(inserted).toHaveLength(1);
     expect(inserted[0].eventType).toBe('destroy');
+  });
+});
+
+describe('ContainerInventoryCollector: ports/mounts fingerprinting', () => {
+  let abortController: AbortController;
+  let setTimeoutSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    abortController = new AbortController();
+    setTimeoutSpy = spyImmediateTimeout();
+  });
+
+  afterEach(() => {
+    setTimeoutSpy.mockRestore();
+    abortController.abort();
+  });
+
+  it('insert carries ports and mounts from the live frame', async () => {
+    const { repo, inserted } = createMockRepo();
+    const container = makeContainer({
+      ports: [{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: 8080 }],
+      mounts: [{ type: 'volume', source: 'app-data', destination: '/data', rw: true }],
+    });
+    const streamConnector = fixedStream([{ op: 'upsert', container }]);
+
+    const collector = new ContainerInventoryCollector(HOST, async () => 'tok', repo, abortController, streamConnector);
+    await (collector as any).collect();
+
+    expect(inserted).toHaveLength(1);
+    const event = inserted[0];
+    if (event.eventType !== 'upsert') throw new Error('expected upsert row');
+    expect(event.ports).toEqual(container.ports);
+    expect(event.mounts).toEqual(container.mounts);
+  });
+
+  it('hydrated cache fingerprint matches a live frame with the same content but reordered jsonb keys', async () => {
+    // Simulates a DB row where jsonb round-trip reordered object keys; values are identical
+    // to the live frame below but property insertion order differs.
+    const dbRowPort = { hostPort: 8080, hostIp: null, protocol: 'tcp', containerPort: 80 };
+    const dbRowMount = { rw: true, destination: '/data', source: 'app-data', type: 'volume' };
+    const snapshot = [makeRow({
+      containerId: 'abc123',
+      state: 'running',
+      eventType: 'upsert',
+      ports: [dbRowPort],
+      mounts: [dbRowMount],
+    })];
+    const { repo, inserted } = createMockRepo(snapshot);
+
+    const liveContainer = makeContainer({
+      state: 'running',
+      ports: [{ containerPort: 80, protocol: 'tcp', hostIp: null, hostPort: 8080 }],
+      mounts: [{ type: 'volume', source: 'app-data', destination: '/data', rw: true }],
+    });
+    const streamConnector = fixedStream([{ op: 'upsert', container: liveContainer }]);
+
+    const collector = new ContainerInventoryCollector(HOST, async () => 'tok', repo, abortController, streamConnector);
+    await (collector as any).hydrateCache();
+    await (collector as any).collect();
+
+    expect(inserted).toHaveLength(0);
+  });
+
+  it('reconcileInit writes exactly once when fingerprint differs from a legacy empty-array row', async () => {
+    const snapshot = [makeRow({ containerId: 'abc123', state: 'running', eventType: 'upsert', ports: [], mounts: [] })];
+    const { repo, inserted } = createMockRepo(snapshot);
+    const container = makeContainer({
+      state: 'running',
+      ports: [{ containerPort: 443, protocol: 'tcp', hostIp: null, hostPort: 443 }],
+    });
+
+    const collector = new ContainerInventoryCollector(HOST, async () => 'tok', repo, abortController);
+    await (collector as any).hydrateCache();
+    await (collector as any).reconcileInit([container]);
+
+    expect(inserted).toHaveLength(1);
+    const event = inserted[0];
+    if (event.eventType !== 'upsert') throw new Error('expected upsert row');
+    expect(event.ports).toEqual(container.ports);
+  });
+
+  it('reconcileInit writes nothing when state and fingerprint both match', async () => {
+    const snapshot = [makeRow({
+      containerId: 'abc123',
+      state: 'running',
+      eventType: 'upsert',
+      ports: [{ containerPort: 443, protocol: 'tcp', hostIp: null, hostPort: 443 }],
+      mounts: [],
+    })];
+    const { repo, inserted } = createMockRepo(snapshot);
+    const container = makeContainer({
+      state: 'running',
+      ports: [{ containerPort: 443, protocol: 'tcp', hostIp: null, hostPort: 443 }],
+    });
+
+    const collector = new ContainerInventoryCollector(HOST, async () => 'tok', repo, abortController);
+    await (collector as any).hydrateCache();
+    await (collector as any).reconcileInit([container]);
+
+    expect(inserted).toHaveLength(0);
+  });
+
+  it('old-agent frame lacking ports/mounts fields defaults to [] and causes no write against a [] cached row', async () => {
+    const snapshot = [makeRow({ containerId: 'abc123', state: 'running', eventType: 'upsert', ports: [], mounts: [] })];
+    const { repo, inserted } = createMockRepo(snapshot);
+    // Raw frame with no ports/mounts keys at all, as an old agent would send; zod fills [] defaults.
+    const legacyFrame = {
+      op: 'upsert',
+      container: {
+        id: 'abc123',
+        name: 'plex',
+        image: 'plexinc/pms-docker:latest',
+        state: 'running',
+        labels: {},
+        startedAt: null,
+        finishedAt: null,
+        exitCode: null,
+      },
+    };
+    const streamConnector = fixedStream([legacyFrame]);
+
+    const collector = new ContainerInventoryCollector(HOST, async () => 'tok', repo, abortController, streamConnector);
+    await (collector as any).hydrateCache();
+    await (collector as any).collect();
+
+    expect(inserted).toHaveLength(0);
   });
 });
 

--- a/src/worker/collectors/container-inventory-collector.ts
+++ b/src/worker/collectors/container-inventory-collector.ts
@@ -1,6 +1,8 @@
 import type {
   AgentContainerEvent,
   ContainerState,
+  ContainerPort,
+  ContainerMount,
   InventorySnapshotContainer,
   InventoryUpdateContainer,
 } from '@/types/docker-inventory';
@@ -19,10 +21,41 @@ export interface ManagedHostInfo {
 /** Injectable connector so tests can supply parsed events without opening a byte stream. */
 type StreamConnector = typeof connectAgentSseStream;
 
+function compareStrings(a: string, b: string): number {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+/** Mirrors the agent's comparePorts (docker-events-broadcaster.ts) so canonical ordering agrees. */
+function comparePorts(a: ContainerPort, b: ContainerPort): number {
+  if (a.containerPort !== b.containerPort) return a.containerPort - b.containerPort;
+  if (a.protocol !== b.protocol) return compareStrings(a.protocol, b.protocol);
+  const aHostIp = a.hostIp ?? '';
+  const bHostIp = b.hostIp ?? '';
+  if (aHostIp !== bHostIp) return compareStrings(aHostIp, bHostIp);
+  return (a.hostPort ?? -1) - (b.hostPort ?? -1);
+}
+
+/** Mirrors the agent's compareMounts (docker-events-broadcaster.ts) so canonical ordering agrees. */
+function compareMounts(a: ContainerMount, b: ContainerMount): number {
+  return compareStrings(a.destination, b.destination);
+}
+
+/** PostgreSQL jsonb does not preserve object key order, so a hydrated DB row's ports/mounts never
+ * JSON.stringify-match a live SSE frame with the same content; canonicalize through sorted tuple
+ * arrays (positional, not key-order dependent) instead. */
+function computeDetailsFingerprint(ports: ContainerPort[], mounts: ContainerMount[]): string {
+  const portTuples = [...ports].sort(comparePorts).map((p) => [p.containerPort, p.protocol, p.hostIp, p.hostPort]);
+  const mountTuples = [...mounts].sort(compareMounts).map((m) => [m.type, m.source, m.destination, m.rw]);
+  return JSON.stringify([portTuples, mountTuples]);
+}
+
 /** Per-container state held in memory to avoid redundant DB writes. */
 interface CachedContainerState {
   state: ContainerState | null;
   eventType: 'upsert' | 'destroy';
+  detailsFingerprint: string;
 }
 
 export class ContainerInventoryCollector extends BaseCollector {
@@ -71,7 +104,10 @@ export class ContainerInventoryCollector extends BaseCollector {
       for (const row of snapshot) {
         if (row.host !== this.host.name) continue;
         const state = row.eventType === 'upsert' ? row.state : null;
-        this.stateCache.set(row.containerId, { state, eventType: row.eventType });
+        const detailsFingerprint = row.eventType === 'upsert'
+          ? computeDetailsFingerprint(row.ports, row.mounts)
+          : computeDetailsFingerprint([], []);
+        this.stateCache.set(row.containerId, { state, eventType: row.eventType, detailsFingerprint });
       }
     } catch (err) {
       console.error(`[ContainerInventoryCollector] Failed to hydrate cache for ${this.host.name}:`, err);
@@ -162,7 +198,8 @@ export class ContainerInventoryCollector extends BaseCollector {
 
     for (const container of containers) {
       const cached = this.stateCache.get(container.id);
-      if (!cached || cached.state !== container.state || cached.eventType !== 'upsert') {
+      const fingerprint = computeDetailsFingerprint(container.ports, container.mounts);
+      if (!cached || cached.state !== container.state || cached.eventType !== 'upsert' || cached.detailsFingerprint !== fingerprint) {
         await this.writeEvent(container, 'upsert');
       }
     }
@@ -187,7 +224,8 @@ export class ContainerInventoryCollector extends BaseCollector {
     const timer = globalThis.setTimeout(() => {
       this.pendingWrites.delete(container.id);
       const cached = this.stateCache.get(container.id);
-      if (cached && cached.eventType === 'upsert' && cached.state === container.state) {
+      const fingerprint = computeDetailsFingerprint(container.ports, container.mounts);
+      if (cached && cached.eventType === 'upsert' && cached.state === container.state && cached.detailsFingerprint === fingerprint) {
         return;
       }
       this.writeEvent(container, eventType).catch((err) => {
@@ -225,6 +263,7 @@ export class ContainerInventoryCollector extends BaseCollector {
     // Streaming upserts carry no labels; serviceKey falls back to name until the next reconcileInit.
     const labels = 'labels' in container ? container.labels : {};
     const serviceKey = computeServiceKey(labels, container.name);
+    const detailsFingerprint = computeDetailsFingerprint(container.ports, container.mounts);
     try {
       await this.eventRepository.insert({
         at: new Date(),
@@ -235,12 +274,14 @@ export class ContainerInventoryCollector extends BaseCollector {
         name: container.name,
         image: container.image,
         labels,
+        ports: container.ports,
+        mounts: container.mounts,
         serviceKey,
         startedAt: container.startedAt ? new Date(container.startedAt) : null,
         finishedAt: container.finishedAt ? new Date(container.finishedAt) : null,
         exitCode: container.exitCode,
       });
-      this.stateCache.set(container.id, { state: container.state, eventType });
+      this.stateCache.set(container.id, { state: container.state, eventType, detailsFingerprint });
     } catch (err) {
       console.error(`[ContainerInventoryCollector] DB error for ${this.host.name}/${container.id}:`, err);
       throw err;
@@ -255,7 +296,7 @@ export class ContainerInventoryCollector extends BaseCollector {
         containerId,
         eventType: 'destroy',
       });
-      this.stateCache.set(containerId, { state: null, eventType: 'destroy' });
+      this.stateCache.set(containerId, { state: null, eventType: 'destroy', detailsFingerprint: computeDetailsFingerprint([], []) });
     } catch (err) {
       console.error(`[ContainerInventoryCollector] DB destroy error for ${this.host.name}/${containerId}:`, err);
       throw err;


### PR DESCRIPTION
## Why

The agent now sends ports/mounts in the inventory protocol (#353), but the worker, database, SSE, and UI dropped them. This carries the data end to end so the Docker page's container detail panel shows published ports and bind mounts. The stack editor Containers tab follows in a separate PR.

## What

- **Migration 026**: `ports`/`mounts` JSONB columns on `docker_container_events` (default `'[]'`), and the migration-018 NOTIFY trigger replaced to include `ports` in the payload, never `mounts` (mount paths are unbounded; `pg_notify` caps at 8000 bytes and a failing notify would abort the INSERT). A size guard drops ports from the payload above 7500 bytes.
- **Worker**: a `detailsFingerprint` on the collector's per-container cache decides writes alongside state/eventType. The fingerprint canonicalizes ports/mounts into sorted tuple arrays before stringifying, applied identically to DB-hydrated rows and live agent frames. This matters because Postgres jsonb does not preserve object key order: a naive stringify comparison would rewrite every container on every worker restart. Legacy rows self-heal with exactly one write per container after upgrade; steady state has zero extra writes.
- **Repository/broadcast/hook**: rows carry the fields; NOTIFY-driven upserts carry ports and preserve the previous entry's mounts; `mergeUpsert` falls back to previous ports for old-payload skew.
- **UI**: new `ContainerPortsMounts` strip in `ContainerDetailPanel` (only when non-empty): `docker ps`-style port chips with the IPv4/IPv6 wildcard pair collapsed (`8080->80/tcp`), specific bind IPs kept, unpublished ports dimmed; mounts as `source -> destination` rows with an `ro` badge and volume names shown instead of `/var/lib/docker/volumes/...` paths; tooltips carry full mappings.
- **Demo mode**: mock containers ship representative ports/mounts.

Version skew is safe in both directions: old agents parse via `.default([])` (empty arrays, UI hidden, no churn), old workers strip the new protocol fields.

Known limitation (accepted): a browser tab already open when a container is created shows its ports from the NOTIFY payload, but mounts only after the next init (reload/reconnect).

## Tests

Collector fingerprint equality across jsonb key reordering, one-write self-heal, no-write steady state; repository defaults and destroy rows; broadcast payload mapping; mergeUpsert preservation/fallback; port/mount formatting helper matrices; detail panel integration; demo generator. 247 tests across the touched files; new files at 100% coverage; `typecheck:all` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq

---
_Generated by [Claude Code](https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container details now display published ports and mounted storage volumes.
  * Port mappings are formatted clearly, with duplicate wildcard bindings removed.
  * Mount information shows volume names, destinations, and read-only status.
  * Docker inventory events now retain ports and mounts for snapshots and updates.

* **Bug Fixes**
  * Large event notifications no longer fail when port data exceeds payload limits.
  * Partial updates preserve previously known port and mount information.

* **Tests**
  * Added coverage for port formatting, mount display, persistence, and update handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->