### PR TITLE
test: fix collection-time migration read, dead coverage exclusion, and untested MSW takeover

### DIFF
--- a/bunfig.toml
+++ b/bunfig.toml
@@ -4,7 +4,6 @@ timeout = 2000
 coverageSkipTestFiles = true
 coveragePathIgnorePatterns = [
   "src/data/*/functions.tsx",
-  "src/lib/server-functions/",
   "src/components/settings/ManagedHostsCardConnected.tsx",
   # Custom client entry: browser-only bootstrap, exercised by the e2e suite.
   "src/client.tsx",

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -7,11 +7,11 @@ coveragePathIgnorePatterns = [
   "src/components/settings/ManagedHostsCardConnected.tsx",
   # Custom client entry: browser-only bootstrap, exercised by the e2e suite.
   "src/client.tsx",
-  # MSW mock backend glue (service worker start + demo data sources). The pure
-  # logic (function-id, sse-stream framing, server-fn dispatch) is unit-tested;
-  # these are browser/streaming wiring covered end-to-end by Playwright instead.
+  # MSW mock backend glue (worker setup + demo data sources). The pure logic
+  # (function-id, sse-stream framing, server-fn dispatch, service worker takeover)
+  # is unit-tested; these are browser/streaming wiring covered end-to-end by
+  # Playwright instead.
   "src/lib/mock/browser.ts",
-  "src/lib/mock/start.ts",
   "src/lib/mock/handlers/index.ts",
   "src/lib/mock/handlers/sse.ts",
   "src/lib/mock/functions/**",

--- a/src/lib/database/__tests__/retention-cascade-migrations.test.ts
+++ b/src/lib/database/__tests__/retention-cascade-migrations.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from 'bun:test';
+import { describe, test, expect, beforeAll } from 'bun:test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -22,7 +22,11 @@ function weightedPairs(sql: string): { sumColumn: string; metric: string }[] {
 }
 
 for (const { table, file } of SOURCES) describe(file, () => {
-  const sql = readMigration(file);
+  let sql: string;
+
+  beforeAll(() => {
+    sql = readMigration(file);
+  });
 
   test('runs inside the standard transaction wrapper', () => {
     expect(sql).not.toContain('-- migrate:no-transaction');
@@ -85,7 +89,11 @@ for (const { table, file } of SOURCES) describe(file, () => {
 });
 
 describe('032_proxmox_stats_retention_cascade.sql counter columns', () => {
-  const sql = readMigration('032_proxmox_stats_retention_cascade.sql');
+  let sql: string;
+
+  beforeAll(() => {
+    sql = readMigration('032_proxmox_stats_retention_cascade.sql');
+  });
 
   // netin/netout are cumulative byte counters from the Proxmox API and uptime is monotonic;
   // averaging any of them yields the bucket midpoint, which is a plausible-looking lie.

--- a/src/lib/mock/__tests__/start.test.ts
+++ b/src/lib/mock/__tests__/start.test.ts
@@ -1,0 +1,259 @@
+import { describe, test, expect, beforeEach, afterEach, mock, spyOn, type Mock } from 'bun:test';
+import { startMockServiceWorker } from '@/lib/mock/start';
+
+interface MockedResponseEvent {
+  response: { body: { cancel: () => Promise<void> } | null };
+}
+
+type ResponseMockedHandler = (event: MockedResponseEvent) => void;
+
+interface WorkerStartOptions {
+  serviceWorker: { url: string };
+  onUnhandledRequest: string;
+  quiet: boolean;
+}
+
+const workerStart = mock(async (_options: WorkerStartOptions): Promise<void> => {});
+const workerEventsOn = mock((_event: string, _handler: ResponseMockedHandler): void => {});
+
+mock.module('@/lib/mock/browser', () => ({
+  worker: { start: workerStart, events: { on: workerEventsOn } },
+}));
+
+const TAKEOVER_RELOAD_KEY = 'msw:takeover-reload';
+const ENV_KEYS = ['BASE_URL', 'VITE_ENABLE_MSW', 'VITE_DEMO_MODE'] as const;
+const env = import.meta.env as unknown as Record<string, string | undefined>;
+
+function deferred(): { promise: Promise<void>; resolve: () => void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('startMockServiceWorker', () => {
+  let addEventListener: Mock<(type: string, handler: () => void, options?: { once?: boolean }) => void>;
+  let controllerChange: (() => void) | undefined;
+  let listenerRegistered: { promise: Promise<void>; resolve: () => void };
+  let serviceWorker: { controller: object | null; addEventListener: typeof addEventListener };
+  let reload: Mock<() => void>;
+  let consoleError: Mock<typeof console.error>;
+  let timeoutSpy: Mock<typeof setTimeout> | undefined;
+  let savedEnv: Record<string, string | undefined>;
+
+  function setController(controller: object | null): void {
+    serviceWorker.controller = controller;
+  }
+
+  function stubTimeout(mode: 'immediate' | 'never'): void {
+    timeoutSpy = spyOn(globalThis, 'setTimeout').mockImplementation(((
+      callback: () => void,
+    ): ReturnType<typeof setTimeout> => {
+      if (mode === 'immediate') callback();
+      return 0 as unknown as ReturnType<typeof setTimeout>;
+    }) as unknown as typeof setTimeout);
+  }
+
+  beforeEach(() => {
+    workerStart.mockClear();
+    workerEventsOn.mockClear();
+    sessionStorage.clear();
+
+    controllerChange = undefined;
+    listenerRegistered = deferred();
+    addEventListener = mock((type: string, handler: () => void) => {
+      if (type !== 'controllerchange') return;
+      controllerChange = handler;
+      listenerRegistered.resolve();
+    });
+    serviceWorker = { controller: null, addEventListener };
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: serviceWorker,
+      configurable: true,
+      writable: true,
+    });
+
+    reload = mock(() => {});
+    Object.defineProperty(window.location, 'reload', {
+      value: reload,
+      configurable: true,
+      writable: true,
+    });
+
+    consoleError = spyOn(console, 'error').mockImplementation(() => {});
+
+    savedEnv = {};
+    for (const key of ENV_KEYS) {
+      savedEnv[key] = env[key];
+      delete env[key];
+    }
+  });
+
+  afterEach(() => {
+    timeoutSpy?.mockRestore();
+    timeoutSpy = undefined;
+    consoleError.mockRestore();
+    Reflect.deleteProperty(navigator, 'serviceWorker');
+    for (const key of ENV_KEYS) {
+      if (savedEnv[key] === undefined) delete env[key];
+      else env[key] = savedEnv[key];
+    }
+  });
+
+  test('registers the worker script at the origin root when no base path is set', async () => {
+    setController({});
+
+    await startMockServiceWorker();
+
+    expect(workerStart).toHaveBeenCalledTimes(1);
+    const options = workerStart.mock.calls[0][0];
+    expect(options.serviceWorker.url).toBe('/mockServiceWorker.js');
+    expect(options.onUnhandledRequest).toBe('bypass');
+    expect(options.quiet).toBe(true);
+  });
+
+  test('registers the worker script under the deploy base path', async () => {
+    setController({});
+    env.BASE_URL = '/homelab/';
+
+    await startMockServiceWorker();
+
+    expect(workerStart.mock.calls[0][0].serviceWorker.url).toBe('/homelab/mockServiceWorker.js');
+  });
+
+  test('drains the teed body of every mocked response', async () => {
+    setController({});
+
+    await startMockServiceWorker();
+
+    expect(workerEventsOn).toHaveBeenCalledTimes(1);
+    expect(workerEventsOn.mock.calls[0][0]).toBe('response:mocked');
+
+    const handler = workerEventsOn.mock.calls[0][1];
+    const cancel = mock(async () => {});
+    handler({ response: { body: { cancel } } });
+    expect(cancel).toHaveBeenCalledTimes(1);
+
+    expect(() => handler({ response: { body: null } })).not.toThrow();
+  });
+
+  test('swallows a cancel that rejects because the consumer already closed the body', async () => {
+    setController({});
+
+    await startMockServiceWorker();
+    const handler = workerEventsOn.mock.calls[0][1];
+
+    let failCancel!: (error: Error) => void;
+    const cancelled = new Promise<void>((_resolve, reject) => {
+      failCancel = reject;
+    });
+
+    expect(() => handler({ response: { body: { cancel: () => cancelled } } })).not.toThrow();
+    failCancel(new Error('stream already cancelled'));
+
+    await cancelled.catch(() => {});
+  });
+
+  test('skips the takeover wait when the worker already controls the page', async () => {
+    setController({});
+    stubTimeout('never');
+
+    await startMockServiceWorker();
+
+    expect(addEventListener).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('resolves without waiting when the environment exposes no service worker', async () => {
+    Object.defineProperty(navigator, 'serviceWorker', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+    stubTimeout('never');
+
+    await startMockServiceWorker();
+
+    expect(workerStart).toHaveBeenCalledTimes(1);
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  test('stays pending until the worker takes control of the page', async () => {
+    stubTimeout('never');
+
+    let settled = false;
+    const started = startMockServiceWorker().then(() => {
+      settled = true;
+    });
+
+    await listenerRegistered.promise;
+    expect(settled).toBe(false);
+
+    setController({});
+    controllerChange?.();
+    await started;
+
+    expect(consoleError).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test('gives up after the 3-second safety net when controllerchange never fires', async () => {
+    env.VITE_DEMO_MODE = 'true';
+    stubTimeout('immediate');
+
+    await startMockServiceWorker();
+
+    expect(timeoutSpy?.mock.calls[0][1]).toBe(3000);
+    expect(consoleError).toHaveBeenCalledTimes(1);
+  });
+
+  test('fails the MSW e2e build instead of degrading to the real backend', async () => {
+    env.VITE_ENABLE_MSW = 'true';
+    stubTimeout('immediate');
+
+    await expect(startMockServiceWorker()).rejects.toThrow(/never took control/);
+    expect(reload).not.toHaveBeenCalled();
+  });
+
+  test('reloads a demo tab once, then leaves it alone', async () => {
+    env.VITE_DEMO_MODE = 'true';
+    stubTimeout('immediate');
+
+    await startMockServiceWorker();
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(TAKEOVER_RELOAD_KEY)).toBe('1');
+
+    await startMockServiceWorker();
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  test('leaves a non-demo, non-e2e build unreloaded and unthrown', async () => {
+    stubTimeout('immediate');
+
+    await startMockServiceWorker();
+
+    expect(reload).not.toHaveBeenCalled();
+    expect(sessionStorage.getItem(TAKEOVER_RELOAD_KEY)).toBeNull();
+  });
+
+  test('does not reload when sessionStorage is unavailable', async () => {
+    env.VITE_DEMO_MODE = 'true';
+    stubTimeout('immediate');
+    const original = Object.getOwnPropertyDescriptor(globalThis, 'sessionStorage');
+    Object.defineProperty(globalThis, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new Error('sessionStorage is disabled');
+      },
+    });
+
+    try {
+      await startMockServiceWorker();
+      expect(reload).not.toHaveBeenCalled();
+    } finally {
+      if (original) Object.defineProperty(globalThis, 'sessionStorage', original);
+      else Reflect.deleteProperty(globalThis, 'sessionStorage');
+    }
+  });
+});


### PR DESCRIPTION
## What and why

Three follow-up items on test and coverage hygiene, plus one investigation that ended in "do not change this".

1. `bunfig.toml` carried `"src/lib/server-functions/"` in `coveragePathIgnorePatterns`. That directory was deleted in #155, and a bare directory with a trailing slash never matched anything in that config in the first place, so the entry read as a working exclusion while excluding nothing. Removed.
2. `retention-cascade-migrations.test.ts` called `readFileSync` in the `describe` callback body, so a missing migration file threw at collection time and dropped nine tests from the run instead of failing one. Moved the read into `beforeAll`.
3. Investigated giving the ZFS mock activity profiles a nonzero `idleBlipScale` to address the ZFS e2e liveness flake. The premise does not hold: every ZFS profile already has one. Nothing changed. Details below.
4. `src/lib/mock/start.ts` had no unit test and was excluded from coverage on the grounds that Playwright covers it; the flow inventory (#384) reports 2 of 20 flows covered, so the service worker takeover race was tested by nothing. Added a unit test at 100% lines and 100% functions and removed the exclusion.

## Flow

No runtime path changes. What changes is what the test and coverage gates see:

    missing migration file -> readMigration in describe body -> collection error, 9 tests never register
    missing migration file -> readMigration in beforeAll     -> 1 failing test with the ENOENT attached

    src/lib/mock/start.ts -> excluded from coverage, no unit test -> takeover race unverified
    src/lib/mock/start.ts -> in the coverage table, start.test.ts -> takeover race asserted per branch

The logic now under test is the takeover race itself: `worker.start()` can resolve a tick before the service worker claims the page, so `startMockServiceWorker` waits for `controllerchange` (with a 3-second safety net) and then, if control still never arrived, throws for the MSW e2e build or reloads a demo tab once per tab.

## What else this touches

Nothing outside the test and coverage configuration. No source module changed: `src/lib/mock/start.ts` itself is untouched, and so are the ZFS mock profiles. No migrations, no SSE channel, no settings key, no env var.

Two coverage-table effects worth knowing:

- `src/lib/mock/start.ts` now enters the coverage denominator. It reports 100% lines / 100% functions on its own test file, so it can only raise the aggregate.
- Removing `"src/lib/server-functions/"` changes nothing measurable, since the pattern matched nothing.

## Verification

- `bun run typecheck`: clean. (`typecheck:all` not run; the agent package is not installed in this worktree.)
- `bun test --isolate src/lib/database/__tests__/retention-cascade-migrations.test.ts`: 34 pass / 0 fail / 99 expect calls, identical before and after the `beforeAll` move.
- `bun test --isolate src/lib/mock/__tests__/start.test.ts`: 12 pass / 0 fail, run three times.
- `bun test --isolate src/lib/mock/__tests__/patterns.test.ts src/lib/mock/__tests__/prng.test.ts`: 39 pass / 0 fail.
- `bun test --isolate --coverage` over `start.test.ts`: `src/lib/mock/start.ts` at 100% funcs / 100% lines.
- Collection-error claim checked directly: with `migrations/031_zfs_stats_retention_cascade.sql` temporarily moved away, the version on `main` reports `25 pass, 0 fail, 1 error` (nine tests missing); this branch reports `25 pass, 1 fail` with the ENOENT on the failing test.
- Exclusion-list audit: `src/data/*/functions.tsx` matches six files and is live (running `src/data/stacks/__tests__/functions.test.ts`, which loads `src/data/stacks/functions.tsx`, keeps that file out of the coverage table). `src/lib/mock/functions/**` matches eight files. Every remaining entry resolves to a file that exists, and none is a bare trailing-slash directory.
- Not run: the full local suite and the coverage gate. Local Bun is 1.3.11 against 1.3.14 in `.bun-version`, and the full suite reports roughly 2800 pass / 520 fail on an unmodified tree here, so the aggregate has to come from CI. Playwright was not run either (no browser, no built target).

### Item 4: mutation results

Each test was checked by breaking the source and confirming the test fails. All nine mutations were killed:

| Mutation of `start.ts` | Killed by |
| --- | --- |
| Drop the `controllerchange` wait entirely | `stays pending until the worker takes control of the page`, `gives up after the 3-second safety net when controllerchange never fires` |
| Drop the 3-second safety-net timer | the whole file: the three tests that depend on the safety net hang and the run never completes |
| Drop the post-wait failure handling | `gives up after the 3-second safety net...`, `fails the MSW e2e build instead of degrading to the real backend`, `reloads a demo tab once, then leaves it alone` |
| `claimTakeoverReload` always allows a reload | `reloads a demo tab once, then leaves it alone`, `does not reload when sessionStorage is unavailable` |
| Drop the base-path trailing-slash strip | `registers the worker script at the origin root when no base path is set`, `registers the worker script under the deploy base path` |
| Drop the mocked-response body drain | `drains the teed body of every mocked response`, `swallows a cancel that rejects because the consumer already closed the body` |
| Wait even when the page is already controlled | `skips the takeover wait when the worker already controls the page` |
| Drop the `navigator.serviceWorker` presence guard | `resolves without waiting when the environment exposes no service worker` |
| Log instead of throwing in the MSW e2e build | `fails the MSW e2e build instead of degrading to the real backend` |

On timers, per CLAUDE.md rule 7: no test awaits a bare `setTimeout`. The pending state is observed through a deferred that the stubbed `addEventListener` resolves, and `globalThis.setTimeout` is spied per test so the safety net either fires immediately or never fires.

### Item 3: no change, premise did not hold

The item assumed the ZFS activity profiles leave `idleBlipScale` at its default of 0. They do not. `src/lib/mock/entities.ts` sets it on all three pool profiles, and the two disk profiles inherit it through object spread:

| Profile | Effective `idleBlipScale` |
| --- | --- |
| `APP_POOL_ACTIVITY` (pool, vdev) | 0.25 |
| `APP_DISK_ACTIVITY` (spreads `APP_POOL_ACTIVITY`) | 0.25 |
| `RUST_POOL_ACTIVITY` (pool, vdev) | 0.20 |
| `RUST_DISK_ACTIVITY` (spreads `RUST_POOL_ACTIVITY`) | 0.20 |
| `SYSTEM_ACTIVITY` (pool, vdev) | 0.30 |

The mechanism also works. Walking every ZFS entity over 6 hours of 1-second samples and comparing each sample against the same profile with `idleBlipScale: 0`, between 6.6% and 13.0% of the samples that would be flat zero come out nonzero, per entity. Neither precondition for the change holds, so the profiles are left alone.

What that does not settle is the flake. `e2e/zfs.e2e.ts` asserts two text changes on a `nas01` row within 8 seconds each, and an idle stretch can still be flat across such a window even with the blips: sampling 24 hours of 1-second data and counting sliding 8-second windows where all four I/O metrics are byte-identical gives application 12.80%, rust 20.70%, system 23.96% (against 26.72% / 37.23% / 49.25% with `idleBlipScale: 0`). The knob already roughly halves the flat-window rate without eliminating it, and pushing it higher trades UI realism for a residual that stays nonzero. The remaining fix looks like it belongs in the spec or in the generator's idle definition, not in this value. Unverified either way here, since Playwright was not run.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PrXhCR7eoQ1fLkuCPAFCJR)_