### PR TITLE
ci: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 2
 
       - name: Detect dependency changes
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
           filters: |
@@ -38,7 +38,7 @@ jobs:
               - 'bun.lock'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload license report
         if: github.event_name == 'push' || steps.changes.outputs.dependencies == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: license-report
           path: license-report.json
@@ -81,18 +81,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Cache Playwright browser
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: playwright-report/
@@ -120,12 +120,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 2
 
       - name: Detect dependency changes
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
           filters: |
@@ -134,7 +134,7 @@ jobs:
               - 'bun.lock'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: cd agent && bun install --frozen-lockfile
@@ -164,7 +164,7 @@ jobs:
 
       - name: Upload license report
         if: github.event_name == 'push' || steps.changes.outputs.dependencies == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agent-license-report
           path: agent/license-report.json
@@ -176,12 +176,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 2
 
       - name: Detect dependency changes
-        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
         id: changes
         with:
           filters: |
@@ -190,7 +190,7 @@ jobs:
               - 'agent-updater/bun.lock'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: cd agent-updater && bun install --frozen-lockfile
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload license report
         if: github.event_name == 'push' || steps.changes.outputs.dependencies == 'true'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: agent-updater-license-report
           path: agent-updater/license-report.json
@@ -232,10 +232,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -274,12 +274,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -320,7 +320,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
 
@@ -340,7 +340,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -350,11 +350,11 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Extract metadata for web image
         id: meta-web
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/jaredglaser/homelab-manager-web
           tags: |
@@ -365,7 +365,7 @@ jobs:
 
       - name: Extract metadata for worker image
         id: meta-worker
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/jaredglaser/homelab-manager-worker
           tags: |
@@ -376,7 +376,7 @@ jobs:
 
       - name: Extract metadata for agent image
         id: meta-agent
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/jaredglaser/homelab-manager-agent
           tags: |
@@ -387,7 +387,7 @@ jobs:
 
       - name: Extract metadata for agent-updater image
         id: meta-agent-updater
-        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6.2.0
         with:
           images: ghcr.io/jaredglaser/homelab-manager-agent-updater
           tags: |
@@ -397,7 +397,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push web image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           target: production
@@ -408,7 +408,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push worker image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
           target: base
@@ -419,7 +419,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push agent image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./agent
           target: base
@@ -430,7 +430,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=agent
 
       - name: Build and push agent-updater image
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: ./agent-updater
           push: true
@@ -457,10 +457,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -476,13 +476,13 @@ jobs:
           cp .output/public/index.html .output/public/404.html
 
       - name: Configure Pages
-        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: .output/public
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 2
 
       - name: Detect dependency changes
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         with:
           filters: |
@@ -38,7 +38,7 @@ jobs:
               - 'bun.lock'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload license report
         if: github.event_name == 'push' || steps.changes.outputs.dependencies == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: license-report
           path: license-report.json
@@ -81,18 +81,18 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Cache Playwright browser
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
@@ -108,7 +108,7 @@ jobs:
 
       - name: Upload Playwright report
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: playwright-report
           path: playwright-report/
@@ -120,12 +120,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 2
 
       - name: Detect dependency changes
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         with:
           filters: |
@@ -134,7 +134,7 @@ jobs:
               - 'bun.lock'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: cd agent && bun install --frozen-lockfile
@@ -164,7 +164,7 @@ jobs:
 
       - name: Upload license report
         if: github.event_name == 'push' || steps.changes.outputs.dependencies == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: agent-license-report
           path: agent/license-report.json
@@ -176,12 +176,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 2
 
       - name: Detect dependency changes
-        uses: dorny/paths-filter@v4
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4
         id: changes
         with:
           filters: |
@@ -190,7 +190,7 @@ jobs:
               - 'agent-updater/bun.lock'
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: cd agent-updater && bun install --frozen-lockfile
@@ -220,7 +220,7 @@ jobs:
 
       - name: Upload license report
         if: github.event_name == 'push' || steps.changes.outputs.dependencies == 'true'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: agent-updater-license-report
           path: agent-updater/license-report.json
@@ -232,10 +232,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -274,12 +274,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -320,12 +320,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 0
 
       - name: SonarQube Scan
-        uses: SonarSource/sonarqube-scan-action@v8.2.1
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
@@ -340,21 +340,21 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Extract metadata for web image
         id: meta-web
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/jaredglaser/homelab-manager-web
           tags: |
@@ -365,7 +365,7 @@ jobs:
 
       - name: Extract metadata for worker image
         id: meta-worker
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/jaredglaser/homelab-manager-worker
           tags: |
@@ -376,7 +376,7 @@ jobs:
 
       - name: Extract metadata for agent image
         id: meta-agent
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/jaredglaser/homelab-manager-agent
           tags: |
@@ -387,7 +387,7 @@ jobs:
 
       - name: Extract metadata for agent-updater image
         id: meta-agent-updater
-        uses: docker/metadata-action@v6
+        uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
           images: ghcr.io/jaredglaser/homelab-manager-agent-updater
           tags: |
@@ -397,7 +397,7 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push web image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           target: production
@@ -408,7 +408,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push worker image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           target: base
@@ -419,7 +419,7 @@ jobs:
           cache-to: type=gha,mode=max
 
       - name: Build and push agent image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./agent
           target: base
@@ -430,7 +430,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=agent
 
       - name: Build and push agent-updater image
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ./agent-updater
           push: true
@@ -457,10 +457,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -476,13 +476,13 @@ jobs:
           cp .output/public/index.html .output/public/404.html
 
       - name: Configure Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: .output/public
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
       actions: read          # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,13 +29,13 @@ jobs:
       actions: read          # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1.0.176
+        uses: anthropics/claude-code-action@700e7f8316990de46bed556429765647af760efc # v1.0.176
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/sonarqube-autofix.yml
+++ b/.github/workflows/sonarqube-autofix.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Set up Bun
         id: setup-bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: latest
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload dry-run artifacts
         if: ${{ inputs.dry_run }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: sonarqube-triage-dryrun
           path: |

--- a/.github/workflows/sonarqube-autofix.yml
+++ b/.github/workflows/sonarqube-autofix.yml
@@ -40,13 +40,13 @@ jobs:
     steps:
       - name: Checkout repository
         id: checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
 
       - name: Set up Bun
         id: setup-bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: latest
 
@@ -88,7 +88,7 @@ jobs:
 
       - name: Upload dry-run artifacts
         if: ${{ inputs.dry_run }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: sonarqube-triage-dryrun
           path: |


### PR DESCRIPTION
## What and why

Every `uses:` reference in `.github/workflows/*.yml` now names a full 40-character commit SHA with a trailing comment for the release it resolves to. A mutable tag like `@v6` can be repointed by the upstream owner at any time, so today's CI is not reproducible and a compromised or force-moved tag executes new code with this repo's `GITHUB_TOKEN`. Pinning by SHA removes that.

Each SHA is what the ref already in the file resolved to when this commit was made, so no action changes version. This is the pinning half of #379 only; the zizmor findings and Dependabot work in that issue are not touched here.

## Flow

CI trigger (push, PR, `workflow_dispatch`) -> GitHub resolves each `uses:` ref -> action code runs.

Before: the ref was a tag (`@v6`, `@v4.4.0`) for 14 of 17 references, so the resolution step could return different code on two runs of the same commit. Three references in `sonarqube-autofix.yml` were already bare SHAs but carried no version comment, so a reader could not tell which release they were on.

After: every reference resolves to a fixed commit. The `# vX` comment is the form Dependabot reads and rewrites, so the `github-actions` ecosystem entry already in `.github/dependabot.yml` keeps proposing updates exactly as it does today.

## What else this touches

Nothing outside the three workflow files. No job, step, permission, `needs:`, input, or `with:` block changed; the only modified bytes are the `uses:` refs and their new trailing comments. `.github/dependabot.yml` is unchanged, and its existing `package-ecosystem: github-actions` entry at `/` already covers these files.

### Mapping table

| Action | Old ref | New SHA | Comment | How established |
| --- | --- | --- | --- | --- |
| `actions/checkout` (ci, claude) | `v6` | `d23441a48e516b6c34aea4fa41551a30e30af803` | `# v6` | `ls-remote refs/tags/v6`, lightweight tag, no peeled ref |
| `dorny/paths-filter` | `v4` | `7b450fff21473bca461d4b92ce414b9d0420d706` | `# v4` | `ls-remote refs/tags/v4`, lightweight |
| `oven-sh/setup-bun` (ci) | `v2` | `0c5077e51419868618aeaa5fe8019c62421857d6` | `# v2` | `ls-remote refs/tags/v2`, lightweight |
| `actions/upload-artifact` (ci) | `v7` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | `# v7` | `ls-remote refs/tags/v7`, lightweight |
| `actions/cache` | `v4` | `0057852bfaa89a56745cba8c7296529d2fc39830` | `# v4` | `ls-remote refs/tags/v4`, lightweight |
| `SonarSource/sonarqube-scan-action` | `v8.2.1` | `22918119ff8e1ca75a623e15c8296b6ea4fbe28f` | `# v8.2.1` | `ls-remote refs/tags/v8.2.1`, lightweight |
| `docker/login-action` | `v4.4.0` | `af1e73f918a031802d376d3c8bbc3fe56130a9b0` | `# v4.4.0` | `ls-remote refs/tags/v4.4.0`, lightweight |
| `docker/setup-buildx-action` | `v4` | `bb05f3f5519dd87d3ba754cc423b652a5edd6d2c` | `# v4` | `ls-remote refs/tags/v4`, lightweight |
| `docker/metadata-action` | `v6` | `dc802804100637a589fabce1cb79ff13a1411302` | `# v6` | `ls-remote refs/tags/v6`, lightweight |
| `docker/build-push-action` | `v7` | `53b7df96c91f9c12dcc8a07bcb9ccacbed38856a` | `# v7` | `ls-remote refs/tags/v7`, lightweight |
| `actions/configure-pages` | `v6` | `45bfe0192ca1faeb007ade9deae92b16b8254a0d` | `# v6` | `ls-remote refs/tags/v6`, lightweight |
| `actions/upload-pages-artifact` | `v5` | `fc324d3547104276b827a68afc52ff2a11cc49c9` | `# v5` | `ls-remote refs/tags/v5`, lightweight |
| `actions/deploy-pages` | `v5` | `cd2ce8fcbc39b97be8ca5fce6e763baed58fa128` | `# v5` | `ls-remote refs/tags/v5`, lightweight |
| `anthropics/claude-code-action` | `v1.0.176` | `700e7f8316990de46bed556429765647af760efc` | `# v1.0.176` | annotated tag: `refs/tags/v1.0.176` is the tag object `73ada59d5881ff691740755279a34c9af7b8b81d`, `refs/tags/v1.0.176^{}` is the commit; the commit is pinned |
| `actions/checkout` (autofix) | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | unchanged | `# v6.0.2` | SHA matched against `ls-remote --tags`; see below |
| `oven-sh/setup-bun` (autofix) | `0c5077e51419868618aeaa5fe8019c62421857d6` | unchanged | `# v2` | SHA matched against `ls-remote --tags`; see below |
| `actions/upload-artifact` (autofix) | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | unchanged | `# v7` | SHA matched against `ls-remote --tags`; see below |

### Provenance of the three pre-existing pins

Each SHA was matched against the full tag listing of its repo (`git ls-remote --tags <url>` filtered to the SHA). None of them is a tag object; all three appear as unpeeled lightweight tags, and none of the matched tags has a `^{}` peeled line.

- `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd` matches exactly one tag, `refs/tags/v6.0.2`. Comment written as `# v6.0.2`.
- `oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6` matches two tags, `refs/tags/v2` and `refs/tags/v2.2.0`, that is, it is the current tip of the `v2` major tag and the exact release v2.2.0. Comment written as `# v2` to match the other `setup-bun` references in `ci.yml`.
- `actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` matches two tags, `refs/tags/v7` and `refs/tags/v7.0.1`, same situation. Comment written as `# v7`.

### Open question: one genuine version divergence

The inventory suggested three actions might be referenced at two different versions. Two of them turned out not to diverge:

- `oven-sh/setup-bun`: the bare SHA in `sonarqube-autofix.yml` is what `@v2` in `ci.yml` resolves to today. Both sides land on the same commit, v2 / v2.2.0. No divergence.
- `actions/upload-artifact`: the bare SHA in `sonarqube-autofix.yml` is what `@v7` in `ci.yml` resolves to today. Both sides land on the same commit, v7 / v7.0.1. No divergence.

One is real:

- **`actions/checkout` runs at two versions.** `sonarqube-autofix.yml` is pinned to `de0fac2e` = **v6.0.2**. `ci.yml` (8 steps) and `claude.yml` (1 step) used `@v6`, which currently resolves to `d23441a4` = **v6.1.0**. This PR pins each side to what it resolves to, so the split is preserved rather than papered over. Whether to converge `sonarqube-autofix.yml` onto v6.1.0 is a repo-owner call and is deliberately not in this diff.

### Colliding Dependabot PRs

This diff rewrites the same `uses:` lines these PRs bump by floating tag, so all three will conflict. Sequencing is the owner's call; none of them were touched, commented on, or rebased.

- #388, `actions/checkout` 6 to 7
- #389, `actions/cache` 4 to 6
- #387, `anthropics/claude-code-action` 1.0.176 to 1.0.179

## Verification

No application code changed, so `typecheck` and the test suites are not implicated. What was run:

- `uses:` line count before and after, per file: `ci.yml` 38 / 38, `claude.yml` 2 / 2, `sonarqube-autofix.yml` 3 / 3. Unchanged.
- `grep -rhoE 'uses: \S+' .github/workflows/*.yml | sort -u` returns 15 unique refs, every one a 40-hex SHA. No tag-shaped ref remains.
- Assertion that every `uses:` line matches `uses: <action>@[0-9a-f]{40} # v...`: passed for all 43 lines, so no pin is missing its version comment.
- Every SHA re-resolved with a fresh `git ls-remote` after the files were written and compared byte for byte against the file contents. All 15 matched, including `refs/tags/v1.0.176^{}` for the one annotated tag and `refs/tags/v6.0.2` for the pre-existing checkout pin.
- Every tag checked for a peeled `^{}` ref, not just the ones queried directly. Only `anthropics/claude-code-action` has one; the other 14 are lightweight tags where the tag ref is already the commit.
- `python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]"` over all three files: parses clean.
- `git diff -U0 .github/workflows/`: 43 changed lines, every one a `uses:` line. `git status` shows only the three workflow files modified.

The real check is CI on this PR: if a SHA were wrong the affected step would fail to resolve the action.

### Deferred, not fixed here

Noticed while working, out of scope for this PR, worth a follow-up issue:

- `.github/dependabot.yml` already has a `package-ecosystem: github-actions` entry at `/`, so there is no config gap blocking SHA pins from being updated. Nothing to change there.
- zizmor-class, all pre-existing: `ci.yml` sets `persist-credentials: false` on only one of its nine checkout steps (the `e2e` job), leaving the credential-in-workdir pattern on the other eight. `ci.yml` has no top-level `permissions:` default, so jobs without an explicit block get the repo default rather than least privilege. `ci.yml`'s "Check out the merge base" step interpolates `${{ github.event_name }}`, `${{ github.event.pull_request.base.sha }}` and `${{ github.event.before }}` directly into a `run:` script, and `sonarqube-autofix.yml`'s "Check for issues to fix" step interpolates `${{ steps.triage.outputs.issue_count }}` the same way; both are template-injection surfaces even though the values are not attacker-controlled today.
- On the plus side, the `timescale/timescaledb` service image in the `migrations` job is already digest-pinned.

Refs #379 (the SHA-pinning half; zizmor and Dependabot items in that issue remain open).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PrXhCR7eoQ1fLkuCPAFCJR)_