### PR TITLE
feat(stacks): resolve stack drift with confirmation and capture-before-destroy

### DIFF
--- a/src/components/stacks/StackDriftActions.tsx
+++ b/src/components/stacks/StackDriftActions.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { toast } from 'sonner';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
@@ -10,8 +9,10 @@ import {
   getStackDriftResolutionLabel,
   isDestructiveStackDriftResolution,
 } from '@/lib/stacks/stack-drift-service';
+import { formatDriftResolutionOutcome } from '@/lib/stacks/deploy-outcome-toast';
 import { resolveDrift } from '@/data/stacks/functions';
 import { STACKS_QUERY_KEY, STACK_DRIFT_QUERY_KEY } from '@/lib/constants/stacks-keys';
+import { useToast } from '@/hooks/toastAtom';
 
 interface StackDriftActionsProps {
   item: StackDriftItem;
@@ -19,6 +20,7 @@ interface StackDriftActionsProps {
 
 export default function StackDriftActions({ item }: Readonly<StackDriftActionsProps>) {
   const queryClient = useQueryClient();
+  const { showToast } = useToast();
   const [pendingResolution, setPendingResolution] = useState<StackDriftResolution | null>(null);
 
   const mutation = useMutation({
@@ -28,14 +30,12 @@ export default function StackDriftActions({ item }: Readonly<StackDriftActionsPr
       setPendingResolution(null);
       queryClient.invalidateQueries({ queryKey: STACK_DRIFT_QUERY_KEY });
       queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY });
-      const archived = result.recoveryCommitSha
-        ? ` Host copy archived in ${result.recoveryCommitSha.slice(0, 7)}.`
-        : '';
-      toast.success(`Resolved drift for ${item.host}/${item.stack}.${archived}`);
+      const { message, severity } = formatDriftResolutionOutcome(`${item.host}/${item.stack}`, result);
+      showToast(message, severity);
     },
     onError: (err) => {
       setPendingResolution(null);
-      toast.error(err instanceof Error ? err.message : String(err));
+      showToast(err instanceof Error ? err.message : String(err), 'error');
     },
   });
 

--- a/src/components/stacks/StackDriftActions.tsx
+++ b/src/components/stacks/StackDriftActions.tsx
@@ -35,6 +35,9 @@ export default function StackDriftActions({ item }: Readonly<StackDriftActionsPr
     },
     onError: (err) => {
       setPendingResolution(null);
+      // A resolution can fail after the host was already changed.
+      queryClient.invalidateQueries({ queryKey: STACK_DRIFT_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY });
       showToast(err instanceof Error ? err.message : String(err), 'error');
     },
   });

--- a/src/components/stacks/StackDriftActions.tsx
+++ b/src/components/stacks/StackDriftActions.tsx
@@ -1,0 +1,71 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import StackDriftResolveDialog from '@/components/stacks/StackDriftResolveDialog';
+import type { StackDriftItem, StackDriftResolution } from '@/types/stacks';
+import {
+  getAllowedStackDriftResolutions,
+  getStackDriftResolutionLabel,
+  isDestructiveStackDriftResolution,
+} from '@/lib/stacks/stack-drift-service';
+import { resolveDrift } from '@/data/stacks/functions';
+import { STACKS_QUERY_KEY, STACK_DRIFT_QUERY_KEY } from '@/lib/constants/stacks-keys';
+
+interface StackDriftActionsProps {
+  item: StackDriftItem;
+}
+
+export default function StackDriftActions({ item }: Readonly<StackDriftActionsProps>) {
+  const queryClient = useQueryClient();
+  const [pendingResolution, setPendingResolution] = useState<StackDriftResolution | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (resolution: StackDriftResolution) =>
+      resolveDrift({ data: { host: item.host, stack: item.stack, kind: item.kind, resolution } }),
+    onSuccess: (result) => {
+      setPendingResolution(null);
+      queryClient.invalidateQueries({ queryKey: STACK_DRIFT_QUERY_KEY });
+      queryClient.invalidateQueries({ queryKey: STACKS_QUERY_KEY });
+      const archived = result.recoveryCommitSha
+        ? ` Host copy archived in ${result.recoveryCommitSha.slice(0, 7)}.`
+        : '';
+      toast.success(`Resolved drift for ${item.host}/${item.stack}.${archived}`);
+    },
+    onError: (err) => {
+      setPendingResolution(null);
+      toast.error(err instanceof Error ? err.message : String(err));
+    },
+  });
+
+  return (
+    <>
+      <div className="flex flex-wrap items-center gap-2">
+        {getAllowedStackDriftResolutions(item.kind).map((resolution) => (
+          <Button
+            key={resolution}
+            size="sm"
+            variant={isDestructiveStackDriftResolution(item.kind, resolution) ? 'destructive' : 'outline'}
+            disabled={mutation.isPending}
+            onClick={() => setPendingResolution(resolution)}
+          >
+            {mutation.isPending && mutation.variables === resolution && <Spinner className="size-3.5" />}
+            {getStackDriftResolutionLabel(item.kind, resolution)}
+          </Button>
+        ))}
+      </div>
+
+      {pendingResolution && (
+        <StackDriftResolveDialog
+          open
+          item={item}
+          resolution={pendingResolution}
+          isLoading={mutation.isPending}
+          onClose={() => setPendingResolution(null)}
+          onConfirm={() => mutation.mutate(pendingResolution)}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/stacks/StackDriftResolveDialog.tsx
+++ b/src/components/stacks/StackDriftResolveDialog.tsx
@@ -1,0 +1,116 @@
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import type { StackDriftItem, StackDriftResolution } from '@/types/stacks';
+import { getStackDriftResolutionLabel, isDestructiveStackDriftResolution } from '@/lib/stacks/stack-drift-service';
+
+interface StackDriftResolveDialogProps {
+  open: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  item: StackDriftItem;
+  resolution: StackDriftResolution;
+  isLoading: boolean;
+}
+
+interface ResolutionCopy {
+  effect: string;
+  /** What is irreversibly gone afterwards, or null when git already holds every discarded version. */
+  loss: string | null;
+  /** Where a discarded host copy can be found afterwards. */
+  recovery: string | null;
+}
+
+function describe(item: StackDriftItem, resolution: StackDriftResolution): ResolutionCopy {
+  const target = `${item.host}/${item.stack}`;
+
+  if (item.kind === 'ghost') {
+    if (resolution === 'trust_repo') {
+      return {
+        effect: `Deploys the repo version of ${item.stack} to ${item.host}.`,
+        loss: null,
+        recovery: null,
+      };
+    }
+    return {
+      effect: `Removes ${item.stack} from the stack repo, leaving ${item.host} as it is.`,
+      loss: `${target} stops being managed. Its compose file and manifest entry are deleted from the repo tip.`,
+      recovery: 'Every deleted version stays in git history and can be restored from an earlier commit.',
+    };
+  }
+
+  if (item.kind === 'untracked') {
+    if (resolution === 'trust_agent') {
+      return {
+        effect: `Commits the copy of ${item.stack} running on ${item.host} into the stack repo and starts tracking it.`,
+        loss: null,
+        recovery: null,
+      };
+    }
+    return {
+      effect: `Runs docker compose down for ${item.stack} on ${item.host}. Its containers, networks, and anonymous volumes are removed.`,
+      loss: `${target} is running from a compose file that exists only on ${item.host}. This is the last chance to keep it.`,
+      recovery: `The host's compose file is committed to the repo under .drift-recovery/ before anything is torn down. If that archive cannot be written, nothing is torn down.`,
+    };
+  }
+
+  if (resolution === 'trust_agent') {
+    return {
+      effect: `Commits the version of ${item.stack} running on ${item.host} over the repo's version.`,
+      loss: "The repo's current compose content is replaced.",
+      recovery: 'The replaced version stays in git history and can be restored from an earlier commit.',
+    };
+  }
+
+  return {
+    effect: `Redeploys the repo version of ${item.stack} to ${item.host}, recreating its containers.`,
+    loss: `The divergent compose file on ${item.host} is overwritten. It exists nowhere else.`,
+    recovery: `The host's compose file is committed to the repo under .drift-recovery/ before the deploy runs. If that archive cannot be written, the deploy does not run.`,
+  };
+}
+
+export default function StackDriftResolveDialog({
+  open,
+  onClose,
+  onConfirm,
+  item,
+  resolution,
+  isLoading,
+}: Readonly<StackDriftResolveDialogProps>) {
+  const copy = describe(item, resolution);
+  const label = getStackDriftResolutionLabel(item.kind, resolution);
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
+      <DialogContent>
+        <DialogTitle>
+          {label}: {item.host}/{item.stack}?
+        </DialogTitle>
+        <DialogBody>
+          <div className="flex flex-col gap-3 text-sm">
+            <p>{copy.effect}</p>
+            {copy.loss && <p className="font-medium text-destructive">{copy.loss}</p>}
+            {copy.recovery && <p className="opacity-70">{copy.recovery}</p>}
+          </div>
+        </DialogBody>
+        <DialogFooter>
+          <Button variant="ghost" className="text-foreground" onClick={onClose} disabled={isLoading}>
+            Cancel
+          </Button>
+          <Button
+            variant={isDestructiveStackDriftResolution(item.kind, resolution) ? 'destructive' : 'default'}
+            onClick={onConfirm}
+            disabled={isLoading}
+          >
+            {label}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/stacks/StackDriftSummary.tsx
+++ b/src/components/stacks/StackDriftSummary.tsx
@@ -2,6 +2,7 @@ import { RefreshCw } from 'lucide-react';
 import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Spinner } from '@/components/ui/spinner';
+import StackDriftActions from '@/components/stacks/StackDriftActions';
 import type { StackDriftReport } from '@/types/stacks';
 import { getStackDriftKindLabel } from '@/lib/stacks/stack-drift-service';
 
@@ -50,6 +51,7 @@ export default function StackDriftSummary({ report, isLoading, onRefresh }: Stac
               {item.host}/{item.stack}
             </span>
             <span className="text-xs opacity-70">{getStackDriftKindLabel(item.kind)}</span>
+            <StackDriftActions item={item} />
           </div>
         ))}
       </div>

--- a/src/components/stacks/StackDriftWarning.tsx
+++ b/src/components/stacks/StackDriftWarning.tsx
@@ -1,4 +1,5 @@
 import { Alert, AlertTitle } from '@/components/ui/alert';
+import StackDriftActions from '@/components/stacks/StackDriftActions';
 import type { StackDriftItem } from '@/types/stacks';
 import { getStackDriftKindLabel } from '@/lib/stacks/stack-drift-service';
 
@@ -9,7 +10,10 @@ interface StackDriftWarningProps {
 export default function StackDriftWarning({ item }: StackDriftWarningProps) {
   return (
     <Alert variant="warning" className="block">
-      <AlertTitle>This stack has {getStackDriftKindLabel(item.kind)} drift.</AlertTitle>
+      <div className="flex flex-col gap-3">
+        <AlertTitle>This stack has {getStackDriftKindLabel(item.kind)} drift.</AlertTitle>
+        <StackDriftActions item={item} />
+      </div>
     </Alert>
   );
 }

--- a/src/components/stacks/__tests__/StackDriftSummary.test.tsx
+++ b/src/components/stacks/__tests__/StackDriftSummary.test.tsx
@@ -1,7 +1,15 @@
 import { describe, expect, it, mock } from 'bun:test';
 import { fireEvent, render, screen } from '@testing-library/react';
-import StackDriftSummary from '@/components/stacks/StackDriftSummary';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { StackDriftReport } from '@/types/stacks';
+
+const mockResolveDrift = mock(() => Promise.resolve({}));
+
+mock.module('@/data/stacks/functions', () => ({
+  resolveDrift: mockResolveDrift,
+}));
+
+const { default: StackDriftSummary } = await import('@/components/stacks/StackDriftSummary');
 
 const report: StackDriftReport = {
   items: [
@@ -18,52 +26,76 @@ const emptyReport: StackDriftReport = {
   scanErrors: [],
 };
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function renderSummary(props: Partial<Parameters<typeof StackDriftSummary>[0]> = {}) {
+  return render(
+    <StackDriftSummary report={report} isLoading={false} onRefresh={() => {}} {...props} />,
+    { wrapper: createWrapper() },
+  );
+}
+
 describe('StackDriftSummary', () => {
   it('renders summary counts by drift kind', () => {
-    render(<StackDriftSummary report={report} isLoading={false} onRefresh={() => {}} />);
+    renderSummary();
     expect(screen.getByText(/1 ghost, 1 untracked, 0 content/i)).toBeDefined();
   });
 
   it('lists each drifted stack with its host and kind label', () => {
-    render(<StackDriftSummary report={report} isLoading={false} onRefresh={() => {}} />);
+    renderSummary();
     expect(screen.getByText('alpha/plex')).toBeDefined();
     expect(screen.getByText('Ghost')).toBeDefined();
     expect(screen.getByText('alpha/grafana')).toBeDefined();
     expect(screen.getByText('Untracked')).toBeDefined();
   });
 
-  it('renders no resolution controls', () => {
-    render(<StackDriftSummary report={report} isLoading={false} onRefresh={() => {}} />);
-    expect(screen.getAllByRole('button').map((btn) => btn.textContent)).toEqual(['Refresh']);
+  it('renders the allowed resolutions for each drifted stack', () => {
+    renderSummary();
+    const labels = screen.getAllByRole('button').map((btn) => btn.textContent);
+    expect(labels).toEqual([
+      'Refresh',
+      'Redeploy from repo',
+      'Drop from repo',
+      'Adopt into repo',
+      'Tear down on host',
+    ]);
+  });
+
+  it('opens a confirmation naming the host, stack and loss instead of resolving immediately', async () => {
+    renderSummary();
+    fireEvent.click(screen.getByRole('button', { name: 'Tear down on host' }));
+    await screen.findByRole('dialog');
+    expect(screen.getByText(/Tear down on host: alpha\/grafana\?/i)).toBeDefined();
+    expect(screen.getByText(/compose file that exists only on alpha/i)).toBeDefined();
+    expect(mockResolveDrift).not.toHaveBeenCalled();
   });
 
   it('calls onRefresh when the refresh button is clicked', () => {
     const onRefresh = mock(() => {});
-    render(<StackDriftSummary report={report} isLoading={false} onRefresh={onRefresh} />);
+    renderSummary({ onRefresh });
     fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
     expect(onRefresh).toHaveBeenCalledTimes(1);
   });
 
   it('renders nothing when there is no drift and no scan errors', () => {
-    const { container } = render(
-      <StackDriftSummary report={emptyReport} isLoading={false} onRefresh={() => {}} />,
-    );
+    const { container } = renderSummary({ report: emptyReport });
     expect(container.textContent).toBe('');
   });
 
   it('renders the loading alert when the first scan is in flight', () => {
-    render(<StackDriftSummary report={null} isLoading onRefresh={() => {}} />);
+    renderSummary({ report: null, isLoading: true });
     expect(screen.getByText(/Checking agent stack state/i)).toBeDefined();
   });
 
   it('renders scan errors with host and message', () => {
-    render(
-      <StackDriftSummary
-        report={{ ...emptyReport, scanErrors: [{ host: 'alpha', message: 'agent unreachable' }] }}
-        isLoading={false}
-        onRefresh={() => {}}
-      />,
-    );
+    renderSummary({ report: { ...emptyReport, scanErrors: [{ host: 'alpha', message: 'agent unreachable' }] } });
     expect(screen.getByText(/alpha: agent unreachable/i)).toBeDefined();
   });
 

--- a/src/components/stacks/__tests__/StackDriftWarning.test.tsx
+++ b/src/components/stacks/__tests__/StackDriftWarning.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from 'bun:test';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { StackDriftItem } from '@/types/stacks';
+import { STACKS_QUERY_KEY, STACK_DRIFT_QUERY_KEY } from '@/lib/constants/stacks-keys';
 
 const mockResolveDrift = mock(() => Promise.resolve({}));
 
@@ -24,13 +25,15 @@ function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  return function Wrapper({ children }: { children: React.ReactNode }) {
+  const Wrapper = function Wrapper({ children }: { children: React.ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
+  return { Wrapper, queryClient };
 }
 
 function renderWarning() {
-  return render(<StackDriftWarning item={item} />, { wrapper: createWrapper() });
+  const { Wrapper, queryClient } = createWrapper();
+  return { ...render(<StackDriftWarning item={item} />, { wrapper: Wrapper }), queryClient };
 }
 
 describe('StackDriftWarning', () => {
@@ -69,5 +72,21 @@ describe('StackDriftWarning', () => {
         data: { host: 'alpha', stack: 'plex', kind: 'content', resolution: 'trust_agent' },
       }),
     );
+  });
+
+  it('refreshes the drift report when a resolution fails, since the host may already have changed', async () => {
+    mockResolveDrift.mockImplementationOnce(() => Promise.reject(new Error('teardown failed')));
+    const { queryClient } = renderWarning();
+    const invalidated: unknown[] = [];
+    queryClient.invalidateQueries = ((filters: { queryKey: unknown }) => {
+      invalidated.push(filters.queryKey);
+      return Promise.resolve();
+    }) as typeof queryClient.invalidateQueries;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Adopt host version' }));
+    await screen.findByRole('dialog');
+    fireEvent.click(screen.getByRole('button', { name: 'Adopt host version' }));
+
+    await waitFor(() => expect(invalidated).toEqual([STACK_DRIFT_QUERY_KEY, STACKS_QUERY_KEY]));
   });
 });

--- a/src/components/stacks/__tests__/StackDriftWarning.test.tsx
+++ b/src/components/stacks/__tests__/StackDriftWarning.test.tsx
@@ -1,7 +1,15 @@
-import { describe, expect, it } from 'bun:test';
-import { render, screen } from '@testing-library/react';
-import StackDriftWarning from '@/components/stacks/StackDriftWarning';
+import { describe, expect, it, mock } from 'bun:test';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { StackDriftItem } from '@/types/stacks';
+
+const mockResolveDrift = mock(() => Promise.resolve({}));
+
+mock.module('@/data/stacks/functions', () => ({
+  resolveDrift: mockResolveDrift,
+}));
+
+const { default: StackDriftWarning } = await import('@/components/stacks/StackDriftWarning');
 
 const item: StackDriftItem = {
   kind: 'content',
@@ -12,14 +20,54 @@ const item: StackDriftItem = {
   latestDeployStatus: 'succeeded',
 };
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+function renderWarning() {
+  return render(<StackDriftWarning item={item} />, { wrapper: createWrapper() });
+}
+
 describe('StackDriftWarning', () => {
   it('renders a warning naming the drift kind', () => {
-    render(<StackDriftWarning item={item} />);
+    renderWarning();
     expect(screen.getByText(/content drift/i)).toBeDefined();
   });
 
-  it('renders no resolution controls', () => {
-    render(<StackDriftWarning item={item} />);
-    expect(screen.queryAllByRole('button')).toHaveLength(0);
+  it('renders the allowed resolutions for the drift kind', () => {
+    renderWarning();
+    expect(screen.getAllByRole('button').map((btn) => btn.textContent)).toEqual([
+      'Redeploy repo version',
+      'Adopt host version',
+    ]);
+  });
+
+  it('requires confirmation naming the host, stack and what is overwritten', async () => {
+    renderWarning();
+    fireEvent.click(screen.getByRole('button', { name: 'Redeploy repo version' }));
+    await screen.findByRole('dialog');
+    expect(screen.getByText(/Redeploy repo version: alpha\/plex\?/i)).toBeDefined();
+    expect(screen.getByText(/divergent compose file on alpha is overwritten/i)).toBeDefined();
+    expect(screen.getByText(/\.drift-recovery/)).toBeDefined();
+    expect(mockResolveDrift).not.toHaveBeenCalled();
+  });
+
+  it('resolves only after the confirmation is accepted', async () => {
+    renderWarning();
+    fireEvent.click(screen.getByRole('button', { name: 'Adopt host version' }));
+    await screen.findByRole('dialog');
+    expect(mockResolveDrift).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Adopt host version' }));
+    await waitFor(() =>
+      expect(mockResolveDrift).toHaveBeenCalledWith({
+        data: { host: 'alpha', stack: 'plex', kind: 'content', resolution: 'trust_agent' },
+      }),
+    );
   });
 });

--- a/src/components/stacks/__tests__/StacksOverview.test.tsx
+++ b/src/components/stacks/__tests__/StacksOverview.test.tsx
@@ -9,6 +9,7 @@ const mockScanDrift = mock(() => Promise.resolve({
   summary: { total: 0, ghost: 0, untracked: 0, content: 0 },
   scanErrors: [],
 }));
+const mockResolveDrift = mock(() => Promise.resolve({}));
 
 let mockListContext = {
   stacks: [] as { host: string; name: string }[],
@@ -29,6 +30,7 @@ mock.module('@tanstack/react-router', () => ({
 mock.module('@/data/stacks/functions', () => ({
   createStack: mockCreateStack,
   scanDrift: mockScanDrift,
+  resolveDrift: mockResolveDrift,
 }));
 
 let mockCanWrite = true;

--- a/src/data/stacks/__tests__/functions.test.ts
+++ b/src/data/stacks/__tests__/functions.test.ts
@@ -288,11 +288,14 @@ describe('stacks.functions module', () => {
     it('gates on the operator role', async () => {
       const requireRoleSpy = spyOn(requireRoleModule, 'requireRole');
       const { resolveDrift } = await import('../functions');
-      await withStartContext(() =>
-        resolveDrift({ data: { host: 'server1', stack: 'nginx', kind: 'ghost', resolution: 'trust_repo' } }),
-      );
-      expect(requireRoleSpy).toHaveBeenCalledWith('admin', 'operator');
-      requireRoleSpy.mockRestore();
+      try {
+        await withStartContext(() =>
+          resolveDrift({ data: { host: 'server1', stack: 'nginx', kind: 'ghost', resolution: 'trust_repo' } }),
+        );
+        expect(requireRoleSpy).toHaveBeenCalledWith('admin', 'operator');
+      } finally {
+        requireRoleSpy.mockRestore();
+      }
     });
 
     it('refuses a viewer', async () => {

--- a/src/data/stacks/__tests__/functions.test.ts
+++ b/src/data/stacks/__tests__/functions.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, mock, beforeEach } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, spyOn } from 'bun:test';
 import { SYNTHETIC_ADMIN } from '@/lib/auth/types';
 import type { AuthUser } from '@/lib/auth/types';
 import { withStartContext } from '@/lib/test/start-context';
+import * as requireRoleModule from '@/lib/auth/require-role';
 
 // Inject a synthetic admin user so requireRole checks pass in tests.
 // `activeUser` is read at call time, so `withUser` can swap the role for one call.
@@ -95,6 +96,15 @@ const mockScanStackDrift = mock(() => Promise.resolve({
   summary: { total: 0, ghost: 0, untracked: 0, content: 0 },
   scanErrors: [],
 }));
+const mockResolveStackDriftItem = mock((input: { host: string; stack: string; kind: string; resolution: string }) =>
+  Promise.resolve({
+    ...input,
+    recoveryCommitSha: null,
+    commitSha: null,
+    deployId: null,
+    deployStatus: null,
+  }),
+);
 
 mock.module('@/lib/stacks/stack-service', () => ({
   getStackSummaries: mockGetStackSummaries,
@@ -111,6 +121,7 @@ mock.module('@/lib/stacks/stack-service', () => ({
   rejectPendingDeploy: mockRejectPendingDeploy,
   controlStackForHost: mockControlStackForHost,
   scanStackDrift: mockScanStackDrift,
+  resolveStackDriftItem: mockResolveStackDriftItem,
 }));
 
 /**
@@ -140,6 +151,7 @@ describe('stacks.functions module', () => {
     mockRejectPendingDeploy.mockClear();
     mockControlStackForHost.mockClear();
     mockScanStackDrift.mockClear();
+    mockResolveStackDriftItem.mockClear();
   });
 
   describe('exports', () => {
@@ -256,6 +268,48 @@ describe('stacks.functions module', () => {
         withUser(viewer, () => withStartContext(() => scanDrift())),
       ).rejects.toThrow('Insufficient permissions');
       expect(mockScanStackDrift).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resolveDrift', () => {
+    it('delegates the validated payload to resolveStackDriftItem', async () => {
+      const { resolveDrift } = await import('../functions');
+      await withStartContext(() =>
+        resolveDrift({ data: { host: 'server1', stack: 'nginx', kind: 'untracked', resolution: 'remove' } }),
+      );
+      expect(mockResolveStackDriftItem).toHaveBeenCalledWith({
+        host: 'server1',
+        stack: 'nginx',
+        kind: 'untracked',
+        resolution: 'remove',
+      });
+    });
+
+    it('gates on the operator role', async () => {
+      const requireRoleSpy = spyOn(requireRoleModule, 'requireRole');
+      const { resolveDrift } = await import('../functions');
+      await withStartContext(() =>
+        resolveDrift({ data: { host: 'server1', stack: 'nginx', kind: 'ghost', resolution: 'trust_repo' } }),
+      );
+      expect(requireRoleSpy).toHaveBeenCalledWith('admin', 'operator');
+      requireRoleSpy.mockRestore();
+    });
+
+    it('refuses a viewer', async () => {
+      const requireRoleSpy = spyOn(requireRoleModule, 'requireRole').mockReturnValue(() => {
+        throw new requireRoleModule.ForbiddenError();
+      });
+      const { resolveDrift } = await import('../functions');
+      try {
+        await expect(
+          withStartContext(() =>
+            resolveDrift({ data: { host: 'server1', stack: 'nginx', kind: 'ghost', resolution: 'trust_repo' } }),
+          ),
+        ).rejects.toThrow(/Insufficient permissions/);
+      } finally {
+        requireRoleSpy.mockRestore();
+      }
+      expect(mockResolveStackDriftItem).not.toHaveBeenCalled();
     });
   });
 

--- a/src/data/stacks/__tests__/schemas.test.ts
+++ b/src/data/stacks/__tests__/schemas.test.ts
@@ -6,6 +6,7 @@ import {
   saveComposeFileSchema,
   updateStackIconSchema,
   controlStackSchema,
+  resolveDriftSchema,
 } from '../schemas';
 
 describe('getStackDetailSchema', () => {
@@ -182,5 +183,33 @@ describe('controlStackSchema', () => {
     expect(() =>
       controlStackSchema.parse({ stack: 's', host: '', action: 'start', scope: 'stack' })
     ).toThrow();
+  });
+});
+
+describe('resolveDriftSchema', () => {
+  const valid = { stack: 'plex', host: 'alpha', kind: 'untracked', resolution: 'remove' };
+
+  it('accepts every drift kind and resolution pair', () => {
+    for (const kind of ['ghost', 'untracked', 'content'] as const) {
+      for (const resolution of ['trust_repo', 'trust_agent', 'remove'] as const) {
+        expect(resolveDriftSchema.parse({ ...valid, kind, resolution })).toEqual({ ...valid, kind, resolution });
+      }
+    }
+  });
+
+  it('rejects an unknown resolution', () => {
+    expect(() => resolveDriftSchema.parse({ ...valid, resolution: 'wipe' })).toThrow();
+  });
+
+  it('rejects an unknown drift kind', () => {
+    expect(() => resolveDriftSchema.parse({ ...valid, kind: 'missing' })).toThrow();
+  });
+
+  it('rejects a stack name that escapes its directory', () => {
+    expect(() => resolveDriftSchema.parse({ ...valid, stack: '../etc' })).toThrow();
+  });
+
+  it('rejects an empty host', () => {
+    expect(() => resolveDriftSchema.parse({ ...valid, host: '' })).toThrow();
   });
 });

--- a/src/data/stacks/functions.tsx
+++ b/src/data/stacks/functions.tsx
@@ -1,6 +1,13 @@
 import { createServerFn } from '@tanstack/react-start';
 import { z } from 'zod';
-import type { StackSummary, StackDetail, StackDeployRecord, DeployStatus, StackDriftReport } from '@/types/stacks';
+import type {
+  StackSummary,
+  StackDetail,
+  StackDeployRecord,
+  DeployStatus,
+  StackDriftReport,
+  StackDriftResolutionResult,
+} from '@/types/stacks';
 import { stackSecretsMiddleware } from '@/middleware/stack-secrets-middleware';
 import type { StackControlRequest } from '@/lib/clients/agent-client';
 import { authMiddleware } from '@/middleware/auth-middleware';
@@ -14,6 +21,7 @@ import {
   resumeDeploySchema,
   rejectDeploySchema,
   controlStackSchema,
+  resolveDriftSchema,
 } from '@/data/stacks/schemas';
 
 /**
@@ -84,6 +92,19 @@ export const scanDrift = createServerFn({ method: 'GET' })
     requireRole('admin', 'operator')(context.user);
     const { scanStackDrift } = await import('@/lib/stacks/stack-service');
     return scanStackDrift();
+  });
+
+/**
+ * Apply a resolution to one drifted stack. The service re-scans before acting,
+ * so an outcome from a stale report is rejected rather than applied.
+ */
+export const resolveDrift = createServerFn({ method: 'POST' })
+  .middleware([authMiddleware])
+  .inputValidator(resolveDriftSchema)
+  .handler(async ({ data, context }): Promise<StackDriftResolutionResult> => {
+    requireRole('admin', 'operator')(context.user);
+    const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+    return resolveStackDriftItem(data);
   });
 
 /**

--- a/src/data/stacks/functions.tsx
+++ b/src/data/stacks/functions.tsx
@@ -95,8 +95,7 @@ export const scanDrift = createServerFn({ method: 'GET' })
   });
 
 /**
- * Apply a resolution to one drifted stack. The service re-scans before acting,
- * so an outcome from a stale report is rejected rather than applied.
+ * Apply a resolution to one drifted stack.
  */
 export const resolveDrift = createServerFn({ method: 'POST' })
   .middleware([authMiddleware])

--- a/src/data/stacks/schemas.ts
+++ b/src/data/stacks/schemas.ts
@@ -45,6 +45,13 @@ export const rejectDeploySchema = z.object({
   deployId: z.number().int().positive(),
 });
 
+export const resolveDriftSchema = z.object({
+  stack: stackNameField,
+  host: z.string().min(1),
+  kind: z.enum(['ghost', 'untracked', 'content']),
+  resolution: z.enum(['trust_repo', 'trust_agent', 'remove']),
+});
+
 export const controlStackSchema = z.discriminatedUnion('scope', [
   z.object({
     stack: stackNameField,

--- a/src/lib/mock/functions/stacks.functions.tsx
+++ b/src/lib/mock/functions/stacks.functions.tsx
@@ -1,4 +1,14 @@
-import type { StackSummary, StackDetail, StackDeployRecord, UIDeployRequest, DeployStatus, StackDriftReport } from '@/types/stacks';
+import type {
+  StackSummary,
+  StackDetail,
+  StackDeployRecord,
+  UIDeployRequest,
+  DeployStatus,
+  StackDriftKind,
+  StackDriftReport,
+  StackDriftResolution,
+  StackDriftResolutionResult,
+} from '@/types/stacks';
 
 const MOCK_STACKS: StackSummary[] = [
   // nas01
@@ -449,10 +459,6 @@ export async function ensureVariablesExist(_opts: {
   // No-op in demo mode
 }
 
-export async function scanDrift(): Promise<StackDriftReport> {
-  return { items: [], summary: { total: 0, ghost: 0, untracked: 0, content: 0 }, scanErrors: [] };
-}
-
 export async function controlStack(_opts: {
   data:
     | { host: string; stack: string; action: 'start' | 'stop' | 'restart'; scope: 'stack' }
@@ -465,4 +471,21 @@ export async function controlStack(_opts: {
       };
 }): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 300));
+}
+
+export async function scanDrift(): Promise<StackDriftReport> {
+  return { items: [], summary: { total: 0, ghost: 0, untracked: 0, content: 0 }, scanErrors: [] };
+}
+
+export async function resolveDrift(opts: {
+  data: { stack: string; host: string; kind: StackDriftKind; resolution: StackDriftResolution };
+}): Promise<StackDriftResolutionResult> {
+  await new Promise((resolve) => setTimeout(resolve, 300));
+  return {
+    ...opts.data,
+    recoveryCommitSha: null,
+    commitSha: null,
+    deployId: null,
+    deployStatus: null,
+  };
 }

--- a/src/lib/stacks/__tests__/deploy-outcome-toast.test.ts
+++ b/src/lib/stacks/__tests__/deploy-outcome-toast.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect } from 'bun:test';
 import {
   createDeployToastGate,
   formatDeployOutcome,
+  formatDriftResolutionOutcome,
   truncateDeployMessage,
 } from '@/lib/stacks/deploy-outcome-toast';
 
@@ -223,5 +224,50 @@ describe('createDeployToastGate', () => {
     const gateB = createDeployToastGate();
     expect(gateA.shouldToast(1)).toBe(true);
     expect(gateB.shouldToast(1)).toBe(true);
+  });
+});
+
+describe('formatDriftResolutionOutcome', () => {
+  test('reports a failed deploy as an error instead of claiming the drift was resolved', () => {
+    const toast = formatDriftResolutionOutcome('alpha/plex', {
+      recoveryCommitSha: 'abc1234def5678',
+      deployStatus: 'failed',
+    });
+    expect(toast.severity).toBe('error');
+    expect(toast.message).toBe('Deploy of alpha/plex failed. Host copy archived in abc1234.');
+  });
+
+  test('reports a succeeded deploy as success and names the archive commit', () => {
+    expect(
+      formatDriftResolutionOutcome('alpha/plex', { recoveryCommitSha: 'abc1234def5678', deployStatus: 'succeeded' }),
+    ).toEqual({ message: 'Deploy of alpha/plex succeeded. Host copy archived in abc1234.', severity: 'success' });
+  });
+
+  test('reports a queued deploy as info', () => {
+    const toast = formatDriftResolutionOutcome('alpha/plex', { recoveryCommitSha: null, deployStatus: 'queued' });
+    expect(toast.severity).toBe('info');
+    expect(toast.message).toContain('queued behind an active deploy');
+  });
+
+  test('reports a non-terminal deploy without claiming it finished', () => {
+    expect(
+      formatDriftResolutionOutcome('alpha/plex', { recoveryCommitSha: 'abc1234def5678', deployStatus: 'in_progress' }),
+    ).toEqual({
+      message: 'Drift resolution for alpha/plex is still deploying. Host copy archived in abc1234.',
+      severity: 'info',
+    });
+  });
+
+  test('reports success for a resolution that runs no deploy', () => {
+    expect(
+      formatDriftResolutionOutcome('alpha/grafana', { recoveryCommitSha: 'abc1234def5678', deployStatus: null }),
+    ).toEqual({ message: 'Resolved drift for alpha/grafana. Host copy archived in abc1234.', severity: 'success' });
+  });
+
+  test('omits the archive clause when the resolution archived nothing', () => {
+    expect(formatDriftResolutionOutcome('alpha/plex', { recoveryCommitSha: null, deployStatus: null })).toEqual({
+      message: 'Resolved drift for alpha/plex.',
+      severity: 'success',
+    });
   });
 });

--- a/src/lib/stacks/__tests__/stack-drift-resolution.test.ts
+++ b/src/lib/stacks/__tests__/stack-drift-resolution.test.ts
@@ -292,6 +292,19 @@ describe('resolveStackDriftItem', () => {
       expect(events).toEqual(['inventory', 'compose']);
     });
 
+    test('an empty host compose aborts before teardown and archives nothing', async () => {
+      composeResponse = () =>
+        Promise.resolve({ stack: 'grafana', composeContent: '  \n\t', composeHash: 'agent-hash' });
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'grafana', kind: 'untracked', resolution: 'remove' }),
+      ).rejects.toThrow(/aborted and the host was left untouched\. The agent returned an empty compose file/);
+
+      expect(events).toEqual(['inventory', 'compose']);
+      expect(await recoveryFiles()).toEqual([]);
+    });
+
     test('a failed teardown surfaces the agent logs and keeps the archive', async () => {
       teardownResponse = () => Promise.resolve({ success: false, logs: 'network in use' });
       const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
@@ -301,6 +314,17 @@ describe('resolveStackDriftItem', () => {
       ).rejects.toThrow(/network in use/);
 
       expect(await recoveryFiles()).toHaveLength(1);
+    });
+
+    test('a failed teardown names the recovery commit and says the host may be partly torn down', async () => {
+      teardownResponse = () => Promise.resolve({ success: false, logs: 'network in use' });
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'grafana', kind: 'untracked', resolution: 'remove' }),
+      ).rejects.toThrow(
+        /the host may be partly torn down, and re-running this resolution is safe\. The host copy is archived in [0-9a-f]{7}\./,
+      );
     });
   });
 
@@ -326,6 +350,23 @@ describe('resolveStackDriftItem', () => {
 
       const [request] = executeMock.mock.calls[0] as [DeployRequest];
       expect(request).toMatchObject({ composeContent: REPO_COMPOSE, forceRecreate: true });
+    });
+
+    test('a redeploy that never starts names the recovery commit and warns the compose may be gone', async () => {
+      executeMock = mock(() => {
+        events.push('deploy');
+        return Promise.reject(new Error('pipeline unavailable'));
+      });
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'content', resolution: 'trust_repo' }),
+      ).rejects.toThrow(
+        /Could not start the redeploy of "alpha\/plex"; the host compose file may already be overwritten, and re-running this resolution is safe\. The host copy is archived in [0-9a-f]{7}\. pipeline unavailable/,
+      );
+
+      expect(events).toEqual(['inventory', 'compose', 'deploy']);
+      expect(await recoveryFiles()).toHaveLength(1);
     });
 
     test('trust_agent adopts the host version over the repo version without an archive', async () => {

--- a/src/lib/stacks/__tests__/stack-drift-resolution.test.ts
+++ b/src/lib/stacks/__tests__/stack-drift-resolution.test.ts
@@ -1,0 +1,433 @@
+import { describe, test, expect, mock, beforeEach, afterEach, spyOn } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import type { AgentStackInventoryEntry, AgentStackInventoryError } from '@homelab-manager/agent/types';
+import type { DeployRecord, DeployRequest } from '@/lib/deploy/types';
+import type { DeployPipeline } from '@/lib/deploy/pipeline';
+import * as gitConfig from '@/lib/config/git-config';
+import * as pipelineFactory from '@/lib/deploy/pipeline-factory';
+import * as repoModule from '@/lib/git/repo';
+import { initBareRepo, commitFiles, listFilesInRepo, readFileFromRepo } from '@/lib/git/repo';
+import { MANIFEST, composePath } from '@/lib/stacks/stack-repo-layout';
+import { getTestTmpDir } from '@/lib/test/tmp-dir';
+
+const AGENT_COMPOSE = 'services:\n  plex:\n    image: plex:host-only\n';
+const REPO_COMPOSE = 'services:\n  plex:\n    image: plex:repo\n';
+
+/** Ordered log of every side effect the resolution reaches, so ordering assertions do not depend on mock call counts alone. */
+let events: string[] = [];
+let inventory: AgentStackInventoryEntry[] = [];
+let inventoryErrors: AgentStackInventoryError[] = [];
+let composeResponse: () => Promise<{ stack: string; composeContent: string; composeHash: string }>;
+let teardownResponse: () => Promise<{ success: boolean; logs: string }>;
+let latestDeploys: DeployRecord[] = [];
+let agentConstructions = 0;
+let privateKeyDecrypts = 0;
+
+mock.module('@/lib/clients/database-client', () => ({
+  databaseConnectionManager: { getClient: () => Promise.resolve({ getPool: () => ({}) }) },
+}));
+
+mock.module('@/lib/config/database-config', () => ({
+  loadDatabaseConfig: () => ({}),
+}));
+
+mock.module('@/lib/database/repositories/deploy-repository', () => ({
+  DeployRepository: class {
+    getLatestDeployPerStack = () => Promise.resolve(latestDeploys);
+  },
+}));
+
+mock.module('@/lib/database/repositories/host-repository', () => ({
+  HostRepository: class {
+    findAll = () => Promise.resolve([
+      { name: 'alpha', agentUrl: 'http://alpha:3001', capabilities: { docker: true } },
+    ]);
+    findByName = (name: string) =>
+      Promise.resolve(
+        name === 'alpha' ? { name: 'alpha', agentUrl: 'http://alpha:3001', capabilities: { docker: true } } : null,
+      );
+  },
+}));
+
+mock.module('@/lib/clients/agent-client', () => ({
+  AgentClient: class {
+    constructor() {
+      agentConstructions++;
+    }
+    getStackInventory = () => {
+      events.push('inventory');
+      return Promise.resolve({ stacks: inventory, errors: inventoryErrors });
+    };
+    getStackCompose = () => {
+      events.push('compose');
+      return composeResponse();
+    };
+    teardown = () => {
+      events.push('teardown');
+      return teardownResponse();
+    };
+  },
+}));
+
+mock.module('@/lib/database/repositories/agent-keypairs-repository', () => ({
+  AgentKeypairsRepository: class {
+    getPrivateKeyForHost = () => {
+      privateKeyDecrypts++;
+      return Promise.resolve({ kty: 'OKP', crv: 'Ed25519', x: 'x', d: 'd' });
+    };
+  },
+}));
+
+mock.module('@/lib/crypto/agent-jwt', () => ({ signAgentJwt: () => Promise.resolve('jwt') }));
+mock.module('@/lib/crypto/master-key', () => ({ loadMasterKeyring: () => Promise.resolve({}) }));
+
+function deployRecord(commitSha: string, overrides?: Partial<DeployRecord>): DeployRecord {
+  return {
+    id: 1,
+    stack: 'plex',
+    host: 'alpha',
+    commitSha,
+    composeHash: 'compose-hash',
+    envHash: 'env-hash',
+    status: 'succeeded',
+    trigger: 'ui',
+    action: 'deploy',
+    forceRecreate: false,
+    logs: null,
+    createdAt: new Date('2026-05-01T00:00:00Z'),
+    postSuccess: null,
+    ...overrides,
+  };
+}
+
+/** sha256 of the compose the fake agent serves, so inventory hashes can agree or disagree with the repo on purpose. */
+async function hashOf(content: string): Promise<string> {
+  const { computeHash } = await import('@/lib/deploy/change-detection');
+  return computeHash(content);
+}
+
+describe('resolveStackDriftItem', () => {
+  let testDir: string;
+  let repoPath: string;
+  let headSha: string;
+  let loadGitConfigSpy: ReturnType<typeof spyOn>;
+  let createDeployPipelineSpy: ReturnType<typeof spyOn>;
+  let executeMock: ReturnType<typeof mock>;
+
+  beforeEach(async () => {
+    events = [];
+    inventory = [];
+    inventoryErrors = [];
+    latestDeploys = [];
+    agentConstructions = 0;
+    privateKeyDecrypts = 0;
+    composeResponse = () =>
+      Promise.resolve({ stack: 'plex', composeContent: AGENT_COMPOSE, composeHash: 'agent-hash' });
+    teardownResponse = () => Promise.resolve({ success: true, logs: 'down' });
+
+    testDir = mkdtempSync(join(getTestTmpDir(), 'drift-resolve-'));
+    repoPath = join(testDir, 'test.git');
+    await initBareRepo(repoPath);
+    headSha = await commitFiles(repoPath, () => ({
+      files: [
+        { path: MANIFEST, content: 'stacks:\n  plex:\n    host: alpha\n    autoDeploy: false\n' },
+        { path: composePath('plex'), content: REPO_COMPOSE },
+      ],
+      message: 'seed',
+      author: { name: 'test', email: 'test@test.com' },
+    }));
+
+    loadGitConfigSpy = spyOn(gitConfig, 'loadGitConfig').mockReturnValue({
+      reposDir: testDir,
+      repoName: 'test',
+      repoPath,
+    });
+
+    executeMock = mock((request: DeployRequest) => {
+      events.push('deploy');
+      return Promise.resolve({ deployId: 42, status: 'succeeded' as const, logs: `deployed ${request.stack}` });
+    });
+    createDeployPipelineSpy = spyOn(pipelineFactory, 'createDeployPipeline').mockResolvedValue({
+      pipeline: { execute: (request: DeployRequest) => executeMock(request) } as unknown as DeployPipeline,
+      deployRepo: {} as never,
+      stackRepoWriter: {} as never,
+    });
+  });
+
+  afterEach(() => {
+    loadGitConfigSpy.mockRestore();
+    createDeployPipelineSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  async function recoveryFiles(): Promise<string[]> {
+    return (await listFilesInRepo(repoPath)).filter((path) => path.startsWith('.drift-recovery/'));
+  }
+
+  describe('ghost drift', () => {
+    beforeEach(() => {
+      latestDeploys = [deployRecord(headSha)];
+      inventory = [];
+    });
+
+    test('trust_repo deploys the repo version and archives nothing', async () => {
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      const result = await resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'ghost', resolution: 'trust_repo' });
+
+      expect(events).toEqual(['inventory', 'deploy']);
+      expect(result).toEqual({
+        host: 'alpha',
+        stack: 'plex',
+        kind: 'ghost',
+        resolution: 'trust_repo',
+        recoveryCommitSha: null,
+        commitSha: null,
+        deployId: 42,
+        deployStatus: 'succeeded',
+      });
+      const [request] = executeMock.mock.calls[0] as [DeployRequest];
+      expect(request.action).toBe('deploy');
+      expect(request).toMatchObject({ composeContent: REPO_COMPOSE, host: 'alpha' });
+      expect(await recoveryFiles()).toEqual([]);
+    });
+
+    test('trust_agent drops the stack from the repo without touching the host', async () => {
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      const result = await resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'ghost', resolution: 'trust_agent' });
+
+      expect(events).toEqual(['inventory']);
+      expect(result.commitSha).toBeString();
+      expect(result.deployId).toBeNull();
+      expect(await readFileFromRepo(repoPath, MANIFEST)).not.toContain('plex');
+      expect(await listFilesInRepo(repoPath)).not.toContain(composePath('plex'));
+    });
+
+    test('rejects the remove resolution', async () => {
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'ghost', resolution: 'remove' }),
+      ).rejects.toThrow(/does not apply to ghost drift/);
+      expect(events).toEqual(['inventory']);
+    });
+
+    test('builds one agent client and decrypts the host key once', async () => {
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      await resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'ghost', resolution: 'trust_repo' });
+
+      expect(agentConstructions).toBe(1);
+      expect(privateKeyDecrypts).toBe(1);
+      expect(events.filter((event) => event === 'inventory')).toHaveLength(1);
+    });
+  });
+
+  describe('untracked drift', () => {
+    beforeEach(async () => {
+      inventory = [{ name: 'grafana', hasComposeFile: true, composeHash: await hashOf(AGENT_COMPOSE) }];
+      composeResponse = () =>
+        Promise.resolve({ stack: 'grafana', composeContent: AGENT_COMPOSE, composeHash: 'agent-hash' });
+    });
+
+    test('trust_agent adopts the host compose into the repo', async () => {
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      const result = await resolveStackDriftItem({
+        host: 'alpha', stack: 'grafana', kind: 'untracked', resolution: 'trust_agent',
+      });
+
+      expect(events).toEqual(['inventory', 'compose']);
+      expect(result.commitSha).toBeString();
+      expect(result.recoveryCommitSha).toBeNull();
+      expect(await readFileFromRepo(repoPath, composePath('grafana'))).toBe(AGENT_COMPOSE);
+      expect(await readFileFromRepo(repoPath, MANIFEST)).toContain('grafana');
+      expect(await recoveryFiles()).toEqual([]);
+    });
+
+    test('remove archives the host compose before tearing the stack down', async () => {
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      const result = await resolveStackDriftItem({
+        host: 'alpha', stack: 'grafana', kind: 'untracked', resolution: 'remove',
+      });
+
+      expect(events).toEqual(['inventory', 'compose', 'teardown']);
+      expect(result.recoveryCommitSha).toBeString();
+
+      const archived = await recoveryFiles();
+      expect(archived).toHaveLength(1);
+      expect(archived[0]).toStartWith('.drift-recovery/alpha/grafana/');
+      expect(await readFileFromRepo(repoPath, archived[0])).toBe(AGENT_COMPOSE);
+    });
+
+    test('trust_repo takes the same teardown path as remove', async () => {
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      await resolveStackDriftItem({ host: 'alpha', stack: 'grafana', kind: 'untracked', resolution: 'trust_repo' });
+
+      expect(events).toEqual(['inventory', 'compose', 'teardown']);
+      expect(await recoveryFiles()).toHaveLength(1);
+    });
+
+    test('a failed compose read aborts before teardown', async () => {
+      composeResponse = () => Promise.reject(new Error('agent refused'));
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'grafana', kind: 'untracked', resolution: 'remove' }),
+      ).rejects.toThrow(/Could not archive the host copy of "alpha\/grafana"/);
+
+      expect(events).toEqual(['inventory', 'compose']);
+      expect(await recoveryFiles()).toEqual([]);
+    });
+
+    test('a failed archive commit aborts before teardown', async () => {
+      const commitSpy = spyOn(repoModule, 'commitFiles').mockRejectedValue(new Error('object store is read-only'));
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+
+      try {
+        await expect(
+          resolveStackDriftItem({ host: 'alpha', stack: 'grafana', kind: 'untracked', resolution: 'remove' }),
+        ).rejects.toThrow(/aborted and the host was left untouched/);
+      } finally {
+        commitSpy.mockRestore();
+      }
+
+      expect(events).toEqual(['inventory', 'compose']);
+    });
+
+    test('a failed teardown surfaces the agent logs and keeps the archive', async () => {
+      teardownResponse = () => Promise.resolve({ success: false, logs: 'network in use' });
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'grafana', kind: 'untracked', resolution: 'remove' }),
+      ).rejects.toThrow(/network in use/);
+
+      expect(await recoveryFiles()).toHaveLength(1);
+    });
+  });
+
+  describe('content drift', () => {
+    beforeEach(async () => {
+      latestDeploys = [deployRecord(headSha)];
+      inventory = [{ name: 'plex', hasComposeFile: true, composeHash: await hashOf(AGENT_COMPOSE) }];
+    });
+
+    test('trust_repo archives the host version before redeploying the repo version', async () => {
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      const result = await resolveStackDriftItem({
+        host: 'alpha', stack: 'plex', kind: 'content', resolution: 'trust_repo',
+      });
+
+      expect(events).toEqual(['inventory', 'compose', 'deploy']);
+      expect(result.recoveryCommitSha).toBeString();
+      expect(result.deployId).toBe(42);
+
+      const archived = await recoveryFiles();
+      expect(archived).toHaveLength(1);
+      expect(await readFileFromRepo(repoPath, archived[0])).toBe(AGENT_COMPOSE);
+
+      const [request] = executeMock.mock.calls[0] as [DeployRequest];
+      expect(request).toMatchObject({ composeContent: REPO_COMPOSE, forceRecreate: true });
+    });
+
+    test('trust_agent adopts the host version over the repo version without an archive', async () => {
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      const result = await resolveStackDriftItem({
+        host: 'alpha', stack: 'plex', kind: 'content', resolution: 'trust_agent',
+      });
+
+      expect(events).toEqual(['inventory', 'compose']);
+      expect(result.recoveryCommitSha).toBeNull();
+      expect(await readFileFromRepo(repoPath, composePath('plex'))).toBe(AGENT_COMPOSE);
+      expect(await readFileFromRepo(repoPath, composePath('plex'), headSha)).toBe(REPO_COMPOSE);
+      expect(await recoveryFiles()).toEqual([]);
+    });
+  });
+
+  describe('re-scan guard', () => {
+    test('refuses when the stack is no longer drifted', async () => {
+      latestDeploys = [deployRecord(headSha)];
+      inventory = [{ name: 'plex', hasComposeFile: true, composeHash: await hashOf(REPO_COMPOSE) }];
+
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'ghost', resolution: 'trust_repo' }),
+      ).rejects.toThrow(/no longer drifted/);
+      expect(events).toEqual(['inventory']);
+    });
+
+    test('refuses when the drift kind changed since the scan', async () => {
+      latestDeploys = [deployRecord(headSha)];
+      inventory = [{ name: 'plex', hasComposeFile: true, composeHash: await hashOf(AGENT_COMPOSE) }];
+
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'ghost', resolution: 'trust_agent' }),
+      ).rejects.toThrow(/drift changed from ghost to content/);
+      expect(await readFileFromRepo(repoPath, MANIFEST)).toContain('plex');
+    });
+
+    test('refuses when the deploy history no longer reports the stack in sync', async () => {
+      latestDeploys = [deployRecord(headSha, { status: 'failed' })];
+      inventory = [];
+
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'ghost', resolution: 'trust_agent' }),
+      ).rejects.toThrow(/no longer drifted/);
+    });
+
+    test('refuses when the agent could not read the target stack', async () => {
+      latestDeploys = [deployRecord(headSha)];
+      inventory = [];
+      inventoryErrors = [{ name: 'plex', message: 'EACCES: permission denied' }];
+
+      const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'ghost', resolution: 'trust_agent' }),
+      ).rejects.toThrow(/could not read "alpha\/plex": EACCES/);
+      expect(events).toEqual(['inventory']);
+      expect(await readFileFromRepo(repoPath, MANIFEST)).toContain('plex');
+    });
+  });
+
+  test('surfaces an unreachable agent and changes nothing', async () => {
+    inventory = [];
+    const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+    const failing = mock(() => Promise.reject(new Error('connect ECONNREFUSED')));
+    mock.module('@/lib/clients/agent-client', () => ({
+      AgentClient: class {
+        getStackInventory = failing;
+      },
+    }));
+
+    try {
+      await expect(
+        resolveStackDriftItem({ host: 'alpha', stack: 'plex', kind: 'ghost', resolution: 'trust_repo' }),
+      ).rejects.toThrow(/ECONNREFUSED/);
+      expect(executeMock).not.toHaveBeenCalled();
+      expect(await listFilesInRepo(repoPath)).toEqual([MANIFEST, composePath('plex')]);
+    } finally {
+      mock.module('@/lib/clients/agent-client', () => ({
+        AgentClient: class {
+          getStackInventory = () => { events.push('inventory'); return Promise.resolve({ stacks: inventory, errors: inventoryErrors }); };
+          getStackCompose = () => { events.push('compose'); return composeResponse(); };
+          teardown = () => { events.push('teardown'); return teardownResponse(); };
+        },
+      }));
+    }
+  });
+
+  test('rejects a stack name that is not a safe path segment', async () => {
+    const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+    await expect(
+      resolveStackDriftItem({ host: 'alpha', stack: '../etc', kind: 'ghost', resolution: 'trust_agent' }),
+    ).rejects.toThrow(/Invalid stack name/);
+    expect(events).toEqual([]);
+  });
+
+  test('rejects a host that is not Docker-capable', async () => {
+    const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+    await expect(
+      resolveStackDriftItem({ host: 'beta', stack: 'plex', kind: 'ghost', resolution: 'trust_agent' }),
+    ).rejects.toThrow(/not found in managed_hosts/);
+  });
+});

--- a/src/lib/stacks/__tests__/stack-drift-resolution.test.ts
+++ b/src/lib/stacks/__tests__/stack-drift-resolution.test.ts
@@ -38,15 +38,15 @@ mock.module('@/lib/database/repositories/deploy-repository', () => ({
   },
 }));
 
+const MANAGED_HOSTS = [
+  { name: 'alpha', agentUrl: 'http://alpha:3001', capabilities: { docker: true } },
+  { name: 'gamma', agentUrl: 'http://gamma:3001', capabilities: { docker: false } },
+];
+
 mock.module('@/lib/database/repositories/host-repository', () => ({
   HostRepository: class {
-    findAll = () => Promise.resolve([
-      { name: 'alpha', agentUrl: 'http://alpha:3001', capabilities: { docker: true } },
-    ]);
-    findByName = (name: string) =>
-      Promise.resolve(
-        name === 'alpha' ? { name: 'alpha', agentUrl: 'http://alpha:3001', capabilities: { docker: true } } : null,
-      );
+    findAll = () => Promise.resolve(MANAGED_HOSTS);
+    findByName = (name: string) => Promise.resolve(MANAGED_HOSTS.find((host) => host.name === name) ?? null);
   },
 }));
 
@@ -424,10 +424,17 @@ describe('resolveStackDriftItem', () => {
     expect(events).toEqual([]);
   });
 
-  test('rejects a host that is not Docker-capable', async () => {
+  test('rejects a host that is not managed', async () => {
     const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
     await expect(
       resolveStackDriftItem({ host: 'beta', stack: 'plex', kind: 'ghost', resolution: 'trust_agent' }),
     ).rejects.toThrow(/not found in managed_hosts/);
+  });
+
+  test('rejects a managed host that is not Docker-capable', async () => {
+    const { resolveStackDriftItem } = await import('@/lib/stacks/stack-service');
+    await expect(
+      resolveStackDriftItem({ host: 'gamma', stack: 'plex', kind: 'ghost', resolution: 'trust_agent' }),
+    ).rejects.toThrow(/not a Docker-capable managed host/);
   });
 });

--- a/src/lib/stacks/__tests__/stack-drift-service.test.ts
+++ b/src/lib/stacks/__tests__/stack-drift-service.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'bun:test';
 import type { DeployRecord } from '@/lib/deploy/types';
-import { buildStackDriftReport, getStackDriftKindLabel } from '@/lib/stacks/stack-drift-service';
+import {
+  buildStackDriftReport,
+  getAllowedStackDriftResolutions,
+  getStackDriftKindLabel,
+  getStackDriftResolutionLabel,
+  isDestructiveStackDriftResolution,
+} from '@/lib/stacks/stack-drift-service';
 
 const HEAD_SHA = 'sha-head';
 
@@ -331,5 +337,38 @@ describe('getStackDriftKindLabel', () => {
     expect(getStackDriftKindLabel('ghost')).toBe('Ghost');
     expect(getStackDriftKindLabel('untracked')).toBe('Untracked');
     expect(getStackDriftKindLabel('content')).toBe('Content Drift');
+  });
+});
+
+describe('getAllowedStackDriftResolutions', () => {
+  it('offers both sides for a stack the repo and the host both know about', () => {
+    expect(getAllowedStackDriftResolutions('ghost')).toEqual(['trust_repo', 'trust_agent']);
+    expect(getAllowedStackDriftResolutions('content')).toEqual(['trust_repo', 'trust_agent']);
+  });
+
+  it('offers adopt or remove for a stack the repo does not track', () => {
+    expect(getAllowedStackDriftResolutions('untracked')).toEqual(['trust_agent', 'remove']);
+  });
+
+  it('labels every offered resolution', () => {
+    for (const kind of ['ghost', 'untracked', 'content'] as const) {
+      for (const resolution of getAllowedStackDriftResolutions(kind)) {
+        expect(getStackDriftResolutionLabel(kind, resolution)).toBeString();
+      }
+    }
+  });
+});
+
+describe('isDestructiveStackDriftResolution', () => {
+  it('treats deploying to an empty host and adopting an untracked stack as additive', () => {
+    expect(isDestructiveStackDriftResolution('ghost', 'trust_repo')).toBe(false);
+    expect(isDestructiveStackDriftResolution('untracked', 'trust_agent')).toBe(false);
+  });
+
+  it('treats everything that discards a version as destructive', () => {
+    expect(isDestructiveStackDriftResolution('ghost', 'trust_agent')).toBe(true);
+    expect(isDestructiveStackDriftResolution('untracked', 'remove')).toBe(true);
+    expect(isDestructiveStackDriftResolution('content', 'trust_repo')).toBe(true);
+    expect(isDestructiveStackDriftResolution('content', 'trust_agent')).toBe(true);
   });
 });

--- a/src/lib/stacks/__tests__/stack-repo-layout.test.ts
+++ b/src/lib/stacks/__tests__/stack-repo-layout.test.ts
@@ -6,6 +6,7 @@ import { initBareRepo, commitFiles } from '@/lib/git/repo';
 import {
   MANIFEST,
   composePath,
+  driftRecoveryPath,
   stackFiles,
   serializeManifest,
   removeStackFromManifest,
@@ -135,5 +136,24 @@ describe('removeStackFromManifest', () => {
     await expect(commitFiles(repoPath, removeStackFromManifest('plex'))).rejects.toThrow(
       'manifest.yaml not found',
     );
+  });
+});
+
+describe('driftRecoveryPath', () => {
+  it('nests archives by host and stack under the recovery directory', () => {
+    expect(driftRecoveryPath('alpha', 'plex', '2026-07-24T10:20:30.400Z')).toBe(
+      '.drift-recovery/alpha/plex/2026-07-24T10-20-30-400Z-docker-compose.yml',
+    );
+  });
+
+  it('keeps an IP-address host name usable as a path segment', () => {
+    expect(driftRecoveryPath('192.168.1.10:2375', 'plex', '2026-07-24T10:20:30.400Z')).toStartWith(
+      '.drift-recovery/192.168.1.10_2375/plex/',
+    );
+  });
+
+  it('stays outside every stack directory, so deleting a stack never sweeps its archives', () => {
+    const path = driftRecoveryPath('alpha', 'plex', '2026-07-24T10:20:30.400Z');
+    expect(stackFiles([path, composePath('plex')], 'plex')).toEqual([composePath('plex')]);
   });
 });

--- a/src/lib/stacks/__tests__/stack-repo-layout.test.ts
+++ b/src/lib/stacks/__tests__/stack-repo-layout.test.ts
@@ -152,6 +152,18 @@ describe('driftRecoveryPath', () => {
     );
   });
 
+  it('neutralizes a lone-dot host segment', () => {
+    expect(driftRecoveryPath('.', 'plex', '2026-07-24T10:20:30.400Z')).toStartWith(
+      '.drift-recovery/_/plex/',
+    );
+  });
+
+  it('neutralizes a parent-dir stack segment', () => {
+    expect(driftRecoveryPath('alpha', '..', '2026-07-24T10:20:30.400Z')).toStartWith(
+      '.drift-recovery/alpha/__/',
+    );
+  });
+
   it('stays outside every stack directory, so deleting a stack never sweeps its archives', () => {
     const path = driftRecoveryPath('alpha', 'plex', '2026-07-24T10:20:30.400Z');
     expect(stackFiles([path, composePath('plex')], 'plex')).toEqual([composePath('plex')]);

--- a/src/lib/stacks/deploy-outcome-toast.ts
+++ b/src/lib/stacks/deploy-outcome-toast.ts
@@ -1,4 +1,5 @@
 import type { DeployAction, DeployStatus, DeployTrigger } from '@/lib/deploy/types';
+import type { StackDriftResolutionResult } from '@/types/stacks';
 import type { ToastSeverity } from '@/hooks/toastAtom';
 
 export interface DeployOutcomeEvent {
@@ -69,6 +70,35 @@ export function formatDeployOutcome(evt: DeployOutcomeEvent): DeployOutcomeToast
 
   const detail = evt.message ? `: ${truncateDeployMessage(evt.message)}` : '';
   return { message: `${base} failed${detail}`, severity: 'error' };
+}
+
+/**
+ * A resolution that ran a deploy reports that deploy's outcome, because the
+ * deploy can fail after the destructive step has already overwritten or torn
+ * down the host's copy.
+ */
+export function formatDriftResolutionOutcome(
+  target: string,
+  result: Pick<StackDriftResolutionResult, 'recoveryCommitSha' | 'deployStatus'>,
+): DeployOutcomeToast {
+  const archived = result.recoveryCommitSha
+    ? ` Host copy archived in ${result.recoveryCommitSha.slice(0, 7)}.`
+    : '';
+
+  if (!result.deployStatus) {
+    return { message: `Resolved drift for ${target}.${archived}`, severity: 'success' };
+  }
+
+  const outcome = formatDeployOutcome({
+    stack: target,
+    action: 'deploy',
+    status: result.deployStatus,
+    trigger: 'ui',
+  });
+  if (!outcome) {
+    return { message: `Drift resolution for ${target} is still deploying.${archived}`, severity: 'info' };
+  }
+  return { message: `${outcome.message}.${archived}`, severity: outcome.severity };
 }
 
 export interface DeployToastGate {

--- a/src/lib/stacks/stack-drift-service.ts
+++ b/src/lib/stacks/stack-drift-service.ts
@@ -9,6 +9,7 @@ import type {
   StackDriftItem,
   StackDriftKind,
   StackDriftReport,
+  StackDriftResolution,
   StackDriftScanError,
 } from '@/types/stacks';
 import { computeSyncStatus } from '@/lib/stacks/stack-mappers';
@@ -43,6 +44,51 @@ const KIND_LABELS: Record<StackDriftKind, string> = {
 
 export function getStackDriftKindLabel(kind: StackDriftKind): string {
   return KIND_LABELS[kind];
+}
+
+/**
+ * Resolutions offered per drift kind, in the order the UI lists them.
+ * `untracked` has no `trust_repo` entry: the repo says nothing about the stack,
+ * so "the repo wins" and "remove it from the host" are the same operation, and
+ * `remove` names it without pretending the repo holds a version to restore.
+ */
+const KIND_RESOLUTIONS: Record<StackDriftKind, StackDriftResolution[]> = {
+  ghost: ['trust_repo', 'trust_agent'],
+  untracked: ['trust_agent', 'remove'],
+  content: ['trust_repo', 'trust_agent'],
+};
+
+const RESOLUTION_LABELS: Record<StackDriftKind, Record<StackDriftResolution, string>> = {
+  ghost: {
+    trust_repo: 'Redeploy from repo',
+    trust_agent: 'Drop from repo',
+    remove: 'Drop from repo',
+  },
+  untracked: {
+    trust_repo: 'Tear down on host',
+    trust_agent: 'Adopt into repo',
+    remove: 'Tear down on host',
+  },
+  content: {
+    trust_repo: 'Redeploy repo version',
+    trust_agent: 'Adopt host version',
+    remove: 'Tear down on host',
+  },
+};
+
+export function getAllowedStackDriftResolutions(kind: StackDriftKind): StackDriftResolution[] {
+  return KIND_RESOLUTIONS[kind];
+}
+
+export function getStackDriftResolutionLabel(kind: StackDriftKind, resolution: StackDriftResolution): string {
+  return RESOLUTION_LABELS[kind][resolution];
+}
+
+/** The two resolutions that only add state: deploying to a host that has nothing, and committing a stack git does not yet track. */
+const NON_DESTRUCTIVE = new Set(['ghost:trust_repo', 'untracked:trust_agent']);
+
+export function isDestructiveStackDriftResolution(kind: StackDriftKind, resolution: StackDriftResolution): boolean {
+  return !NON_DESTRUCTIVE.has(`${kind}:${resolution}`);
 }
 
 export function buildStackDriftReport(input: BuildStackDriftReportInput): StackDriftReport {

--- a/src/lib/stacks/stack-repo-layout.ts
+++ b/src/lib/stacks/stack-repo-layout.ts
@@ -26,6 +26,20 @@ function stackDirPrefix(stackName: string): string {
   return `${stackName}/`;
 }
 
+/** Root of the drift-recovery archive. Leading dot keeps it out of the stack namespace: stack names cannot contain a dot, so `identifyChangedStacks` never matches it against the manifest and a push carrying an archive never triggers a deploy. */
+export const DRIFT_RECOVERY_DIR = '.drift-recovery';
+
+/**
+ * Path for an archived copy of a host's compose file, taken before a drift
+ * resolution destroys it. Colons and dots in the timestamp become hyphens so the
+ * path stays checkout-safe on every platform.
+ */
+export function driftRecoveryPath(host: string, stackName: string, capturedAt: string): string {
+  const safeHost = host.replace(/[^a-zA-Z0-9_.-]/g, '_');
+  const safeTimestamp = capturedAt.replace(/[:.]/g, '-');
+  return `${DRIFT_RECOVERY_DIR}/${safeHost}/${stackName}/${safeTimestamp}-docker-compose.yml`;
+}
+
 /** Filter a set of repo paths down to the ones that belong to a stack, for deletion. */
 export function stackFiles(existingPaths: Iterable<string>, stackName: string): string[] {
   const prefix = stackDirPrefix(stackName);

--- a/src/lib/stacks/stack-repo-layout.ts
+++ b/src/lib/stacks/stack-repo-layout.ts
@@ -29,15 +29,21 @@ function stackDirPrefix(stackName: string): string {
 /** Root of the drift-recovery archive. Leading dot keeps it out of the stack namespace: stack names cannot contain a dot, so `identifyChangedStacks` never matches it against the manifest and a push carrying an archive never triggers a deploy. */
 export const DRIFT_RECOVERY_DIR = '.drift-recovery';
 
+function safeSegment(value: string): string {
+  const replaced = value.replace(/[^a-zA-Z0-9_.-]/g, '_');
+  return /^\.+$/.test(replaced) ? replaced.replace(/\./g, '_') : replaced;
+}
+
 /**
  * Path for an archived copy of a host's compose file, taken before a drift
  * resolution destroys it. Colons and dots in the timestamp become hyphens so the
  * path stays checkout-safe on every platform.
  */
 export function driftRecoveryPath(host: string, stackName: string, capturedAt: string): string {
-  const safeHost = host.replace(/[^a-zA-Z0-9_.-]/g, '_');
+  const safeHost = safeSegment(host);
+  const safeStackName = safeSegment(stackName);
   const safeTimestamp = capturedAt.replace(/[:.]/g, '-');
-  return `${DRIFT_RECOVERY_DIR}/${safeHost}/${stackName}/${safeTimestamp}-docker-compose.yml`;
+  return `${DRIFT_RECOVERY_DIR}/${safeHost}/${safeStackName}/${safeTimestamp}-docker-compose.yml`;
 }
 
 /** Filter a set of repo paths down to the ones that belong to a stack, for deletion. */

--- a/src/lib/stacks/stack-service.ts
+++ b/src/lib/stacks/stack-service.ts
@@ -567,7 +567,6 @@ interface DriftScanInputs {
   currentHeadSha: string | null;
 }
 
-/** Everything a drift classification needs except the agent inventories themselves. */
 async function loadDriftScanInputs(): Promise<DriftScanInputs> {
   const { databaseConnectionManager } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
@@ -639,9 +638,9 @@ export async function scanStackDrift(): Promise<StackDriftReport> {
 }
 
 /**
- * Re-classify drift for one stack on one host, reusing an already-built agent
- * client. Runs the same `buildStackDriftReport` gate the full scan runs, so a
- * resolution can never act on a stack the scan would not report as drifted.
+ * Re-classify drift for one stack on one host. Runs the same
+ * `buildStackDriftReport` gate the full scan runs, so a resolution can never act
+ * on a stack the scan would not report as drifted.
  */
 async function rescanDriftItem(
   agent: AgentClient,
@@ -695,6 +694,9 @@ async function captureAgentCompose(
   const capturedAt = new Date().toISOString();
   try {
     const { composeContent } = await agent.getStackCompose(stack);
+    if (!composeContent.trim()) {
+      throw new Error('The agent returned an empty compose file, so there is nothing to recover from.');
+    }
     return await commitFiles(getRepoPath(), () => ({
       files: [{ path: driftRecoveryPath(host, stack, capturedAt), content: composeContent }],
       message: `Archive ${host}/${stack} compose before ${resolution} of ${kind} drift (${capturedAt})`,
@@ -734,10 +736,34 @@ async function adoptAgentCompose(
   });
 }
 
-async function teardownOnAgent(agent: AgentClient, host: string, stack: string): Promise<void> {
+async function teardownOnAgent(
+  agent: AgentClient,
+  host: string,
+  stack: string,
+  recoveryCommitSha: string,
+): Promise<void> {
   const result = await agent.teardown(stack);
   if (!result.success) {
-    throw new Error(`docker compose down failed for "${host}/${stack}": ${result.logs}`);
+    throw new Error(
+      `docker compose down failed for "${host}/${stack}"; the host may be partly torn down, and re-running this resolution is safe. The host copy is archived in ${recoveryCommitSha.slice(0, 7)}. ${result.logs}`,
+    );
+  }
+}
+
+async function deployAfterCapture(
+  host: string,
+  stack: string,
+  recoveryCommitSha: string,
+): Promise<{ deployId: number; status: DeployStatus; logs: string }> {
+  try {
+    return await triggerStackDeploy({ stack, host, action: 'deploy', forceRecreate: true });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[StackService] drift redeploy failed for "${host}/${stack}":`, err);
+    throw new Error(
+      `Could not start the redeploy of "${host}/${stack}"; the host compose file may already be overwritten, and re-running this resolution is safe. The host copy is archived in ${recoveryCommitSha.slice(0, 7)}. ${message}`,
+      { cause: err },
+    );
   }
 }
 
@@ -800,7 +826,7 @@ export async function resolveStackDriftItem(input: {
   // repo tracks no version to restore, so trusting it means the stack should not run.
   if (kind === 'untracked') {
     const recoveryCommitSha = await captureAgentCompose(agent, host, stack, kind, resolution);
-    await teardownOnAgent(agent, host, stack);
+    await teardownOnAgent(agent, host, stack, recoveryCommitSha);
     return { ...base, ...EMPTY_RESOLUTION, recoveryCommitSha };
   }
 
@@ -809,6 +835,6 @@ export async function resolveStackDriftItem(input: {
   }
 
   const recoveryCommitSha = await captureAgentCompose(agent, host, stack, kind, resolution);
-  const deploy = await triggerStackDeploy({ stack, host, action: 'deploy', forceRecreate: true });
+  const deploy = await deployAfterCapture(host, stack, recoveryCommitSha);
   return { ...base, ...EMPTY_RESOLUTION, recoveryCommitSha, deployId: deploy.deployId, deployStatus: deploy.status };
 }

--- a/src/lib/stacks/stack-service.ts
+++ b/src/lib/stacks/stack-service.ts
@@ -3,16 +3,27 @@
  * Called by server functions in src/data/stacks/functions.tsx.
  */
 
-import type { StackSummary, StackDetail, StackDeployRecord, StackDriftReport, StackDriftScanError } from '@/types/stacks';
+import type {
+  StackSummary,
+  StackDetail,
+  StackDeployRecord,
+  StackDriftItem,
+  StackDriftKind,
+  StackDriftReport,
+  StackDriftResolution,
+  StackDriftResolutionResult,
+  StackDriftScanError,
+} from '@/types/stacks';
 import type { DeployAction, DeployRecord, DeployRequest, DeployStatus } from '@/lib/deploy/types';
 import type { AgentClient, StackControlRequest } from '@/lib/clients/agent-client';
 import type { AgentStackInventoryEntry, AgentStackInventoryError } from '@homelab-manager/agent/types';
+import type { ManagedHost } from '@/lib/database/repositories/host-repository';
 import type { RepoStackSnapshot } from '@/lib/stacks/stack-drift-service';
 import { loadGitConfig } from '@/lib/config/git-config';
 import { readFileFromRepo, commitFiles, FileNotFoundError } from '@/lib/git/repo';
 import { parseManifest } from '@/lib/git/manifest';
 import { saveAndCommitFile } from '@/lib/git/editor-operations';
-import { MANIFEST, composePath, serializeManifest } from '@/lib/stacks/stack-repo-layout';
+import { MANIFEST, composePath, driftRecoveryPath, serializeManifest } from '@/lib/stacks/stack-repo-layout';
 import { createStackRepoWriter } from '@/lib/deploy/stack-repo-writer';
 import {
   manifestEntryToSummary,
@@ -549,16 +560,19 @@ async function loadRepoStacks(): Promise<RepoStackSnapshot[]> {
   );
 }
 
-/**
- * Compare the repo manifest against each Docker host's on-disk stack inventory.
- * Read-only: one agent inventory call per host, no writes anywhere.
- */
-export async function scanStackDrift(): Promise<StackDriftReport> {
+interface DriftScanInputs {
+  repoStacks: RepoStackSnapshot[];
+  hosts: ManagedHost[];
+  latestDeploys: DeployRecord[];
+  currentHeadSha: string | null;
+}
+
+/** Everything a drift classification needs except the agent inventories themselves. */
+async function loadDriftScanInputs(): Promise<DriftScanInputs> {
   const { databaseConnectionManager } = await import('@/lib/clients/database-client');
   const { loadDatabaseConfig } = await import('@/lib/config/database-config');
   const { DeployRepository } = await import('@/lib/database/repositories/deploy-repository');
   const { HostRepository } = await import('@/lib/database/repositories/host-repository');
-  const { buildStackDriftReport } = await import('@/lib/stacks/stack-drift-service');
   const { default: git } = await import('isomorphic-git');
   const fs = await import('node:fs');
 
@@ -571,6 +585,17 @@ export async function scanStackDrift(): Promise<StackDriftReport> {
     new DeployRepository(pool).getLatestDeployPerStack(),
     git.resolveRef({ fs, gitdir: getRepoPath(), ref: 'HEAD' }).catch(() => null),
   ]);
+
+  return { repoStacks, hosts, latestDeploys, currentHeadSha };
+}
+
+/**
+ * Compare the repo manifest against each Docker host's on-disk stack inventory.
+ * Read-only: one agent inventory call per host, no writes anywhere.
+ */
+export async function scanStackDrift(): Promise<StackDriftReport> {
+  const { buildStackDriftReport } = await import('@/lib/stacks/stack-drift-service');
+  const { repoStacks, hosts, latestDeploys, currentHeadSha } = await loadDriftScanInputs();
 
   const dockerHosts = hosts
     .filter((host) => host.capabilities.docker === true)
@@ -611,4 +636,179 @@ export async function scanStackDrift(): Promise<StackDriftReport> {
     agentStackErrorsByHost,
     scanErrors,
   });
+}
+
+/**
+ * Re-classify drift for one stack on one host, reusing an already-built agent
+ * client. Runs the same `buildStackDriftReport` gate the full scan runs, so a
+ * resolution can never act on a stack the scan would not report as drifted.
+ */
+async function rescanDriftItem(
+  agent: AgentClient,
+  host: string,
+  stack: string,
+): Promise<StackDriftItem | null> {
+  const { buildStackDriftReport } = await import('@/lib/stacks/stack-drift-service');
+  const [{ repoStacks, hosts, latestDeploys, currentHeadSha }, inventory] = await Promise.all([
+    loadDriftScanInputs(),
+    agent.getStackInventory(),
+  ]);
+
+  const managedHost = hosts.find((entry) => entry.name === host);
+  if (!managedHost || managedHost.capabilities.docker !== true) {
+    throw new Error(`Host "${host}" is not a Docker-capable managed host.`);
+  }
+
+  const report = buildStackDriftReport({
+    repoStacks: repoStacks.filter((entry) => entry.host === host),
+    hosts: [{ name: host, dockerEnabled: true }],
+    latestDeploys,
+    currentHeadSha,
+    agentStacksByHost: new Map([[host, inventory.stacks]]),
+    agentStackErrorsByHost: new Map([[host, inventory.errors]]),
+    scanErrors: [],
+  });
+
+  const unreadable = report.scanErrors.find((error) => error.stack === stack);
+  if (unreadable) {
+    throw new Error(
+      `The agent on "${host}" could not read "${host}/${stack}": ${unreadable.message}. Refresh the drift scan and retry.`,
+    );
+  }
+
+  return report.items.find((item) => item.stack === stack) ?? null;
+}
+
+/**
+ * Commit the host's copy of a compose file into the repo before a resolution
+ * destroys it. Every failure here throws, and every caller awaits it before the
+ * destructive step, so a failed capture aborts the resolution with the host
+ * untouched.
+ */
+async function captureAgentCompose(
+  agent: AgentClient,
+  host: string,
+  stack: string,
+  kind: StackDriftKind,
+  resolution: StackDriftResolution,
+): Promise<string> {
+  const capturedAt = new Date().toISOString();
+  try {
+    const { composeContent } = await agent.getStackCompose(stack);
+    return await commitFiles(getRepoPath(), () => ({
+      files: [{ path: driftRecoveryPath(host, stack, capturedAt), content: composeContent }],
+      message: `Archive ${host}/${stack} compose before ${resolution} of ${kind} drift (${capturedAt})`,
+      author: SYSTEM_AUTHOR,
+    }));
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[StackService] drift capture failed for "${host}/${stack}":`, err);
+    throw new Error(
+      `Could not archive the host copy of "${host}/${stack}"; ${resolution} aborted and the host was left untouched. ${message}`,
+      { cause: err },
+    );
+  }
+}
+
+async function adoptAgentCompose(
+  agent: AgentClient,
+  host: string,
+  stack: string,
+  kind: StackDriftKind,
+): Promise<string> {
+  const { composeContent } = await agent.getStackCompose(stack);
+
+  return commitFiles(getRepoPath(), (existingFiles) => {
+    const manifestContent = existingFiles.get(MANIFEST);
+    const manifest = manifestContent ? parseManifest(manifestContent) : { stacks: {} };
+    manifest.stacks[stack] = manifest.stacks[stack] ?? { host, autoDeploy: false };
+
+    return {
+      files: [
+        { path: composePath(stack), content: composeContent },
+        { path: MANIFEST, content: serializeManifest(manifest) },
+      ],
+      message: `Adopt ${host}/${stack} compose from the host (${kind} drift)`,
+      author: SYSTEM_AUTHOR,
+    };
+  });
+}
+
+async function teardownOnAgent(agent: AgentClient, host: string, stack: string): Promise<void> {
+  const result = await agent.teardown(stack);
+  if (!result.success) {
+    throw new Error(`docker compose down failed for "${host}/${stack}": ${result.logs}`);
+  }
+}
+
+const EMPTY_RESOLUTION = {
+  recoveryCommitSha: null,
+  commitSha: null,
+  deployId: null,
+  deployStatus: null,
+} satisfies Omit<StackDriftResolutionResult, 'host' | 'stack' | 'kind' | 'resolution'>;
+
+/**
+ * Apply a resolution to a single drifted stack.
+ *
+ * Re-scans before acting so a stale click from an old report cannot drive a
+ * destructive resolution against state that has since changed, and archives the
+ * host's compose into the repo before any step that would otherwise leave it
+ * unrecoverable (`untracked` teardown, `content` overwrite).
+ */
+export async function resolveStackDriftItem(input: {
+  host: string;
+  stack: string;
+  kind: StackDriftKind;
+  resolution: StackDriftResolution;
+}): Promise<StackDriftResolutionResult> {
+  const { host, stack, kind, resolution } = input;
+
+  if (!SAFE_PATH_SEGMENT_PATTERN.test(stack)) {
+    throw new Error(`Invalid stack name "${stack}": must contain only letters, numbers, hyphens, and underscores`);
+  }
+
+  const agent = await getAgentClientForHost(host);
+  const current = await rescanDriftItem(agent, host, stack);
+
+  if (!current) {
+    throw new Error(`"${host}/${stack}" is no longer drifted. Refresh the drift scan and retry.`);
+  }
+  if (current.kind !== kind) {
+    throw new Error(
+      `"${host}/${stack}" drift changed from ${kind} to ${current.kind} since the scan. Refresh the drift scan and retry.`,
+    );
+  }
+
+  const base = { host, stack, kind, resolution };
+
+  if (kind === 'ghost' && resolution === 'trust_repo') {
+    const deploy = await triggerStackDeploy({ stack, host, action: 'deploy' });
+    return { ...base, ...EMPTY_RESOLUTION, deployId: deploy.deployId, deployStatus: deploy.status };
+  }
+
+  if (kind === 'ghost' && resolution === 'trust_agent') {
+    const { commitSha } = await createStackRepoWriter().removeStackFromManifest(stack);
+    return { ...base, ...EMPTY_RESOLUTION, commitSha };
+  }
+
+  if (kind !== 'ghost' && resolution === 'trust_agent') {
+    return { ...base, ...EMPTY_RESOLUTION, commitSha: await adoptAgentCompose(agent, host, stack, kind) };
+  }
+
+  // `trust_repo` and `remove` are the same operation on an untracked stack: the
+  // repo tracks no version to restore, so trusting it means the stack should not run.
+  if (kind === 'untracked') {
+    const recoveryCommitSha = await captureAgentCompose(agent, host, stack, kind, resolution);
+    await teardownOnAgent(agent, host, stack);
+    return { ...base, ...EMPTY_RESOLUTION, recoveryCommitSha };
+  }
+
+  if (resolution === 'remove') {
+    throw new Error(`Resolution "remove" does not apply to ${kind} drift on "${host}/${stack}".`);
+  }
+
+  const recoveryCommitSha = await captureAgentCompose(agent, host, stack, kind, resolution);
+  const deploy = await triggerStackDeploy({ stack, host, action: 'deploy', forceRecreate: true });
+  return { ...base, ...EMPTY_RESOLUTION, recoveryCommitSha, deployId: deploy.deployId, deployStatus: deploy.status };
 }

--- a/src/types/stacks.ts
+++ b/src/types/stacks.ts
@@ -47,6 +47,25 @@ export interface StackDriftReport {
   scanErrors: StackDriftScanError[];
 }
 
+/**
+ * Which side of a drift wins. `remove` is neither side: it discards the stack
+ * from the host without adopting it into the repo.
+ */
+export type StackDriftResolution = 'trust_repo' | 'trust_agent' | 'remove';
+
+export interface StackDriftResolutionResult {
+  host: string;
+  stack: string;
+  kind: StackDriftKind;
+  resolution: StackDriftResolution;
+  /** Commit archiving the agent's compose before it was overwritten or torn down. Null when the resolution discards nothing git does not already hold. */
+  recoveryCommitSha: string | null;
+  /** Commit the resolution itself made in the stack repo (adopt or manifest removal). */
+  commitSha: string | null;
+  deployId: number | null;
+  deployStatus: DeployStatus | null;
+}
+
 /** Summary of a stack as shown in the list view */
 export interface StackSummary {
   name: string;


### PR DESCRIPTION
Stacked on #306 (target that branch, not `main`). #306 is detection only; this adds the resolution actions, split out so the destructive half is reviewed on its own.

## Summary

Adds the three resolution paths for each drift kind, every one behind a confirmation dialog, and makes the one previously unrecoverable action recoverable.

- `ghost` (in repo, absent on agent): `trust_repo` redeploys; `trust_agent` drops the git entry.
- `untracked` (on agent, absent from repo): `trust_agent` adopts into git; `remove` tears down on the host.
- `content` (both, hashes differ): `trust_repo` redeploys the repo version; `trust_agent` adopts the host version.

## Confirmation on everything

`StackDriftResolveDialog.tsx` follows `DeleteStackDialog`: Base UI `Dialog`, Cancel plus a `variant="destructive"` confirm. The body states what the resolution does, what is irreversibly gone (in `text-destructive`, omitted for the two additive resolutions), and where a discarded host copy will be found. Nothing fires on a bare button click.

Buttons and dialog live in one shared `StackDriftActions` used by both `StackDriftSummary` (overview) and `StackDriftWarning` (detail page), so the two surfaces cannot drift apart.

## Capture before destroy

`captureAgentCompose` fetches via the existing `GET /stacks/compose` and commits to `.drift-recovery/<host>/<stack>/<timestamp>-docker-compose.yml`, with a message naming host, stack, resolution and timestamp. Applied to `untracked`+`remove`, `untracked`+`trust_repo` and `content`+`trust_repo`: every path that discards agent-side content.

Fetch and commit sit in one `try`; any failure throws before any destructive call, with a message stating the host was left untouched. `ghost`+`trust_agent` and `content`+`trust_agent` get no archive, since git history already holds what they discard.

The leading dot in `.drift-recovery` is load-bearing: stack names cannot contain a dot, so `identifyChangedStacks` never matches it against the manifest and a push carrying an archive cannot trigger a deploy. It also sits outside `stackFiles()`'s `<stack>/` prefix, so deleting a stack never sweeps its archives. Both are tested.

## One scan, one decrypt

`resolveStackDriftItem` builds the agent client once, then re-scans through a single host-scoped `buildStackDriftReport` reusing that client, refusing if the stack is no longer drifted or its kind changed since the report. The re-scan is deliberate: it stops a stale UI click driving a destructive resolution against changed state. What was removed is the original's three redundant full scans and second private-key decrypt. A test asserts exactly one `AgentClient` construction, one decrypt and one inventory call per resolution.

## Note on `untracked` + `trust_repo`

Not offered as its own button. With only `teardown` available on the agent, "the repo wins" and "remove it from the host" are byte-identical operations, and two identically-behaving buttons is worse than one. `getAllowedStackDriftResolutions('untracked')` returns `['trust_agent', 'remove']`. The service still accepts `trust_repo` for an untracked item and routes it down the same capture-then-teardown branch, so the semantics remain reachable through the server function.

## Testing

`bun run typecheck:all` clean. Per-file, this branch versus #306: new `stack-drift-resolution.test.ts` 18 pass; `stack-drift-service` 14 to 19; `stack-repo-layout` 9 to 12; `data/stacks/functions` 36 to 39; `data/stacks/schemas` 28 to 33; drift components 9 to 12. Zero failures either side.

## Manual verification: NOT DONE

No Docker host or agent was reachable from the environment this was written in. Every path below is covered only by unit tests against a fake agent and a real temporary git repo. **A human must exercise this against two real managed hosts before merge.**

- [ ] `ghost` / `trust_repo`: remove the stack directory on hostA, rescan, resolve. Stack returns with the repo's compose, drift clears, no `.drift-recovery/` commit.
- [ ] `ghost` / `trust_agent`: manifest entry and compose gone from the repo tip, hostA untouched, `git log -p` still shows the deleted compose.
- [ ] `untracked` / `trust_agent`: create a stack on hostB outside the repo, resolve. Repo gains a byte-identical compose and a manifest entry with `autoDeploy: false`; containers keep running.
- [ ] `untracked` / `remove`, ordering: with distinctive content, confirm the `.drift-recovery/` commit lands and matches the host file exactly, and only then are the containers gone.
- [ ] `untracked` / `remove`, capture failure aborts: stop the agent between rescan and confirm. UI must surface the archive failure and containers must still be running.
- [ ] `content` / `trust_repo`: edit the compose on hostA, resolve. The divergent version is committed under `.drift-recovery/` before the deploy runs.
- [ ] `content` / `trust_agent`: repo matches the host, previous version reachable in `git log`, no archive commit.
- [ ] Recovery: clone the repo, `git log -- .drift-recovery/`, check out an archived file, redeploy it, confirm a working stack.
- [ ] Stale click refused: resolve in one tab, then click the same resolution in a second stale tab. Must fail and change nothing. Note that this uses a single stack, so it passes whether or not the multi-stack bug below is present; it is not a substitute for it.
- [ ] Agent unreachable mid-resolution: repo tip unchanged, no deploy record.
- [ ] Role gating: a `viewer` must be rejected with 403.
- [ ] Archives survive a stack delete through the normal delete dialog.

### Added after review

Four gaps the original twelve cannot surface. The first two correspond to #382 and #383, both open and neither fixed here.

- [ ] **Two drifted stacks at once (#382).** Drift two repo-tracked stacks on hostA, say `plex` and `sonarr`, both `content`. Confirm both appear in the report. Resolve `plex` only, then rescan. **`sonarr` must still be listed.** If the list drops to one item, the global-HEAD gate in `buildStackDriftReport` is dropping every other `ghost`/`content` item because the resolution just moved repo HEAD. Clicking `sonarr` from the stale list then produces `"hostA/sonarr" is no longer drifted. Refresh the drift scan and retry.`, which is false, and the operator who refreshes sees an empty list and concludes the drift is gone.
- [ ] **Rescan after a successful teardown (#383).** Run `untracked` / `remove` on hostB, wait for the success toast, then rescan. **The item must be gone.** If it is still reported as `untracked`, the agent's `docker compose down` left the compose file on disk, and re-running the resolution writes a second `.drift-recovery` commit for a no-op `down`. Repeat the check after deleting a stack through the normal delete dialog, which reaches the same agent endpoint and is the most likely way an untracked item comes to exist.
- [ ] **Deploy fails after the archive succeeded.** Run `content` / `trust_repo` where the repo compose parses but cannot start (an image tag that does not exist). The `.drift-recovery/` commit must land first, and the toast must report the deploy failure rather than success: `Deploy of hostA/plex failed: <detail>. Host copy archived in <sha>.` The host copy must be recoverable from that commit.
- [ ] **Post-archive failure messages name the state the host is left in.** Two paths, both after the archive commit has landed, so neither is covered by the capture-failure scenario above. Stop the agent between the archive and the teardown on `untracked` / `remove`: the error must read `docker compose down failed for "hostB/<stack>"; the host may be partly torn down, and re-running this resolution is safe. The host copy is archived in <sha>.` Break the deploy dispatch on `content` / `trust_repo`: the error must read `Could not start the redeploy of "hostA/<stack>"; the host compose file may already be overwritten, and re-running this resolution is safe.` In both cases the drift report must refresh on its own, since the failing mutation invalidates it, and re-running the same resolution must be safe.

---
_Generated by [Claude Code](https://claude.ai/code/session_01E72xKQhMceYgcw4WrtjZau)_


## Summary by CodeRabbit

* **New Features**
  * Added per-stack drift resolution controls with confirmation dialogs describing the expected effects.
  * Supports trusting repository changes, trusting agent changes, or removing untracked stacks.
  * Resolution actions now provide outcome toasts including recovery commit and deployment status when available.
  * Drift recovery archives are captured before destructive operations.
* **Bug Fixes**
  * Rechecks drift conditions before applying a resolution to prevent stale actions.
  * Enforces admin/operator authorization and validates hosts, stack names, drift kinds, and resolution choices.
  * Improved resolution toast messaging across deploy outcome states.
