### PR TITLE
ci: cancel superseded CI runs per ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,14 @@ on:
   pull_request:
     branches: [main]
 
+# One run per ref: a newer push cancels the in-progress run for the same branch or
+# PR, so rapid merges to main (e.g. a batch of Dependabot PRs) don't each run CI to
+# completion. Keyed on github.ref so distinct PRs stay independent and release-tag
+# builds (refs/tags/v*) are never canceled by a main push.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-test:
     name: Build, Test & License Check


### PR DESCRIPTION
## What

Adds a workflow-level `concurrency` group to the CI workflow so a newer push cancels the in-progress run for the same branch or PR.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

## Why

When a batch of Dependabot PRs is merged to `main` in quick succession, each merge currently spins up a full CI run and all of them run to completion, burning runner minutes on commits that are already superseded. With this group, only the latest run for a given ref survives; earlier in-progress runs are canceled.

## Scope of the key

Keyed on `github.ref` so:
- Distinct PRs stay independent (each PR has its own ref, so one PR's push never cancels another's).
- Release-tag builds (`refs/tags/v*.*.*`) get their own group and are never canceled by a `main` push.

Only in-flight runs for the same ref are affected; nothing else in the pipeline changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015VS9bkwReJgTDAP5Z9eFjq)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CI now cancels outdated runs when newer changes are pushed to the same branch or pull request.
  * Separate branches, pull requests, and tags continue to run independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->