### PR TITLE
ci: fail the build on test failures, not just coverage

### DIFF
--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -24,71 +24,77 @@ const THRESHOLDS = {
   // Note: Bun doesn't report branch coverage yet
 };
 
-let output;
-try {
-  output = readFileSync(0, 'utf-8'); // fd 0 is stdin
-} catch {
-  console.error('❌ Failed to read test output from stdin');
-  process.exit(1);
-}
-
-// Bun's output was consumed by this script; re-emit it so failures and the
-// coverage table remain visible in CI logs.
-process.stdout.write(output);
-
-let failed = false;
-
-// A single piped stream can hide a non-zero bun exit, so gate on the printed
-// summary directly. Bun prints one "<n> fail" line at the end of the run.
-const failMatches = [...output.matchAll(/^\s*(\d+)\s+fail\b/gm)];
-const failCount = failMatches.length > 0 ? Number(failMatches.at(-1)[1]) : null;
-
-if (failCount === null) {
-  console.error('\n❌ Could not find a test summary ("<n> fail") in the output');
-  console.error('The test run likely crashed before reporting; treating as failed.');
-  failed = true;
-} else if (failCount > 0) {
-  console.error(`\n❌ ${failCount} test${failCount === 1 ? '' : 's'} failed`);
-  const failingTests = [...output.matchAll(/^\(fail\) .+$/gm)].map((m) => m[0]);
-  for (const line of failingTests) {
-    console.error(`   ${line}`);
+function main() {
+  let output;
+  try {
+    output = readFileSync(0, 'utf-8'); // fd 0 is stdin
+  } catch {
+    console.error('❌ Failed to read test output from stdin');
+    return 1;
   }
-  failed = true;
+
+  // Bun's output was consumed by this script; re-emit it so failures and the
+  // coverage table remain visible in CI logs.
+  process.stdout.write(output);
+
+  let failed = false;
+
+  // A single piped stream can hide a non-zero bun exit, so gate on the printed
+  // summary directly. Bun prints one "<n> fail" line at the end of the run.
+  const failMatches = [...output.matchAll(/^\s*(\d+)\s+fail\b/gm)];
+  const failCount = failMatches.length > 0 ? Number(failMatches.at(-1)[1]) : null;
+
+  if (failCount === null) {
+    console.error('\n❌ Could not find a test summary ("<n> fail") in the output');
+    console.error('The test run likely crashed before reporting; treating as failed.');
+    failed = true;
+  } else if (failCount > 0) {
+    console.error(`\n❌ ${failCount} test${failCount === 1 ? '' : 's'} failed`);
+    const failingTests = [...output.matchAll(/^\(fail\) .+$/gm)].map((m) => m[0]);
+    for (const line of failingTests) {
+      console.error(`   ${line}`);
+    }
+    failed = true;
+  }
+
+  const match = output.match(/All files\s+\|\s+([\d.]+)\s+\|\s+([\d.]+)\s+\|/);
+
+  if (!match) {
+    console.error('\n❌ Could not parse coverage from test output');
+    console.error('Expected format: "All files | <functions%> | <lines%> |"');
+    return 1;
+  }
+
+  const coverage = {
+    functions: Number.parseFloat(match[1]),
+    lines: Number.parseFloat(match[2]),
+  };
+
+  console.log('\n📊 Coverage Summary:');
+  console.log(`   Functions: ${coverage.functions.toFixed(2)}% (threshold: ${THRESHOLDS.functions}%)`);
+  console.log(`   Lines: ${coverage.lines.toFixed(2)}% (threshold: ${THRESHOLDS.lines}%)`);
+
+  if (coverage.functions < THRESHOLDS.functions) {
+    console.error(`\n❌ Function coverage ${coverage.functions.toFixed(2)}% is below threshold ${THRESHOLDS.functions}%`);
+    console.error(`   Need ${(THRESHOLDS.functions - coverage.functions).toFixed(2)}% more function coverage`);
+    failed = true;
+  }
+
+  if (coverage.lines < THRESHOLDS.lines) {
+    console.error(`\n❌ Line coverage ${coverage.lines.toFixed(2)}% is below threshold ${THRESHOLDS.lines}%`);
+    console.error(`   Need ${(THRESHOLDS.lines - coverage.lines).toFixed(2)}% more line coverage`);
+    failed = true;
+  }
+
+  if (failed) {
+    console.error('\n💔 Test/coverage check FAILED');
+    return 1;
+  }
+
+  console.log('\n✅ Test and coverage checks PASSED');
+  return 0;
 }
 
-const match = output.match(/All files\s+\|\s+([\d.]+)\s+\|\s+([\d.]+)\s+\|/);
-
-if (!match) {
-  console.error('\n❌ Could not parse coverage from test output');
-  console.error('Expected format: "All files | <functions%> | <lines%> |"');
-  process.exit(1);
-}
-
-const coverage = {
-  functions: Number.parseFloat(match[1]),
-  lines: Number.parseFloat(match[2]),
-};
-
-console.log('\n📊 Coverage Summary:');
-console.log(`   Functions: ${coverage.functions.toFixed(2)}% (threshold: ${THRESHOLDS.functions}%)`);
-console.log(`   Lines: ${coverage.lines.toFixed(2)}% (threshold: ${THRESHOLDS.lines}%)`);
-
-if (coverage.functions < THRESHOLDS.functions) {
-  console.error(`\n❌ Function coverage ${coverage.functions.toFixed(2)}% is below threshold ${THRESHOLDS.functions}%`);
-  console.error(`   Need ${(THRESHOLDS.functions - coverage.functions).toFixed(2)}% more function coverage`);
-  failed = true;
-}
-
-if (coverage.lines < THRESHOLDS.lines) {
-  console.error(`\n❌ Line coverage ${coverage.lines.toFixed(2)}% is below threshold ${THRESHOLDS.lines}%`);
-  console.error(`   Need ${(THRESHOLDS.lines - coverage.lines).toFixed(2)}% more line coverage`);
-  failed = true;
-}
-
-if (failed) {
-  console.error('\n💔 Test/coverage check FAILED');
-  process.exit(1);
-}
-
-console.log('\n✅ Test and coverage checks PASSED');
-process.exit(0);
+// process.exit would discard the re-emitted output above, since stdout writes
+// are asynchronous when piped. Setting exitCode lets the stream flush first.
+process.exitCode = main();

--- a/scripts/check-coverage.js
+++ b/scripts/check-coverage.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 
 /**
- * Check test coverage against minimum thresholds.
- * Reads Bun's text coverage output from stdin and enforces minimums.
+ * Check test results and coverage against minimum thresholds.
+ * Reads Bun's text test + coverage output from stdin, echoes it so the
+ * results stay visible in logs, then enforces both a zero-failure gate and
+ * the coverage minimums.
  *
  * Usage:
  *   bun test --coverage 2>&1 | node scripts/check-coverage.js
@@ -22,58 +24,71 @@ const THRESHOLDS = {
   // Note: Bun doesn't report branch coverage yet
 };
 
-// Read from stdin (piped from bun test --coverage)
 let output;
 try {
   output = readFileSync(0, 'utf-8'); // fd 0 is stdin
-} catch (error) {
-  console.error('❌ Failed to read coverage from stdin');
+} catch {
+  console.error('❌ Failed to read test output from stdin');
   process.exit(1);
 }
 
-// Parse coverage from output
-// Format: "All files                                  |   93.32 |   93.27 |"
-// Note: there may be many spaces between "All files" and the first |
+// Bun's output was consumed by this script; re-emit it so failures and the
+// coverage table remain visible in CI logs.
+process.stdout.write(output);
+
+let failed = false;
+
+// A single piped stream can hide a non-zero bun exit, so gate on the printed
+// summary directly. Bun prints one "<n> fail" line at the end of the run.
+const failMatches = [...output.matchAll(/^\s*(\d+)\s+fail\b/gm)];
+const failCount = failMatches.length > 0 ? Number(failMatches.at(-1)[1]) : null;
+
+if (failCount === null) {
+  console.error('\n❌ Could not find a test summary ("<n> fail") in the output');
+  console.error('The test run likely crashed before reporting; treating as failed.');
+  failed = true;
+} else if (failCount > 0) {
+  console.error(`\n❌ ${failCount} test${failCount === 1 ? '' : 's'} failed`);
+  const failingTests = [...output.matchAll(/^\(fail\) .+$/gm)].map((m) => m[0]);
+  for (const line of failingTests) {
+    console.error(`   ${line}`);
+  }
+  failed = true;
+}
+
 const match = output.match(/All files\s+\|\s+([\d.]+)\s+\|\s+([\d.]+)\s+\|/);
 
 if (!match) {
-  console.error('❌ Could not parse coverage from test output');
+  console.error('\n❌ Could not parse coverage from test output');
   console.error('Expected format: "All files | <functions%> | <lines%> |"');
   process.exit(1);
 }
 
-const [, functionsPercent, linesPercent] = match;
 const coverage = {
-  functions: Number.parseFloat(functionsPercent),
-  lines: Number.parseFloat(linesPercent),
+  functions: Number.parseFloat(match[1]),
+  lines: Number.parseFloat(match[2]),
 };
 
 console.log('\n📊 Coverage Summary:');
 console.log(`   Functions: ${coverage.functions.toFixed(2)}% (threshold: ${THRESHOLDS.functions}%)`);
 console.log(`   Lines: ${coverage.lines.toFixed(2)}% (threshold: ${THRESHOLDS.lines}%)`);
 
-let failed = false;
-
 if (coverage.functions < THRESHOLDS.functions) {
   console.error(`\n❌ Function coverage ${coverage.functions.toFixed(2)}% is below threshold ${THRESHOLDS.functions}%`);
-  const deficit = THRESHOLDS.functions - coverage.functions;
-  console.error(`   Need ${deficit.toFixed(2)}% more function coverage`);
+  console.error(`   Need ${(THRESHOLDS.functions - coverage.functions).toFixed(2)}% more function coverage`);
   failed = true;
 }
 
 if (coverage.lines < THRESHOLDS.lines) {
   console.error(`\n❌ Line coverage ${coverage.lines.toFixed(2)}% is below threshold ${THRESHOLDS.lines}%`);
-  const deficit = THRESHOLDS.lines - coverage.lines;
-  console.error(`   Need ${deficit.toFixed(2)}% more line coverage`);
+  console.error(`   Need ${(THRESHOLDS.lines - coverage.lines).toFixed(2)}% more line coverage`);
   failed = true;
 }
 
 if (failed) {
-  console.error('\n💔 Coverage check FAILED');
-  console.error('Please add tests to improve coverage before committing.');
+  console.error('\n💔 Test/coverage check FAILED');
   process.exit(1);
 }
 
-console.log('\n✅ Coverage check PASSED');
-console.log('All coverage thresholds met!');
+console.log('\n✅ Test and coverage checks PASSED');
 process.exit(0);


### PR DESCRIPTION
## Problem

The test step runs `bun test --isolate --coverage 2>&1 | node scripts/check-coverage.js`. Two layers meant failing tests never failed CI:

1. The pipe dropped bun's non-zero exit code; only `check-coverage.js`'s exit status mattered.
2. `check-coverage.js` slurped bun's entire output via `readFileSync(0)` and parsed only the `All files` coverage line, never echoing the test results, so failures were invisible in the logs too.

A run went green with tests failing as long as coverage stayed above the floor, and the only symptom was an unexplained coverage dip.

## This PR

`scripts/check-coverage.js` now:

- echoes the output it consumed, so test results and the coverage table stay visible in CI logs
- gates on the printed `<n> fail` summary: any failing test fails the build, with the failing test names surfaced
- fails when no test summary is found at all (a run that crashed before reporting no longer slips through)
- keeps the existing 94% functions / 98% lines thresholds unchanged

## Why it matters

This is what surfaced the real cause of the coverage dip on the dependency-bump PR (#325): 46 tests were failing there, and the gate was reporting only "line coverage 97.94%, need 0.06% more". Those failures turned out to be a breaking change in the TanStack Start bump, not a coverage shortfall. Fixed separately on that branch.

`main` itself is unaffected: verified locally on the pinned Bun 1.3.14 that the full suite is 0 fail at 98.41% lines, and this PR's own CI run is green with the stricter gate in place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CI checks now fail when automated tests report failures, even if coverage thresholds are met.
  * Coverage validation now checks both function and line coverage.
  * Improved handling and reporting when test results or coverage data cannot be parsed.
  * Failure messages now identify whether tests or coverage caused the check to fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->