### PR TITLE
ci: run CI on pull requests targeting any base branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,9 @@ on:
     branches: [main]
     tags:
       - 'v*.*.*'
+  # No branches filter: a mid-stack PR targets its parent PR's branch, not main, and a
+  # filter here silently gives it zero check runs instead of a failure anyone can see.
   pull_request:
-    branches: [main]
 
 # One run per ref: a newer push cancels the in-progress run for the same branch or
 # PR, so rapid merges to main (e.g. a batch of Dependabot PRs) don't each run CI to


### PR DESCRIPTION
## Problem

`ci.yml` filtered the pull_request trigger to `branches: [main]`, so a PR whose base is another PR branch never triggered CI. Four open PRs are affected: #371 (base #306), #293, #294 (base #293) and #295 (base #293). Each has zero check runs.

Zero check runs is the failure mode worth fixing. An empty check-run list reads exactly like "queued and still waiting" through the API and in the PR UI, so a mid-stack PR looks pending indefinitely rather than untested. That is a silent gap rather than a visible one.

## Change

Drop the `branches` filter from `pull_request`. Default event types are unchanged, since the previous form did not set `types` either.

The `push` trigger keeps `branches: [main]` plus the `v*.*.*` tag filter, so nothing about main pushes or release builds changes.

## Why this cannot reach publish or deploy

Both side-effecting jobs were already gated on the event type, not on the branch filter:

- `publish` is `if: github.event_name == 'push'`
- `deploy-demo` is `if: github.event_name == 'push' && github.ref == 'refs/heads/main'`

A pull_request event fails both conditions regardless of base branch, so widening the trigger cannot publish an image or deploy the demo. The jobs that do run on a stacked PR are build/test, agent, agent-updater, demo-build and sonarcloud.

Concurrency is unaffected: the group is keyed on `github.ref`, which is `refs/pull/N/merge` for PR events, so distinct PRs stay independent.

## Follow-up needed after merge

For pull_request events GitHub uses the workflow file from the PR's merge ref, so this fix does not retroactively apply to the existing stacked PRs. Each needs its base merged in to pick up the new trigger, walking up the stack: main into #306, then #306 into #371. Same for #293 and its children.

## Scope

One workflow file, two lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E72xKQhMceYgcw4WrtjZau

`pr-queue session pq-db6c36c3`

---
_Generated by [Claude Code](https://claude.ai/code/session_01E72xKQhMceYgcw4WrtjZau)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks to run for pull requests targeting any branch.
  * Improved coverage for pull requests between related branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->