### PR TITLE
docs: add a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## What and why
+
+<!-- One or two sentences. What changes, and what problem it solves. Link the issue if there is one. -->
+
+## Flow
+
+<!-- The path through the system, not a list of files. Where does this sit, and what moves through it?
+Arrows are good:
+
+  AgentStatsCollector -> docker_stats -> StatsPollService -> /api/docker-stats -> useTimeSeriesStream
+  git push -> post-receive -> DeployRequest -> resolve secrets -> agent -> deploy_history
+
+If the path already exists and you are changing it, show before and after. If it is new, show the whole
+thing. For work with no runtime path (CI, tooling, docs) describe what triggers it and what it gates. -->
+
+## What else this touches
+
+<!-- Other callers of anything whose signature or behavior changed. Migrations, and whether the number
+collides. Anything reading the same table, SSE channel, or settings key. Anything gated on an env var or
+event type. "Nothing outside <x>" is a good answer when it is true; say it rather than leaving this empty. -->
+
+## Verification
+
+<!-- What you ran and what it showed, not what should pass. `bun run typecheck:all` and `bun run test:all`
+at minimum for code changes. Coverage differs between local and CI because some tests skip in CI, so cite
+the CI result for anything coverage-related. Note manual steps separately if a real host was involved. -->


### PR DESCRIPTION
## What and why

The repo has no PR template, so every body invents its own shape. Adds `.github/pull_request_template.md`. This body is filled in using the template itself, so the PR is its own worked example.

## Flow

Not a runtime change. GitHub reads `.github/pull_request_template.md` and prefills the body on every new PR, human or agent. Agents already look for a template before writing a PR body and mirror its headings when one exists, so this steers their output too, which is most of the volume in this queue right now.

Four sections:

- **What and why**, one or two sentences.
- **Flow**, the path through the system rather than a list of files, with before and after when an existing path moves. Two real examples are in the guidance (`AgentStatsCollector -> docker_stats -> StatsPollService -> /api/docker-stats -> useTimeSeriesStream`, and the git-push deploy chain). Non-runtime work describes its trigger instead, which is the branch this PR takes.
- **What else this touches**, adjacency.
- **Verification**, what was run and what it showed.

Guidance lives in HTML comments, so a filled-in body renders clean with no leftover scaffolding.

## What else this touches

Nothing in the build. No workflow, source, or config file is affected, and GitHub picks the file up with no wiring.

It does change agent behavior on every future PR in this repo, which is the intent. `.github/` currently holds only `dependabot.yml`, `scripts/` and `workflows/`, so there is no existing template or `PULL_REQUEST_TEMPLATE/` directory to conflict with.

The five symbols named in the guidance were checked against the tree so the examples cite real seams: `AgentStatsCollector` (`src/worker/collectors/agent-stats-collector.ts`), `StatsPollService` (`src/lib/database/subscription-service.ts`), `useTimeSeriesStream` (`src/hooks/useTimeSeriesStream.ts`), `DeployRequest` (`src/types/stacks.ts`), `post-receive-handler` (`src/lib/git/`). `/api/docker-stats` exists as `src/routes/api/docker-stats.ts`.

## Verification

Markdown only, no code paths touched, so `typecheck:all` and `test:all` have nothing to exercise here. What was verified instead: the file lands at the path GitHub reads, and every symbol and route in the guidance resolves in the current tree (grep output above).

The section on coverage differing between local and CI restates the rule already in CLAUDE.md rather than introducing a new one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E72xKQhMceYgcw4WrtjZau

`pr-queue session pq-db6c36c3`

---
_Generated by [Claude Code](https://claude.ai/code/session_01E72xKQhMceYgcw4WrtjZau)_