### PR TITLE
fix(ci): anchor the counter fixture to a whole minute so migration verification stops flaking

### DIFF
--- a/scripts/migration-verify/assertions.ts
+++ b/scripts/migration-verify/assertions.ts
@@ -2,6 +2,7 @@ import type { Pool } from 'pg';
 import type { Checks } from './checks';
 import {
   ACTIVE_CONTAINER,
+  COUNTER_BUCKET_SAMPLES,
   COUNTER_GUEST,
   DOCKER_HOST,
   DROPPED_TABLES,
@@ -309,7 +310,12 @@ export async function assertCumulativeCounters(pool: Pool, checks: Checks): Prom
     );
     checks.equal(`proxmox_stats.${column} is monotonically increasing`, violations, 0);
 
-    const row = await selectRow<{ last_value: string; avg_value: string; max_value: string }>(
+    const row = await selectRow<{
+      last_value: string;
+      avg_value: string;
+      max_value: string;
+      bucket_samples: string;
+    }>(
       pool,
       `WITH bucketed AS (
          SELECT date_trunc('minute', time) AS bucket, time, ${column} AS value
@@ -324,13 +330,20 @@ export async function assertCumulativeCounters(pool: Pool, checks: Checks): Prom
          (SELECT avg(value) FROM bucketed, newest_bucket
           WHERE bucketed.bucket = newest_bucket.bucket) AS avg_value,
          (SELECT max(value) FROM bucketed, newest_bucket
-          WHERE bucketed.bucket = newest_bucket.bucket) AS max_value`,
+          WHERE bucketed.bucket = newest_bucket.bucket) AS max_value,
+         (SELECT count(*) FROM bucketed, newest_bucket
+          WHERE bucketed.bucket = newest_bucket.bucket) AS bucket_samples`,
       [PROXMOX_HOST, COUNTER_GUEST.entityId, COUNTER_GUEST.entityType]
     );
 
     const lastValue = Number(row?.last_value);
     const avgValue = Number(row?.avg_value);
     const maxValue = Number(row?.max_value);
+    checks.equal(
+      `${column} newest bucket is a whole minute of samples`,
+      Number(row?.bucket_samples),
+      COUNTER_BUCKET_SAMPLES
+    );
     checks.equal(`${column} bucket LAST equals bucket MAX`, lastValue, maxValue);
     checks.differsBy(
       `${column} bucket AVG is not the counter value`,

--- a/scripts/migration-verify/fixture.ts
+++ b/scripts/migration-verify/fixture.ts
@@ -71,6 +71,9 @@ export const COUNTER_GUEST = {
   uptimeStep: 1,
 };
 
+/** Counter rows are one per second, so a whole minute bucket holds 60 of them. */
+export const COUNTER_BUCKET_SAMPLES = Math.min(COUNTER_GUEST.samples, 60);
+
 export const PROXMOX_SUPPORTING_ENTITIES = [
   { entityType: 'cluster', entityId: 'ci-cluster', entityName: 'ci-cluster', node: null },
   { entityType: 'node', entityId: 'ci-node-1', entityName: 'ci-node-1', node: 'ci-node-1' },

--- a/scripts/migration-verify/seed.ts
+++ b/scripts/migration-verify/seed.ts
@@ -197,11 +197,13 @@ const PROXMOX_COLUMNS = `(
   cpu, max_cpu, mem, max_mem, disk, max_disk, uptime, vmid, netin, netout
 )`;
 
+// Anchored to the last second of the previous whole minute: seeding up to now() leaves the newest
+// bucket holding only the seconds elapsed past it, and under 4 samples its AVG converges on its LAST.
 async function seedProxmoxCounters(pool: Pool): Promise<void> {
   await pool.query(
     `INSERT INTO proxmox_stats ${PROXMOX_COLUMNS}
      SELECT
-       now() - make_interval(secs => s),
+       date_trunc('minute', now()) - make_interval(secs => s + 1),
        $1, $2, $3, $4, $5, 'running',
        0.15 + 0.05 * sin(s / 20.0), 4,
        2147483648, 4294967296, 10737418240, 53687091200,


### PR DESCRIPTION
## What and why

`assertCumulativeCounters` fails on roughly 5% of runs depending on the wall-clock second the job starts. The counter fixture seeds one row per second ending at `now()`, so the newest minute bucket holds only the seconds elapsed past the boundary. When that bucket is short, its AVG has not yet separated from its LAST, and the assertion reads the collapse as a rollup that averaged a cumulative counter.

Run 89645822051 hit it exactly: the `upgrade` scenario logged `seeded 8882 rows` at `05:11:00.039`, leaving one row in the newest bucket, and all three counters failed with a difference of `0`.

## Flow

The Migration Verification job's `upgrade` scenario, between the seed and the assertion:

```
seedProxmoxCounters -> proxmox_stats (1 row/sec) -> assertCumulativeCounters
                                                     date_trunc('minute', time)
                                                     -> max(bucket)
                                                     -> AVG vs LAST
```

Only the anchor changes:

```
before:  now() - make_interval(secs => s)                        newest bucket = 0..59 rows
after:   date_trunc('minute', now()) - make_interval(secs => s + 1)   newest bucket = 60 rows
```

Ending on the last second of the previous whole minute makes the bucket under test complete no matter when the job starts. It also keeps `max(time)` out of a freshly opened *hour*, which matters because the `AGGREGATE_TIERS` last-value checks bucket the same guest by hour and would inherit the identical race once a tier is registered.

The assertion now also reads the bucket's sample count, so a change that reintroduces a partial bucket fails by name rather than as an unexplained zero difference.

## What else this touches

Nothing outside `scripts/migration-verify/`. The other seeds were checked and none feeds a bucketed assertion: `seedDockerSparseHour` already anchors to `date_trunc('hour', now()) - 2 hours` and `assertWeightedRollup` derives its window from `min(time)`, which is why the sparse-hour checks have never flaked. `assertIdleContainerIdentity` measures age against `now()` and is unaffected. No migration, table, SSE channel, or settings key is involved, and nothing under `src/` or `agent/` imports these scripts.

## Verification

`bun run typecheck:all` passes (`tsconfig.json` includes `**/*.ts`, so it covers these scripts).

The mechanism was reproduced against a real PostgreSQL 16 rather than argued from the code. Every construct involved is core PostgreSQL, so the shipped `assertCumulativeCounters` runs unmodified against a plain `proxmox_stats` table, and the seed SQL was lifted out of `seed.ts` with `now()` replaced by a literal so the clock could be placed at chosen offsets into the minute:

| offset into minute | newest bucket rows | before | after |
| --- | --- | --- | --- |
| 00.039 (the CI failure) | 1 | FAIL netin, netout, uptime | PASS |
| 00.500 | 1 | FAIL netin, netout, uptime | PASS |
| 01.200 | 2 | FAIL uptime | PASS |
| 30.000 | 31 | PASS | PASS |
| 59.900 | 60 | PASS | PASS |

The two failure widths differ because the threshold is `abs(last) * 1e-6 + 1`. netin and netout step by 4096 and 2048, so two samples already clear it; `uptime` steps by 1 against a base of 86400, so it needs four. That puts the real flake window at the first second of a minute for netin/netout and the first three for uptime, about 5% of runs overall.

`bun run test:all` is not meaningful evidence here: no test file imports `scripts/migration-verify`, and the local run is against bun 1.3.11 while `.bun-version` pins 1.3.14, which produces unrelated cross-file failures under `--isolate` that do not reproduce per-file. CI runs the pinned version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01E72xKQhMceYgcw4WrtjZau)_