### PR TITLE
fix(agent-updater): run as root and point health checks at the agent

### DIFF
--- a/agent-updater/Dockerfile
+++ b/agent-updater/Dockerfile
@@ -10,7 +10,6 @@ WORKDIR /app
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/src ./src
 COPY --from=builder /app/package.json ./
-USER bun
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD ["bun", "--eval", "process.exit(0)"]
 CMD ["bun", "src/index.ts"]

--- a/src/lib/templates/__tests__/__snapshots__/agent-stack-compose.test.ts.snap
+++ b/src/lib/templates/__tests__/__snapshots__/agent-stack-compose.test.ts.snap
@@ -56,9 +56,12 @@ services:
       HLM_WATCH_CONTAINER: hlm-agent
       HLM_WATCH_IMAGE: \${AGENT_IMAGE}
       HLM_CHECK_INTERVAL: \${HLM_CHECK_INTERVAL:-6h}
+      HLM_AGENT_URL: http://hlm-agent:9090
     labels:
       - hlm.managed=true
       - hlm.role=agent-updater
+    networks:
+      - agent-public
 networks:
   agent-internal:
     driver: bridge
@@ -99,6 +102,7 @@ services:
       HLM_WATCH_CONTAINER: hlm-agent
       HLM_WATCH_IMAGE: \${AGENT_IMAGE}
       HLM_CHECK_INTERVAL: \${HLM_CHECK_INTERVAL:-6h}
+      HLM_AGENT_URL: http://hlm-agent:9090
     labels:
       - hlm.managed=true
       - hlm.role=agent-updater
@@ -167,9 +171,12 @@ services:
       HLM_WATCH_CONTAINER: hlm-agent
       HLM_WATCH_IMAGE: \${AGENT_IMAGE}
       HLM_CHECK_INTERVAL: \${HLM_CHECK_INTERVAL:-6h}
+      HLM_AGENT_URL: http://hlm-agent:9090
     labels:
       - hlm.managed=true
       - hlm.role=agent-updater
+    networks:
+      - agent-public
 networks:
   agent-internal:
     driver: bridge

--- a/src/lib/templates/__tests__/agent-stack-compose.test.ts
+++ b/src/lib/templates/__tests__/agent-stack-compose.test.ts
@@ -167,6 +167,26 @@ describe('generateAgentStackCompose', () => {
     }
   });
 
+  it('agent-updater always points at the agent for health checks', () => {
+    for (const config of [dockerOnlyConfig, zfsOnlyConfig, dockerZfsConfig]) {
+      const result = generateAgentStackCompose(config);
+      const parsed = parseYaml(result);
+      expect(parsed.services['agent-updater'].environment.HLM_AGENT_URL).toBe(
+        'http://hlm-agent:9090'
+      );
+    }
+  });
+
+  it('agent-updater joins agent-public only when docker capability is enabled', () => {
+    const dockerResult = generateAgentStackCompose(dockerOnlyConfig);
+    const dockerParsed = parseYaml(dockerResult);
+    expect(dockerParsed.services['agent-updater'].networks).toEqual(['agent-public']);
+
+    const zfsResult = generateAgentStackCompose(zfsOnlyConfig);
+    const zfsParsed = parseYaml(zfsResult);
+    expect(zfsParsed.services['agent-updater'].networks).toBeUndefined();
+  });
+
   it('agent attached to both internal and public networks when docker capability', () => {
     const zfsResult = generateAgentStackCompose(zfsOnlyConfig);
     const zfsParsed = parseYaml(zfsResult);

--- a/src/lib/templates/agent-stack-compose.ts
+++ b/src/lib/templates/agent-stack-compose.ts
@@ -24,7 +24,7 @@ export function generateAgentStackCompose(config: AgentStackConfig): string {
   }
 
   services['agent'] = buildAgent(config);
-  services['agent-updater'] = buildAgentUpdater();
+  services['agent-updater'] = buildAgentUpdater(config);
 
   const doc: Record<string, unknown> = { services };
 
@@ -155,8 +155,8 @@ function buildAgent(config: AgentStackConfig): Record<string, unknown> {
   return agent;
 }
 
-function buildAgentUpdater(): Record<string, unknown> {
-  return {
+function buildAgentUpdater(config: AgentStackConfig): Record<string, unknown> {
+  const agentUpdater: Record<string, unknown> = {
     image: '${AGENT_UPDATER_IMAGE}',
     container_name: 'hlm-agent-updater',
     restart: 'unless-stopped',
@@ -165,7 +165,14 @@ function buildAgentUpdater(): Record<string, unknown> {
       HLM_WATCH_CONTAINER: 'hlm-agent',
       HLM_WATCH_IMAGE: '${AGENT_IMAGE}',
       HLM_CHECK_INTERVAL: '${HLM_CHECK_INTERVAL:-6h}',
+      HLM_AGENT_URL: 'http://hlm-agent:9090',
     },
     labels: ['hlm.managed=true', 'hlm.role=agent-updater'],
   };
+
+  if (config.capabilities.docker) {
+    agentUpdater['networks'] = ['agent-public'];
+  }
+
+  return agentUpdater;
 }


### PR DESCRIPTION
Two bugs kept the agent-updater sidecar from working in the stack the Add Host wizard generates.

## 1. Non-root process against a root-owned socket

The Dockerfile ended with `USER bun`, but the generated compose mounts the raw root-owned `/var/run/docker.sock`. The socket is `root:docker 0660`, so a non-root process that is not in the docker group cannot open it at all. Bun surfaces the resulting `EACCES` as the misleading "Was there a typo in the url or port?", so the updater never completed a single check. Removed `USER bun`.

### Why root rather than non-root

Worth stating explicitly, because "run it as root" reads like a downgrade:

**Mounting the Docker socket is already host-root equivalent.** Anything that can reach that socket can start a privileged container bind-mounting `/`. The privilege boundary is crossed by the mount, not by the process UID. So `USER bun` was not buying isolation here; it was buying breakage, and it gave the config the appearance of being hardened while it was in fact broken.

**Non-root plus `group_add` would be the same privilege.** The only way to let a non-root user open that socket is to add the host's docker group, which grants exactly the capability that made root look concerning in the first place. It would also cost an operational change: the enrollment wizard only collects the host's docker GID for docker+zfs hosts today, and it would have to always collect it. That is real cost for no security delta.

**The updater's own surface is small.** It has no inbound listener (no `Bun.serve`, no bound port; the Dockerfile HEALTHCHECK is just `bun --eval process.exit(0)`). Its entire input set is four operator-set environment variables, Docker API responses, and one outbound `fetch` to the agent's `/health` whose body is ignored (only the status is read). Nothing parses untrusted input.

**What actually governs blast radius is unchanged by the UID.** The updater pulls a remote image and runs it as the agent, following a moving tag. If the registry or that tag were compromised, the new image is deployed automatically. That is inherent to any auto-updater, and it is identical whether the updater process is uid 0 or not, because the daemon runs the resulting container as root either way.

If this is ever hardened further, the option with a genuine security delta is routing the updater through the existing socket-proxy over TCP the way the agent already does (`DOCKER_HOST=tcp://socket-proxy:2375`), which removes the raw socket mount entirely and restricts the reachable endpoints. linuxserver/socket-proxy exposes a `DISTRIBUTION` toggle, which covers the digest lookup the update check needs. That is deliberately out of scope here: it would require emitting the proxy for zfs-only stacks, which do not have one today.

## 2. Post-update health check pointed at the updater itself

`buildAgentUpdater()` never set `HLM_AGENT_URL`, so `index.ts` fell back to `http://localhost:9090`, which inside the updater container is the updater, not the agent. The updater also had no network in common with the agent. Every post-update `checkAgentHealth()` therefore failed and forced a rollback of an otherwise healthy update.

`buildAgentUpdater()` now takes the stack config, sets `HLM_AGENT_URL` to the agent's address, and joins `agent-public` when the docker capability is enabled so the agent's container name resolves.

On a zfs-only host neither service declares a network, so both sit on the compose default network where the container name already resolves; no networks key is emitted there.

## Tests

Two assertions added beyond the snapshot: the health-check URL is present for all three capability configs, and the shared network is joined only when docker is enabled. Snapshot regenerated.