### PR TITLE
test(ci): verify the stats rollup math in the migration harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,7 +347,6 @@ jobs:
         run: bun scripts/migration-verify/run.ts upgrade
         env:
           MIGRATION_BASE_ROOT: ${{ steps.base.outputs.root }}
-          MIGRATION_VERIFY_SIMULATE_REGRESSION: 'true'
 
       - name: Re-run idempotency
         run: bun scripts/migration-verify/run.ts idempotent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
         run: bun scripts/migration-verify/run.ts upgrade
         env:
           MIGRATION_BASE_ROOT: ${{ steps.base.outputs.root }}
+          MIGRATION_VERIFY_SIMULATE_REGRESSION: 'true'
 
       - name: Re-run idempotency
         run: bun scripts/migration-verify/run.ts idempotent

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,6 +273,7 @@ jobs:
   migrations:
     name: Migration Verification
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     # Pinned by digest: a floating tag (latest-pg16) lets an upstream image push
     # break main with no commit in this repo. This digest is what latest-pg16
@@ -286,12 +287,16 @@ jobs:
           POSTGRES_DB: postgres
         ports:
           - 5432:5432
+        # The log cap is not cosmetic: CI dumps this container's whole log after the last step, and
+        # the policy schedulers write a line per chunk they touch, which pushed the harness's own
+        # check report thousands of lines out of the job log tail.
         options: >-
           --health-cmd "pg_isready -U postgres -d postgres"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 20
           --health-start-period 30s
+          --log-opt max-size=8k
 
     env:
       POSTGRES_HOST: localhost

--- a/scripts/migration-verify/assertions.ts
+++ b/scripts/migration-verify/assertions.ts
@@ -414,7 +414,7 @@ export async function assertRollupBackfill(pool: Pool, checks: Checks): Promise<
   }
 
   await assertBackfillReachedFullHistory(pool, checks);
-  await assertNoFailedPolicyJobs(pool, checks);
+  await assertNoFailedRetentionJobs(pool, checks);
 
   const policies = await pool.query<{ target: string; drop_after: string }>(
     `SELECT
@@ -478,11 +478,14 @@ async function assertBackfillReachedFullHistory(pool: Pool, checks: Checks): Pro
 
 /**
  * The verification databases run at `log_min_messages = 'fatal'`, which hides the server-side ERROR
- * a failed background job leaves behind, so the harness has to read the job status itself. Scoped
- * to the two policies the rollup assertions depend on; compression is excluded because it competes
- * with retention for the same chunks and a loss there says nothing about the aggregate definitions.
+ * a failed background job leaves behind, so the harness has to read the job status itself.
+ *
+ * Retention only. The runner is short enough on background workers that a refresh or compression
+ * policy regularly loses its slot ("out of background workers"), and neither one's run status is
+ * load-bearing here: the harness drives every refresh itself through `runStatsRollupBackfill` and
+ * checks the resulting numbers directly. Retention is the one policy nothing else re-derives.
  */
-async function assertNoFailedPolicyJobs(pool: Pool, checks: Checks): Promise<void> {
+async function assertNoFailedRetentionJobs(pool: Pool, checks: Checks): Promise<void> {
   const available = await selectRow<{ present: boolean }>(
     pool,
     `SELECT to_regclass('timescaledb_information.job_stats') IS NOT NULL AS present`
@@ -500,10 +503,9 @@ async function assertNoFailedPolicyJobs(pool: Pool, checks: Checks): Promise<voi
      LEFT JOIN timescaledb_information.continuous_aggregates ca
        ON ca.materialization_hypertable_schema = j.hypertable_schema
       AND ca.materialization_hypertable_name = j.hypertable_name
-     WHERE s.last_run_status = 'Failed'
-       AND j.proc_name IN ('policy_retention', 'policy_refresh_continuous_aggregate')`
+     WHERE s.last_run_status = 'Failed' AND j.proc_name = 'policy_retention'`
   );
-  checks.equal('no retention or refresh job has failed', failed.join(', ') || 'none', 'none');
+  checks.equal('no retention job has failed', failed.join(', ') || 'none', 'none');
 }
 
 /**

--- a/scripts/migration-verify/assertions.ts
+++ b/scripts/migration-verify/assertions.ts
@@ -9,16 +9,53 @@ import {
   EXPECTED_HYPERTABLES,
   EXPECTED_TABLES,
   IDLE_CONTAINER,
+  NULL_METRIC_HOUR,
   PROXMOX_HOST,
   REMOVED_COLUMNS,
   SPARSE_HOUR,
+  ZFS_ENTITIES,
   ZFS_HOST,
+  ZFS_POOL,
+  nullMetricDilutedAverage,
+  nullMetricRawAverage,
   sparseHourNaiveAverage,
   sparseHourRawAverage,
 } from './fixture';
 
-const WEIGHTED_EPSILON = 1e-9;
+const RELATIVE_EPSILON = 1e-9;
 const MIN_DISCRIMINATION = 0.5;
+/** uptime is the slowest counter in the fixture; its bucket AVG trails its LAST by ~29.5. */
+const COUNTER_AVG_MIN_SEPARATION = 1;
+
+const ROLLUP_SOURCES = ['docker_stats', 'zfs_stats', 'proxmox_stats'];
+
+/**
+ * The hour a single-hour docker fixture occupies, read from the rows themselves: an assertion that
+ * recomputed `date_trunc('hour', now()) - N hours` would miss the bucket whenever the run crosses
+ * an hour boundary after seeding.
+ */
+const FIXTURE_HOUR_CTE = `bounds AS (
+  SELECT date_trunc('hour', min(time)) AS lo
+  FROM docker_stats WHERE host = $1 AND container_id = $2
+)`;
+
+/**
+ * Scaffolding: substitutes the number a regressed aggregate would report so every value check
+ * below can be watched to fail in CI. Set MIGRATION_VERIFY_SIMULATE_REGRESSION=true to arm it.
+ */
+const SIMULATE_REGRESSION = process.env.MIGRATION_VERIFY_SIMULATE_REGRESSION === 'true';
+
+function observed(actual: number, regression: number): number {
+  return SIMULATE_REGRESSION ? regression : actual;
+}
+
+function observedText(actual: string | null, regression: string): string | null {
+  return SIMULATE_REGRESSION ? regression : actual;
+}
+
+function toleranceFor(expected: number): number {
+  return Math.max(1e-9, Math.abs(expected) * RELATIVE_EPSILON);
+}
 
 const EXPECTED_SEGMENTBY: Record<string, string[]> = {
   docker_stats: ['host', 'container_id'],
@@ -28,73 +65,119 @@ const EXPECTED_SEGMENTBY: Record<string, string[]> = {
 };
 
 /**
- * Registry of continuous-aggregate tiers. `assertAggregateTiers` enforces that
- * the database's set of continuous aggregates matches this list exactly.
+ * Registry of continuous-aggregate tiers. `assertAggregateRegistry` enforces that the database's
+ * set of continuous aggregates matches this list exactly, and `assertAggregateTierValues` replays
+ * each tier's aggregation rules against its source for the probe entity.
  */
 export interface AggregateTier {
   view: string;
   sourceTable: string;
-  timeColumn: string;
-  sampleCountColumn: string;
+  /** Doubles as the bucket width and as the boundary that excludes the in-progress bucket. */
+  bucketUnit: 'minute' | 'hour';
+  /** Weight a source row carries in its bucket: raw rows count once, `_1m` rows carry sample_count. */
+  sourceWeight: string;
+  /** `_1m` materializes the bucket mean; `_1h` materializes SUM(metric * sample_count) as `<metric>_sum`. */
+  weightedColumnShape: 'mean' | 'weighted_sum';
+  keyColumns: string[];
+  /** Values for `keyColumns`, identifying the entity whose buckets get replayed. */
+  probeKey: string[];
   weightedAverageColumns: string[];
   lastValueColumns: string[];
 }
 
-/**
- * Both column lists are empty on every tier: the generic checks below filter the
- * source on `container_id` or `entity_id`, truncate the bucket bound to the hour,
- * and read one column name from both view and source, none of which holds for a
- * minute tier, a zfs tier, or the hourly tiers' `<metric>_sum` columns. The
- * aggregates are also created `WITH NO DATA`, so the harness sees them unpopulated.
- */
+const DOCKER_TIER_KEYS = ['host', 'container_id'];
+const DOCKER_PROBE = [DOCKER_HOST, SPARSE_HOUR.containerId];
+const DOCKER_WEIGHTED = [
+  'cpu_percent',
+  'memory_usage',
+  'memory_percent',
+  'network_rx_bytes_per_sec',
+  'block_io_write_bytes_per_sec',
+];
+const DOCKER_LAST = ['container_name', 'image'];
+
+const ZFS_TIER_KEYS = ['host', 'pool', 'entity'];
+const ZFS_PROBE = [ZFS_HOST, ZFS_POOL, ZFS_ENTITIES[0].entity];
+const ZFS_WEIGHTED = [
+  'capacity_alloc',
+  'read_ops_per_sec',
+  'write_bytes_per_sec',
+  'utilization_percent',
+];
+const ZFS_LAST = ['entity_type', 'indent'];
+
+const PROXMOX_TIER_KEYS = ['host', 'entity_type', 'entity_id'];
+const PROXMOX_PROBE = [PROXMOX_HOST, COUNTER_GUEST.entityType, COUNTER_GUEST.entityId];
+/** storage_avail is NULL for every guest row, so it has no weighted average to compare here. */
+const PROXMOX_WEIGHTED = ['cpu', 'mem', 'disk'];
+const PROXMOX_LAST = ['netin', 'netout', 'uptime', 'vmid', 'status'];
+
 export const AGGREGATE_TIERS: AggregateTier[] = [
   {
     view: 'docker_stats_1m',
     sourceTable: 'docker_stats',
-    timeColumn: 'time',
-    sampleCountColumn: 'sample_count',
-    weightedAverageColumns: [],
-    lastValueColumns: [],
+    bucketUnit: 'minute',
+    sourceWeight: '1',
+    weightedColumnShape: 'mean',
+    keyColumns: DOCKER_TIER_KEYS,
+    probeKey: DOCKER_PROBE,
+    weightedAverageColumns: DOCKER_WEIGHTED,
+    lastValueColumns: DOCKER_LAST,
   },
   {
     view: 'docker_stats_1h',
     sourceTable: 'docker_stats_1m',
-    timeColumn: 'time',
-    sampleCountColumn: 'sample_count',
-    weightedAverageColumns: [],
-    lastValueColumns: [],
+    bucketUnit: 'hour',
+    sourceWeight: 'sample_count',
+    weightedColumnShape: 'weighted_sum',
+    keyColumns: DOCKER_TIER_KEYS,
+    probeKey: DOCKER_PROBE,
+    weightedAverageColumns: DOCKER_WEIGHTED,
+    lastValueColumns: DOCKER_LAST,
   },
   {
     view: 'zfs_stats_1m',
     sourceTable: 'zfs_stats',
-    timeColumn: 'time',
-    sampleCountColumn: 'sample_count',
-    weightedAverageColumns: [],
-    lastValueColumns: [],
+    bucketUnit: 'minute',
+    sourceWeight: '1',
+    weightedColumnShape: 'mean',
+    keyColumns: ZFS_TIER_KEYS,
+    probeKey: ZFS_PROBE,
+    weightedAverageColumns: ZFS_WEIGHTED,
+    lastValueColumns: ZFS_LAST,
   },
   {
     view: 'zfs_stats_1h',
     sourceTable: 'zfs_stats_1m',
-    timeColumn: 'time',
-    sampleCountColumn: 'sample_count',
-    weightedAverageColumns: [],
-    lastValueColumns: [],
+    bucketUnit: 'hour',
+    sourceWeight: 'sample_count',
+    weightedColumnShape: 'weighted_sum',
+    keyColumns: ZFS_TIER_KEYS,
+    probeKey: ZFS_PROBE,
+    weightedAverageColumns: ZFS_WEIGHTED,
+    lastValueColumns: ZFS_LAST,
   },
   {
     view: 'proxmox_stats_1m',
     sourceTable: 'proxmox_stats',
-    timeColumn: 'time',
-    sampleCountColumn: 'sample_count',
-    weightedAverageColumns: [],
-    lastValueColumns: [],
+    bucketUnit: 'minute',
+    sourceWeight: '1',
+    weightedColumnShape: 'mean',
+    keyColumns: PROXMOX_TIER_KEYS,
+    probeKey: PROXMOX_PROBE,
+    weightedAverageColumns: PROXMOX_WEIGHTED,
+    lastValueColumns: PROXMOX_LAST,
   },
   {
     view: 'proxmox_stats_1h',
     sourceTable: 'proxmox_stats_1m',
-    timeColumn: 'time',
-    sampleCountColumn: 'sample_count',
-    weightedAverageColumns: [],
-    lastValueColumns: [],
+    bucketUnit: 'hour',
+    sourceWeight: 'sample_count',
+    weightedColumnShape: 'weighted_sum',
+    keyColumns: PROXMOX_TIER_KEYS,
+    probeKey: PROXMOX_PROBE,
+    weightedAverageColumns: PROXMOX_WEIGHTED,
+    lastValueColumns: PROXMOX_LAST,
   },
 ];
 
@@ -205,7 +288,12 @@ export interface RowCountSnapshot {
 
 export async function captureRowCounts(pool: Pool): Promise<RowCountSnapshot> {
   const snapshot: RowCountSnapshot = {};
-  const dockerContainers = [ACTIVE_CONTAINER.id, IDLE_CONTAINER.id, SPARSE_HOUR.containerId];
+  const dockerContainers = [
+    ACTIVE_CONTAINER.id,
+    IDLE_CONTAINER.id,
+    SPARSE_HOUR.containerId,
+    NULL_METRIC_HOUR.containerId,
+  ];
   for (const containerId of dockerContainers) {
     snapshot[`docker_stats/${containerId}`] = await count(
       pool,
@@ -273,82 +361,141 @@ export async function assertIdleContainerIdentity(pool: Pool, checks: Checks): P
 }
 
 /**
- * The sparse hour holds 59 minutes of 60 samples plus one minute of 12. A
- * sample-count weighted rollup reproduces the raw average exactly; an
- * equal-weighted AVG() of per-minute averages is off by about 1.06 points.
+ * `runStatsRollupBackfill` swallows a per-source failure and only skips that source's retention,
+ * so an empty view or a missing policy is how a failed refresh surfaces.
+ */
+export async function assertRollupBackfill(pool: Pool, checks: Checks): Promise<void> {
+  for (const tier of AGGREGATE_TIERS) {
+    const rows = await count(pool, `SELECT count(*) FROM ${tier.view}`);
+    checks.equal(`${tier.view} was materialized by the backfill`, rows > 0, true);
+  }
+
+  const policies = await pool.query<{ target: string; drop_after: string }>(
+    `SELECT
+       COALESCE(ca.view_name, j.hypertable_name) AS target,
+       CASE
+         WHEN (j.config->>'drop_after')::interval = INTERVAL '24 hours' THEN '24 hours'
+         WHEN (j.config->>'drop_after')::interval = INTERVAL '30 days' THEN '30 days'
+         ELSE COALESCE(j.config->>'drop_after', 'unset')
+       END AS drop_after
+     FROM timescaledb_information.jobs j
+     LEFT JOIN timescaledb_information.continuous_aggregates ca
+       ON ca.materialization_hypertable_schema = j.hypertable_schema
+      AND ca.materialization_hypertable_name = j.hypertable_name
+     WHERE j.proc_name = 'policy_retention'`
+  );
+  const dropAfter = new Map(policies.rows.map(row => [row.target, row.drop_after]));
+
+  for (const source of ROLLUP_SOURCES) {
+    checks.equal(
+      `${source} raw rows are dropped after 24 hours`,
+      observedText(dropAfter.get(source) ?? 'none', 'none'),
+      '24 hours'
+    );
+    checks.equal(
+      `${source}_1m rows are dropped after 30 days`,
+      observedText(dropAfter.get(`${source}_1m`) ?? 'none', 'none'),
+      '30 days'
+    );
+    checks.equal(`${source}_1h keeps its rows forever`, dropAfter.has(`${source}_1h`), false);
+  }
+}
+
+/**
+ * The sparse hour holds 59 minutes of 60 samples plus one minute of 12, so `docker_stats_1h_avg`
+ * lands on the raw average only if the hourly tier weighted each minute by its sample count. An
+ * equal-weighted AVG() over the per-minute averages misses it by about 1.06 points.
  */
 export async function assertWeightedRollup(pool: Pool, checks: Checks): Promise<void> {
-  const row = await selectRow<{
-    raw_count: string;
-    raw_avg: string;
-    weighted_avg: string;
-    naive_avg: string;
-    minute_count: string;
-    min_samples: string;
-    max_samples: string;
-  }>(
-    pool,
-    `WITH window_bounds AS (
-       SELECT date_trunc('hour', min(time)) AS lo
-       FROM docker_stats WHERE host = $1 AND container_id = $2
-     ),
-     rows_in_window AS (
-       SELECT time, cpu_percent
-       FROM docker_stats, window_bounds
-       WHERE host = $1 AND container_id = $2
-         AND time >= window_bounds.lo
-         AND time < window_bounds.lo + INTERVAL '1 hour'
-     ),
-     per_minute AS (
-       SELECT date_trunc('minute', time) AS bucket,
-              avg(cpu_percent) AS avg_cpu,
-              count(*) AS sample_count
-       FROM rows_in_window
-       GROUP BY 1
-     )
-     SELECT
-       (SELECT count(*) FROM rows_in_window) AS raw_count,
-       (SELECT avg(cpu_percent) FROM rows_in_window) AS raw_avg,
-       (SELECT sum(avg_cpu * sample_count) / sum(sample_count) FROM per_minute) AS weighted_avg,
-       (SELECT avg(avg_cpu) FROM per_minute) AS naive_avg,
-       (SELECT count(*) FROM per_minute) AS minute_count,
-       (SELECT min(sample_count) FROM per_minute) AS min_samples,
-       (SELECT max(sample_count) FROM per_minute) AS max_samples`,
-    [DOCKER_HOST, SPARSE_HOUR.containerId]
-  );
-
   const expectedRows =
     SPARSE_HOUR.fullMinutes * SPARSE_HOUR.fullSamplesPerMinute + SPARSE_HOUR.shortSamples;
-  checks.equal('sparse hour row count', Number(row?.raw_count), expectedRows);
-  checks.equal('sparse hour spans 60 minute buckets', Number(row?.minute_count), 60);
-  checks.equal('sparse hour has a short bucket', Number(row?.min_samples), SPARSE_HOUR.shortSamples);
-  checks.equal(
-    'sparse hour has full buckets',
-    Number(row?.max_samples),
-    SPARSE_HOUR.fullSamplesPerMinute
+  const params = [DOCKER_HOST, SPARSE_HOUR.containerId];
+
+  const raw = await selectRow<{ raw_count: string; raw_avg: string | null }>(
+    pool,
+    `WITH ${FIXTURE_HOUR_CTE}
+     SELECT count(*) AS raw_count, avg(cpu_percent) AS raw_avg
+     FROM docker_stats, bounds
+     WHERE host = $1 AND container_id = $2
+       AND time >= bounds.lo AND time < bounds.lo + INTERVAL '1 hour'`,
+    params
   );
-
-  const rawAvg = Number(row?.raw_avg);
-  const weighted = Number(row?.weighted_avg);
-  const naive = Number(row?.naive_avg);
-
-  checks.closeTo('raw average matches the fixture', rawAvg, sparseHourRawAverage(), 1e-9);
-  checks.closeTo('weighted rollup equals the raw average', weighted, rawAvg, WEIGHTED_EPSILON);
-  checks.closeTo('naive rollup matches the fixture', naive, sparseHourNaiveAverage(), 1e-9);
+  checks.equal('sparse hour row count', Number(raw?.raw_count), expectedRows);
+  checks.closeTo('raw average matches the fixture', Number(raw?.raw_avg), sparseHourRawAverage(), 1e-9);
   checks.differsBy(
     'fixture discriminates weighted from naive rollups',
-    naive,
-    rawAvg,
+    sparseHourNaiveAverage(),
+    sparseHourRawAverage(),
+    MIN_DISCRIMINATION
+  );
+
+  const rolled = await selectRow<{
+    hourly_cpu: string | null;
+    hourly_samples: string | null;
+    minute_buckets: string;
+    min_minute_samples: string | null;
+    max_minute_samples: string | null;
+  }>(
+    pool,
+    `WITH ${FIXTURE_HOUR_CTE}
+     SELECT
+       (SELECT cpu_percent FROM docker_stats_1h_avg, bounds
+        WHERE host = $1 AND container_id = $2 AND time = bounds.lo) AS hourly_cpu,
+       (SELECT sample_count FROM docker_stats_1h_avg, bounds
+        WHERE host = $1 AND container_id = $2 AND time = bounds.lo) AS hourly_samples,
+       (SELECT count(*) FROM docker_stats_1m
+        WHERE host = $1 AND container_id = $2) AS minute_buckets,
+       (SELECT min(sample_count) FROM docker_stats_1m
+        WHERE host = $1 AND container_id = $2) AS min_minute_samples,
+       (SELECT max(sample_count) FROM docker_stats_1m
+        WHERE host = $1 AND container_id = $2) AS max_minute_samples`,
+    params
+  );
+
+  checks.equal('docker_stats_1m holds one bucket per fixture minute', Number(rolled?.minute_buckets), 60);
+  checks.equal(
+    'docker_stats_1m keeps the short minute sample count',
+    Number(rolled?.min_minute_samples),
+    SPARSE_HOUR.shortSamples
+  );
+  checks.equal(
+    'docker_stats_1m keeps the full minute sample count',
+    Number(rolled?.max_minute_samples),
+    SPARSE_HOUR.fullSamplesPerMinute
+  );
+  checks.equal(
+    'docker_stats_1h_avg.sample_count totals the raw rows',
+    Number(rolled?.hourly_samples),
+    expectedRows
+  );
+
+  if (rolled?.hourly_cpu == null) {
+    checks.record('docker_stats_1h_avg holds the sparse hour bucket', false, 'cpu_percent is NULL or the bucket is missing');
+    return;
+  }
+  const hourlyCpu = observed(Number(rolled.hourly_cpu), sparseHourNaiveAverage());
+  checks.closeTo(
+    'docker_stats_1h_avg.cpu_percent equals the raw average',
+    hourlyCpu,
+    sparseHourRawAverage(),
+    toleranceFor(sparseHourRawAverage())
+  );
+  checks.differsBy(
+    'docker_stats_1h_avg.cpu_percent is not the equal-weighted average of the minute averages',
+    hourlyCpu,
+    sparseHourNaiveAverage(),
     MIN_DISCRIMINATION
   );
 }
 
 /**
- * Proxmox reports netin/netout/uptime as cumulative totals with no delta
- * applied downstream, so a bucket must carry its LAST value. The mean of a
- * monotonic counter is the bucket midpoint: plausible-looking and wrong.
+ * Proxmox reports netin/netout/uptime as cumulative totals with no delta applied downstream, so
+ * `proxmox_stats_1m` has to carry each bucket's LAST value. The mean of a monotonic counter is the
+ * bucket midpoint: plausible-looking and wrong.
  */
 export async function assertCumulativeCounters(pool: Pool, checks: Checks): Promise<void> {
+  const params = [PROXMOX_HOST, COUNTER_GUEST.entityId, COUNTER_GUEST.entityType];
+
   for (const column of ['netin', 'netout', 'uptime']) {
     const violations = await count(
       pool,
@@ -359,60 +506,161 @@ export async function assertCumulativeCounters(pool: Pool, checks: Checks): Prom
          WHERE host = $1 AND entity_id = $2 AND entity_type = $3
        ) ordered
        WHERE previous IS NOT NULL AND value < previous`,
-      [PROXMOX_HOST, COUNTER_GUEST.entityId, COUNTER_GUEST.entityType]
+      params
     );
     checks.equal(`proxmox_stats.${column} is monotonically increasing`, violations, 0);
 
     const row = await selectRow<{
-      last_value: string;
-      avg_value: string;
-      max_value: string;
+      tier_value: string | null;
+      raw_last: string | null;
+      raw_avg: string | null;
       bucket_samples: string;
     }>(
       pool,
-      `WITH bucketed AS (
-         SELECT date_trunc('minute', time) AS bucket, time, ${column} AS value
-         FROM proxmox_stats
+      `WITH probe AS (
+         SELECT max(time) AS bucket FROM proxmox_stats_1m
          WHERE host = $1 AND entity_id = $2 AND entity_type = $3
+           AND time < date_trunc('minute', now())
        ),
-       newest_bucket AS (SELECT max(bucket) AS bucket FROM bucketed)
+       raw_bucket AS (
+         SELECT time, ${column} AS value
+         FROM proxmox_stats, probe
+         WHERE host = $1 AND entity_id = $2 AND entity_type = $3
+           AND time >= probe.bucket AND time < probe.bucket + INTERVAL '1 minute'
+       )
        SELECT
-         (SELECT value FROM bucketed, newest_bucket
-          WHERE bucketed.bucket = newest_bucket.bucket
-          ORDER BY time DESC LIMIT 1) AS last_value,
-         (SELECT avg(value) FROM bucketed, newest_bucket
-          WHERE bucketed.bucket = newest_bucket.bucket) AS avg_value,
-         (SELECT max(value) FROM bucketed, newest_bucket
-          WHERE bucketed.bucket = newest_bucket.bucket) AS max_value,
-         (SELECT count(*) FROM bucketed, newest_bucket
-          WHERE bucketed.bucket = newest_bucket.bucket) AS bucket_samples`,
-      [PROXMOX_HOST, COUNTER_GUEST.entityId, COUNTER_GUEST.entityType]
+         (SELECT ${column} FROM proxmox_stats_1m, probe
+          WHERE host = $1 AND entity_id = $2 AND entity_type = $3
+            AND time = probe.bucket) AS tier_value,
+         (SELECT value FROM raw_bucket ORDER BY time DESC LIMIT 1) AS raw_last,
+         (SELECT avg(value) FROM raw_bucket) AS raw_avg,
+         (SELECT count(*) FROM raw_bucket) AS bucket_samples`,
+      params
     );
 
-    const lastValue = Number(row?.last_value);
-    const avgValue = Number(row?.avg_value);
-    const maxValue = Number(row?.max_value);
     checks.equal(
-      `${column} newest bucket is a whole minute of samples`,
+      `${column} probe bucket is a whole minute of samples`,
       Number(row?.bucket_samples),
       COUNTER_BUCKET_SAMPLES
     );
-    checks.equal(`${column} bucket LAST equals bucket MAX`, lastValue, maxValue);
+    if (row?.tier_value == null || row.raw_last == null || row.raw_avg == null) {
+      checks.record(
+        `proxmox_stats_1m holds a ${column} bucket to compare`,
+        false,
+        `tier=${row?.tier_value} raw_last=${row?.raw_last} raw_avg=${row?.raw_avg}`
+      );
+      continue;
+    }
+
+    const rawAvg = Number(row.raw_avg);
+    const tierValue = observed(Number(row.tier_value), rawAvg);
+    checks.equal(
+      `proxmox_stats_1m.${column} carries the bucket LAST value`,
+      tierValue,
+      Number(row.raw_last)
+    );
     checks.differsBy(
-      `${column} bucket AVG is not the counter value`,
-      avgValue,
-      lastValue,
-      Math.abs(lastValue) * 1e-6 + 1
+      `proxmox_stats_1m.${column} is not the bucket average`,
+      tierValue,
+      rawAvg,
+      COUNTER_AVG_MIN_SEPARATION
     );
   }
 }
 
 /**
- * Enforces that the database's continuous aggregates and `AGGREGATE_TIERS` stay
- * in step, then applies the weighted-average and last-value rules to every
- * registered tier.
+ * Measures the NULL dilution that migration 030 documents as a known limitation: a metric NULL for
+ * only part of an hour is scaled by the populated fraction, while a metric present on every row is
+ * unaffected. Kept as a boundary marker, since no collector writes that state.
  */
-export async function assertAggregateTiers(pool: Pool, checks: Checks): Promise<void> {
+export async function assertNullMetricDilution(pool: Pool, checks: Checks): Promise<void> {
+  const populatedMinutes = NULL_METRIC_HOUR.minutes - NULL_METRIC_HOUR.nullMinutes;
+  const row = await selectRow<{
+    minute_buckets: string;
+    null_minutes: string;
+    null_minute_samples: string | null;
+    hourly_cpu: string | null;
+    hourly_memory: string | null;
+    raw_cpu_avg: string | null;
+    raw_memory_avg: string | null;
+  }>(
+    pool,
+    `WITH ${FIXTURE_HOUR_CTE}
+     SELECT
+       (SELECT count(*) FROM docker_stats_1m
+        WHERE host = $1 AND container_id = $2) AS minute_buckets,
+       (SELECT count(*) FROM docker_stats_1m
+        WHERE host = $1 AND container_id = $2 AND cpu_percent IS NULL) AS null_minutes,
+       (SELECT sum(sample_count) FROM docker_stats_1m
+        WHERE host = $1 AND container_id = $2 AND cpu_percent IS NULL) AS null_minute_samples,
+       (SELECT cpu_percent FROM docker_stats_1h_avg, bounds
+        WHERE host = $1 AND container_id = $2 AND time = bounds.lo) AS hourly_cpu,
+       (SELECT memory_percent FROM docker_stats_1h_avg, bounds
+        WHERE host = $1 AND container_id = $2 AND time = bounds.lo) AS hourly_memory,
+       (SELECT avg(cpu_percent) FROM docker_stats, bounds
+        WHERE host = $1 AND container_id = $2
+          AND time >= bounds.lo AND time < bounds.lo + INTERVAL '1 hour') AS raw_cpu_avg,
+       (SELECT avg(memory_percent) FROM docker_stats, bounds
+        WHERE host = $1 AND container_id = $2
+          AND time >= bounds.lo AND time < bounds.lo + INTERVAL '1 hour') AS raw_memory_avg`,
+    [DOCKER_HOST, NULL_METRIC_HOUR.containerId]
+  );
+
+  checks.equal(
+    'null-metric hour spans every fixture minute',
+    Number(row?.minute_buckets),
+    NULL_METRIC_HOUR.minutes
+  );
+  checks.equal(
+    'docker_stats_1m leaves the unpopulated minutes NULL',
+    Number(row?.null_minutes),
+    NULL_METRIC_HOUR.nullMinutes
+  );
+  checks.equal(
+    'docker_stats_1m still counts the samples behind a NULL metric',
+    Number(row?.null_minute_samples),
+    NULL_METRIC_HOUR.nullMinutes * NULL_METRIC_HOUR.samplesPerMinute
+  );
+  checks.closeTo(
+    'raw average over the populated rows matches the fixture',
+    Number(row?.raw_cpu_avg),
+    nullMetricRawAverage(),
+    1e-9
+  );
+
+  if (row?.hourly_cpu == null || row.hourly_memory == null || row.raw_memory_avg == null) {
+    checks.record(
+      'docker_stats_1h_avg holds the null-metric hour',
+      false,
+      `cpu=${row?.hourly_cpu} memory=${row?.hourly_memory} raw_memory=${row?.raw_memory_avg}`
+    );
+    return;
+  }
+
+  const hourlyCpu = observed(Number(row.hourly_cpu), nullMetricRawAverage());
+  checks.closeTo(
+    `docker_stats_1h_avg.cpu_percent is diluted to ${populatedMinutes}/${NULL_METRIC_HOUR.minutes} of the populated average`,
+    hourlyCpu,
+    nullMetricDilutedAverage(),
+    toleranceFor(nullMetricDilutedAverage())
+  );
+  checks.differsBy(
+    'the diluted hourly average is not the populated average',
+    hourlyCpu,
+    nullMetricRawAverage(),
+    MIN_DISCRIMINATION
+  );
+
+  const rawMemoryAvg = Number(row.raw_memory_avg);
+  checks.closeTo(
+    'a metric populated on every row is undiluted in the same hour',
+    observed(Number(row.hourly_memory), rawMemoryAvg * 1.5 + 1),
+    rawMemoryAvg,
+    toleranceFor(rawMemoryAvg)
+  );
+}
+
+export async function assertAggregateRegistry(pool: Pool, checks: Checks): Promise<void> {
   const views = await selectColumn<string>(
     pool,
     'SELECT view_name FROM timescaledb_information.continuous_aggregates'
@@ -422,52 +670,117 @@ export async function assertAggregateTiers(pool: Pool, checks: Checks): Promise<
     views,
     AGGREGATE_TIERS.map(tier => tier.view)
   );
+}
 
+/**
+ * Replays each tier's aggregation rules against its own source for the probe entity: the weighted
+ * average or weighted sum, the last-value columns, and the sample_count that the hourly tier
+ * divides by. The bucket comes from the view itself, excluding the in-progress one, so a tier that
+ * materialized nothing fails on a missing bucket rather than comparing NULL against NULL.
+ */
+export async function assertAggregateTierValues(pool: Pool, checks: Checks): Promise<void> {
   for (const tier of AGGREGATE_TIERS) {
+    const keyPredicate = tier.keyColumns.map((column, index) => `${column} = $${index + 1}`).join(' AND ');
+    const bucketWidth = `INTERVAL '1 ${tier.bucketUnit}'`;
+    const probeCte = `probe AS (
+      SELECT max(time) AS bucket FROM ${tier.view}
+      WHERE ${keyPredicate} AND time < date_trunc('${tier.bucketUnit}', now())
+    )`;
+    const sourceFrom = `${tier.sourceTable}, probe`;
+    const sourceWhere = `${keyPredicate} AND time >= probe.bucket AND time < probe.bucket + ${bucketWidth}`;
+    const viewFrom = `${tier.view}, probe`;
+    const viewWhere = `${keyPredicate} AND time = probe.bucket`;
+
+    const probe = await selectRow<{ bucket: Date | null }>(
+      pool,
+      `WITH ${probeCte} SELECT bucket FROM probe`,
+      tier.probeKey
+    );
+    if (probe?.bucket == null) {
+      checks.record(
+        `${tier.view} materialized a closed bucket for the probe entity`,
+        false,
+        'the view holds no bucket for the probe entity'
+      );
+      continue;
+    }
+
+    const counts = await selectRow<{ view_value: string | null; expected: string | null }>(
+      pool,
+      `WITH ${probeCte}
+       SELECT
+         (SELECT sample_count FROM ${viewFrom} WHERE ${viewWhere}) AS view_value,
+         (SELECT sum(${tier.sourceWeight}) FROM ${sourceFrom} WHERE ${sourceWhere}) AS expected`,
+      tier.probeKey
+    );
+    const expectedWeight = Number(counts?.expected);
+    checks.equal(
+      `${tier.view}.sample_count totals the source weights`,
+      observed(Number(counts?.view_value), expectedWeight + 1),
+      expectedWeight
+    );
+
     for (const column of tier.weightedAverageColumns) {
-      const row = await selectRow<{ tier_value: string; raw_value: string }>(
+      const weightedSum = tier.weightedColumnShape === 'weighted_sum';
+      const viewColumn = weightedSum ? `${column}_sum` : column;
+      const divisor = weightedSum ? '' : ' / NULLIF(sum(weight), 0)';
+      const row = await selectRow<{ view_value: string | null; expected: string | null }>(
         pool,
-        `WITH bounds AS (
-           SELECT date_trunc('hour', min(time)) AS lo
-           FROM ${tier.sourceTable} WHERE host = $1 AND container_id = $2
+        `WITH ${probeCte},
+         source_rows AS (
+           SELECT ${column} AS value, ${tier.sourceWeight} AS weight
+           FROM ${sourceFrom} WHERE ${sourceWhere} AND ${column} IS NOT NULL
          )
          SELECT
-           (SELECT ${column} FROM ${tier.view}, bounds
-            WHERE ${tier.timeColumn} = bounds.lo LIMIT 1) AS tier_value,
-           (SELECT avg(${column}) FROM ${tier.sourceTable}, bounds
-            WHERE host = $1 AND container_id = $2
-              AND time >= bounds.lo AND time < bounds.lo + INTERVAL '1 hour') AS raw_value`,
-        [DOCKER_HOST, SPARSE_HOUR.containerId]
+           (SELECT ${viewColumn} FROM ${viewFrom} WHERE ${viewWhere}) AS view_value,
+           (SELECT sum(value * weight)${divisor} FROM source_rows) AS expected`,
+        tier.probeKey
       );
+
+      const label = `${tier.view}.${viewColumn}`;
+      if (row?.view_value == null || row.expected == null) {
+        checks.record(
+          `${label} and its source expectation are both populated`,
+          false,
+          `view=${row?.view_value} source=${row?.expected}`
+        );
+        continue;
+      }
+      const expected = Number(row.expected);
       checks.closeTo(
-        `${tier.view}.${column} is sample-count weighted`,
-        Number(row?.tier_value),
-        Number(row?.raw_value),
-        WEIGHTED_EPSILON
+        weightedSum
+          ? `${label} is the sample-count weighted sum of its source`
+          : `${label} is the bucket mean of its source`,
+        observed(Number(row.view_value), expected * 1.5 + 1),
+        expected,
+        toleranceFor(expected)
       );
     }
 
     for (const column of tier.lastValueColumns) {
-      const row = await selectRow<{ tier_value: string; raw_last: string }>(
+      const row = await selectRow<{ view_value: string | null; expected: string | null }>(
         pool,
-        `WITH bounds AS (
-           SELECT date_trunc('hour', max(time)) AS lo
-           FROM ${tier.sourceTable} WHERE host = $1 AND entity_id = $2
-         )
+        `WITH ${probeCte}
          SELECT
-           (SELECT ${column} FROM ${tier.view}, bounds
-            WHERE ${tier.timeColumn} = bounds.lo LIMIT 1) AS tier_value,
-           (SELECT ${column} FROM ${tier.sourceTable}, bounds
-            WHERE host = $1 AND entity_id = $2
-              AND time >= bounds.lo AND time < bounds.lo + INTERVAL '1 hour'
-            ORDER BY time DESC LIMIT 1) AS raw_last
-        `,
-        [PROXMOX_HOST, COUNTER_GUEST.entityId]
+           (SELECT ${column}::text FROM ${viewFrom} WHERE ${viewWhere}) AS view_value,
+           (SELECT ${column}::text FROM ${sourceFrom} WHERE ${sourceWhere}
+            ORDER BY time DESC LIMIT 1) AS expected`,
+        tier.probeKey
       );
+
+      const label = `${tier.view}.${column}`;
+      if (row?.view_value == null || row.expected == null) {
+        checks.record(
+          `${label} and its source expectation are both populated`,
+          false,
+          `view=${row?.view_value} source=${row?.expected}`
+        );
+        continue;
+      }
       checks.equal(
-        `${tier.view}.${column} carries the bucket LAST value`,
-        Number(row?.tier_value),
-        Number(row?.raw_last)
+        `${label} carries the bucket LAST value`,
+        observedText(row.view_value, 'simulated-regression'),
+        row.expected
       );
     }
   }

--- a/scripts/migration-verify/assertions.ts
+++ b/scripts/migration-verify/assertions.ts
@@ -9,8 +9,11 @@ import {
   EXPECTED_HYPERTABLES,
   EXPECTED_TABLES,
   IDLE_CONTAINER,
+  MIN_ROLLUP_DISCRIMINATION,
   NULL_METRIC_HOUR,
+  PROXMOX_CLUSTER_ENTITY,
   PROXMOX_HOST,
+  PROXMOX_STORAGE_ENTITY,
   REMOVED_COLUMNS,
   SPARSE_HOUR,
   ZFS_ENTITIES,
@@ -23,7 +26,6 @@ import {
 } from './fixture';
 
 const RELATIVE_EPSILON = 1e-9;
-const MIN_DISCRIMINATION = 0.5;
 /** uptime is the slowest counter in the fixture; its bucket AVG trails its LAST by ~29.5. */
 const COUNTER_AVG_MIN_SEPARATION = 1;
 
@@ -51,9 +53,22 @@ const EXPECTED_SEGMENTBY: Record<string, string[]> = {
 };
 
 /**
+ * One entity whose buckets get replayed against the tier's source. A tier needs more than one
+ * whenever the NULL pattern varies by group key: a proxmox guest carries cpu/mem/disk and a NULL
+ * storage_avail, a storage row is the inverse, so neither alone reaches every column.
+ */
+export interface TierProbe {
+  /** Values for the tier's `keyColumns`. */
+  key: string[];
+  weightedAverageColumns: string[];
+  lastValueColumns: string[];
+}
+
+/**
  * Registry of continuous-aggregate tiers. `assertAggregateRegistry` enforces that the database's
- * set of continuous aggregates matches this list exactly, and `assertAggregateTierValues` replays
- * each tier's aggregation rules against its source for the probe entity.
+ * set of continuous aggregates matches this list exactly, `assertTierColumnCoverage` enforces that
+ * every column of every tier is claimed by some probe, and `assertAggregateTierValues` replays each
+ * tier's aggregation rules against its source.
  */
 export interface AggregateTier {
   view: string;
@@ -65,38 +80,73 @@ export interface AggregateTier {
   /** `_1m` materializes the bucket mean; `_1h` materializes SUM(metric * sample_count) as `<metric>_sum`. */
   weightedColumnShape: 'mean' | 'weighted_sum';
   keyColumns: string[];
-  /** Values for `keyColumns`, identifying the entity whose buckets get replayed. */
-  probeKey: string[];
-  weightedAverageColumns: string[];
-  lastValueColumns: string[];
+  probes: TierProbe[];
 }
 
 const DOCKER_TIER_KEYS = ['host', 'container_id'];
-const DOCKER_PROBE = [DOCKER_HOST, SPARSE_HOUR.containerId];
-const DOCKER_WEIGHTED = [
-  'cpu_percent',
-  'memory_usage',
-  'memory_percent',
-  'network_rx_bytes_per_sec',
-  'block_io_write_bytes_per_sec',
+const DOCKER_PROBES: TierProbe[] = [
+  {
+    key: [DOCKER_HOST, SPARSE_HOUR.containerId],
+    weightedAverageColumns: [
+      'cpu_percent',
+      'memory_usage',
+      'memory_limit',
+      'memory_percent',
+      'network_rx_bytes_per_sec',
+      'network_tx_bytes_per_sec',
+      'block_io_read_bytes_per_sec',
+      'block_io_write_bytes_per_sec',
+    ],
+    lastValueColumns: ['container_name', 'image'],
+  },
 ];
-const DOCKER_LAST = ['container_name', 'image'];
 
 const ZFS_TIER_KEYS = ['host', 'pool', 'entity'];
-const ZFS_PROBE = [ZFS_HOST, ZFS_POOL, ZFS_ENTITIES[0].entity];
-const ZFS_WEIGHTED = [
-  'capacity_alloc',
-  'read_ops_per_sec',
-  'write_bytes_per_sec',
-  'utilization_percent',
+const ZFS_PROBES: TierProbe[] = [
+  {
+    key: [ZFS_HOST, ZFS_POOL, ZFS_ENTITIES[0].entity],
+    weightedAverageColumns: [
+      'capacity_alloc',
+      'capacity_free',
+      'read_ops_per_sec',
+      'write_ops_per_sec',
+      'read_bytes_per_sec',
+      'write_bytes_per_sec',
+      'utilization_percent',
+    ],
+    lastValueColumns: ['entity_type', 'indent'],
+  },
 ];
-const ZFS_LAST = ['entity_type', 'indent'];
 
 const PROXMOX_TIER_KEYS = ['host', 'entity_type', 'entity_id'];
-const PROXMOX_PROBE = [PROXMOX_HOST, COUNTER_GUEST.entityType, COUNTER_GUEST.entityId];
-/** storage_avail is NULL for every guest row, so it has no weighted average to compare here. */
-const PROXMOX_WEIGHTED = ['cpu', 'mem', 'disk'];
-const PROXMOX_LAST = ['netin', 'netout', 'uptime', 'vmid', 'status'];
+const PROXMOX_PROBES: TierProbe[] = [
+  {
+    key: [PROXMOX_HOST, COUNTER_GUEST.entityType, COUNTER_GUEST.entityId],
+    weightedAverageColumns: ['cpu', 'mem', 'disk'],
+    lastValueColumns: [
+      'node',
+      'entity_name',
+      'status',
+      'max_cpu',
+      'max_mem',
+      'max_disk',
+      'uptime',
+      'vmid',
+      'netin',
+      'netout',
+    ],
+  },
+  {
+    key: [PROXMOX_HOST, PROXMOX_STORAGE_ENTITY.entityType, PROXMOX_STORAGE_ENTITY.entityId],
+    weightedAverageColumns: ['storage_avail'],
+    lastValueColumns: ['storage_type', 'storage_content', 'storage_shared'],
+  },
+  {
+    key: [PROXMOX_HOST, PROXMOX_CLUSTER_ENTITY.entityType, PROXMOX_CLUSTER_ENTITY.entityId],
+    weightedAverageColumns: [],
+    lastValueColumns: ['cluster_version'],
+  },
+];
 
 export const AGGREGATE_TIERS: AggregateTier[] = [
   {
@@ -106,9 +156,7 @@ export const AGGREGATE_TIERS: AggregateTier[] = [
     sourceWeight: '1',
     weightedColumnShape: 'mean',
     keyColumns: DOCKER_TIER_KEYS,
-    probeKey: DOCKER_PROBE,
-    weightedAverageColumns: DOCKER_WEIGHTED,
-    lastValueColumns: DOCKER_LAST,
+    probes: DOCKER_PROBES,
   },
   {
     view: 'docker_stats_1h',
@@ -117,9 +165,7 @@ export const AGGREGATE_TIERS: AggregateTier[] = [
     sourceWeight: 'sample_count',
     weightedColumnShape: 'weighted_sum',
     keyColumns: DOCKER_TIER_KEYS,
-    probeKey: DOCKER_PROBE,
-    weightedAverageColumns: DOCKER_WEIGHTED,
-    lastValueColumns: DOCKER_LAST,
+    probes: DOCKER_PROBES,
   },
   {
     view: 'zfs_stats_1m',
@@ -128,9 +174,7 @@ export const AGGREGATE_TIERS: AggregateTier[] = [
     sourceWeight: '1',
     weightedColumnShape: 'mean',
     keyColumns: ZFS_TIER_KEYS,
-    probeKey: ZFS_PROBE,
-    weightedAverageColumns: ZFS_WEIGHTED,
-    lastValueColumns: ZFS_LAST,
+    probes: ZFS_PROBES,
   },
   {
     view: 'zfs_stats_1h',
@@ -139,9 +183,7 @@ export const AGGREGATE_TIERS: AggregateTier[] = [
     sourceWeight: 'sample_count',
     weightedColumnShape: 'weighted_sum',
     keyColumns: ZFS_TIER_KEYS,
-    probeKey: ZFS_PROBE,
-    weightedAverageColumns: ZFS_WEIGHTED,
-    lastValueColumns: ZFS_LAST,
+    probes: ZFS_PROBES,
   },
   {
     view: 'proxmox_stats_1m',
@@ -150,9 +192,7 @@ export const AGGREGATE_TIERS: AggregateTier[] = [
     sourceWeight: '1',
     weightedColumnShape: 'mean',
     keyColumns: PROXMOX_TIER_KEYS,
-    probeKey: PROXMOX_PROBE,
-    weightedAverageColumns: PROXMOX_WEIGHTED,
-    lastValueColumns: PROXMOX_LAST,
+    probes: PROXMOX_PROBES,
   },
   {
     view: 'proxmox_stats_1h',
@@ -161,11 +201,28 @@ export const AGGREGATE_TIERS: AggregateTier[] = [
     sourceWeight: 'sample_count',
     weightedColumnShape: 'weighted_sum',
     keyColumns: PROXMOX_TIER_KEYS,
-    probeKey: PROXMOX_PROBE,
-    weightedAverageColumns: PROXMOX_WEIGHTED,
-    lastValueColumns: PROXMOX_LAST,
+    probes: PROXMOX_PROBES,
   },
 ];
+
+function viewColumnFor(tier: AggregateTier, column: string): string {
+  return tier.weightedColumnShape === 'weighted_sum' ? `${column}_sum` : column;
+}
+
+function probeLabel(probe: TierProbe): string {
+  return probe.key[probe.key.length - 1];
+}
+
+function keyPredicateFor(tier: AggregateTier): string {
+  return tier.keyColumns.map((column, index) => `${column} = $${index + 1}`).join(' AND ');
+}
+
+function probeCteFor(tier: AggregateTier): string {
+  return `probe AS (
+    SELECT max(time) AS bucket FROM ${tier.view}
+    WHERE ${keyPredicateFor(tier)} AND time < date_trunc('${tier.bucketUnit}', now())
+  )`;
+}
 
 export async function assertSchema(pool: Pool, checks: Checks): Promise<void> {
   const tables = await selectColumn<string>(
@@ -356,6 +413,9 @@ export async function assertRollupBackfill(pool: Pool, checks: Checks): Promise<
     checks.equal(`${tier.view} was materialized by the backfill`, rows > 0, true);
   }
 
+  await assertBackfillReachedFullHistory(pool, checks);
+  await assertNoFailedPolicyJobs(pool, checks);
+
   const policies = await pool.query<{ target: string; drop_after: string }>(
     `SELECT
        COALESCE(ca.view_name, j.hypertable_name) AS target,
@@ -388,6 +448,65 @@ export async function assertRollupBackfill(pool: Pool, checks: Checks): Promise<
 }
 
 /**
+ * `refreshWindows` walks the whole history in fixed-size windows, so a bug in its loop bound leaves
+ * recent buckets present and old ones missing. The idle container's 96 samples sit 31 days back,
+ * past every window but the first. Read from `_1h`, which carries no retention policy: the same
+ * buckets in `_1m` are older than the 30-day policy the backfill has just installed, and a
+ * scheduler run could drop them mid-assertion.
+ */
+async function assertBackfillReachedFullHistory(pool: Pool, checks: Checks): Promise<void> {
+  const row = await selectRow<{ hourly_samples: string | null; oldest_age_days: string | null }>(
+    pool,
+    `SELECT
+       sum(sample_count) AS hourly_samples,
+       EXTRACT(EPOCH FROM (now() - min(time))) / 86400 AS oldest_age_days
+     FROM docker_stats_1h WHERE host = $1 AND container_id = $2`,
+    [DOCKER_HOST, IDLE_CONTAINER.id]
+  );
+
+  checks.equal(
+    'the backfill rolled up every idle-container sample from 31 days back',
+    Number(row?.hourly_samples),
+    IDLE_CONTAINER.samples
+  );
+  checks.equal(
+    'docker_stats_1h reaches past the raw retention window',
+    Number(row?.oldest_age_days) > IDLE_CONTAINER.newestAgeDays,
+    true
+  );
+}
+
+/**
+ * The verification databases run at `log_min_messages = 'fatal'`, which hides the server-side ERROR
+ * a failed background job leaves behind, so the harness has to read the job status itself. Scoped
+ * to the two policies the rollup assertions depend on; compression is excluded because it competes
+ * with retention for the same chunks and a loss there says nothing about the aggregate definitions.
+ */
+async function assertNoFailedPolicyJobs(pool: Pool, checks: Checks): Promise<void> {
+  const available = await selectRow<{ present: boolean }>(
+    pool,
+    `SELECT to_regclass('timescaledb_information.job_stats') IS NOT NULL AS present`
+  );
+  if (available?.present !== true) {
+    checks.record('background job status is readable', false, 'job_stats view is missing');
+    return;
+  }
+
+  const failed = await selectColumn<string>(
+    pool,
+    `SELECT j.proc_name || ' on ' || COALESCE(ca.view_name, j.hypertable_name, 'unknown')
+     FROM timescaledb_information.job_stats s
+     JOIN timescaledb_information.jobs j ON j.job_id = s.job_id
+     LEFT JOIN timescaledb_information.continuous_aggregates ca
+       ON ca.materialization_hypertable_schema = j.hypertable_schema
+      AND ca.materialization_hypertable_name = j.hypertable_name
+     WHERE s.last_run_status = 'Failed'
+       AND j.proc_name IN ('policy_retention', 'policy_refresh_continuous_aggregate')`
+  );
+  checks.equal('no retention or refresh job has failed', failed.join(', ') || 'none', 'none');
+}
+
+/**
  * The sparse hour holds 59 minutes of 60 samples plus one minute of 12, so `docker_stats_1h_avg`
  * lands on the raw average only if the hourly tier weighted each minute by its sample count. An
  * equal-weighted AVG() over the per-minute averages misses it by about 1.06 points.
@@ -407,16 +526,15 @@ export async function assertWeightedRollup(pool: Pool, checks: Checks): Promise<
     params
   );
   checks.equal('sparse hour row count', Number(raw?.raw_count), expectedRows);
-  checks.closeTo('raw average matches the fixture', Number(raw?.raw_avg), sparseHourRawAverage(), 1e-9);
-  checks.differsBy(
-    'fixture discriminates weighted from naive rollups',
-    sparseHourNaiveAverage(),
+  checks.closeTo(
+    'raw average matches the fixture',
+    Number(raw?.raw_avg),
     sparseHourRawAverage(),
-    MIN_DISCRIMINATION
+    1e-9
   );
 
   const rolled = await selectRow<{
-    hourly_cpu: string | null;
+    hourly_cpu: unknown;
     hourly_samples: string | null;
     minute_buckets: string;
     min_minute_samples: string | null;
@@ -438,7 +556,11 @@ export async function assertWeightedRollup(pool: Pool, checks: Checks): Promise<
     params
   );
 
-  checks.equal('docker_stats_1m holds one bucket per fixture minute', Number(rolled?.minute_buckets), 60);
+  checks.equal(
+    'docker_stats_1m holds one bucket per fixture minute',
+    Number(rolled?.minute_buckets),
+    60
+  );
   checks.equal(
     'docker_stats_1m keeps the short minute sample count',
     Number(rolled?.min_minute_samples),
@@ -456,7 +578,11 @@ export async function assertWeightedRollup(pool: Pool, checks: Checks): Promise<
   );
 
   if (rolled?.hourly_cpu == null) {
-    checks.record('docker_stats_1h_avg holds the sparse hour bucket', false, 'cpu_percent is NULL or the bucket is missing');
+    checks.record(
+      'docker_stats_1h_avg holds the sparse hour bucket',
+      false,
+      'cpu_percent is NULL or the bucket is missing'
+    );
     return;
   }
   const hourlyCpu = Number(rolled.hourly_cpu);
@@ -470,7 +596,7 @@ export async function assertWeightedRollup(pool: Pool, checks: Checks): Promise<
     'docker_stats_1h_avg.cpu_percent is not the equal-weighted average of the minute averages',
     hourlyCpu,
     sparseHourNaiveAverage(),
-    MIN_DISCRIMINATION
+    MIN_ROLLUP_DISCRIMINATION
   );
 }
 
@@ -634,7 +760,7 @@ export async function assertNullMetricDilution(pool: Pool, checks: Checks): Prom
     'the diluted hourly average is not the populated average',
     hourlyCpu,
     nullMetricRawAverage(),
-    MIN_DISCRIMINATION
+    MIN_ROLLUP_DISCRIMINATION
   );
 
   const rawMemoryAvg = Number(row.raw_memory_avg);
@@ -659,116 +785,212 @@ export async function assertAggregateRegistry(pool: Pool, checks: Checks): Promi
 }
 
 /**
- * Replays each tier's aggregation rules against its own source for the probe entity: the weighted
- * average or weighted sum, the last-value columns, and the sample_count that the hourly tier
- * divides by. The bucket comes from the view itself, excluding the in-progress one, so a tier that
- * materialized nothing fails on a missing bucket rather than comparing NULL against NULL.
+ * Every column of every tier has to be claimed by some probe. Without this the registry's column
+ * lists are a hand-picked subset, and a metric added to an aggregate, renamed, or sourced from the
+ * wrong column reaches production with nothing replaying it.
+ */
+export async function assertTierColumnCoverage(pool: Pool, checks: Checks): Promise<void> {
+  for (const tier of AGGREGATE_TIERS) {
+    const columns = await selectColumn<string>(
+      pool,
+      `SELECT column_name FROM information_schema.columns
+       WHERE table_schema = 'public' AND table_name = $1`,
+      [tier.view]
+    );
+
+    const claimed = new Set<string>(['time', 'sample_count', ...tier.keyColumns]);
+    for (const probe of tier.probes) {
+      for (const column of probe.weightedAverageColumns) {
+        claimed.add(viewColumnFor(tier, column));
+      }
+      for (const column of probe.lastValueColumns) {
+        claimed.add(column);
+      }
+    }
+
+    checks.sameSet(`every ${tier.view} column is claimed by a tier probe`, columns, [...claimed]);
+  }
+}
+
+/**
+ * `resolveStatsTier` reads `<source>_1h_avg`, not the hourly aggregate itself, so the division and
+ * the `::double precision` cast that view adds sit on the app's hot path. The cast exists to keep
+ * `AVG(bigint)`'s numeric off the wire, where node-postgres hands it back as a string, so the type
+ * matters as much as the value: `Number()` on both sides would coerce that regression away.
+ */
+export async function assertHourlyAverageViews(pool: Pool, checks: Checks): Promise<void> {
+  for (const tier of AGGREGATE_TIERS) {
+    if (tier.weightedColumnShape !== 'weighted_sum') continue;
+    const avgView = `${tier.view}_avg`;
+
+    const available = await selectRow<{ present: boolean }>(
+      pool,
+      'SELECT to_regclass($1::text) IS NOT NULL AS present',
+      [avgView]
+    );
+    checks.equal(`${avgView} exists`, available?.present, true);
+    if (available?.present !== true) continue;
+
+    const probeCte = probeCteFor(tier);
+    const where = `${keyPredicateFor(tier)} AND time = probe.bucket`;
+
+    for (const probe of tier.probes) {
+      for (const column of probe.weightedAverageColumns) {
+        const row = await selectRow<{ view_value: unknown; expected: string | null }>(
+          pool,
+          `WITH ${probeCte}
+           SELECT
+             (SELECT ${column} FROM ${avgView}, probe WHERE ${where}) AS view_value,
+             (SELECT ${column}_sum / NULLIF(sample_count, 0) FROM ${tier.view}, probe
+              WHERE ${where}) AS expected`,
+          probe.key
+        );
+
+        const label = `${avgView}.${column} [${probeLabel(probe)}]`;
+        if (row?.view_value == null || row.expected == null) {
+          checks.record(
+            `${label} and its aggregate expectation are both populated`,
+            false,
+            `view=${row?.view_value} aggregate=${row?.expected}`
+          );
+          continue;
+        }
+        checks.equal(`${label} arrives as a JS number, not numeric text`, typeof row.view_value, 'number');
+        const expected = Number(row.expected);
+        checks.closeTo(
+          `${label} divides the weighted sum by sample_count`,
+          Number(row.view_value),
+          expected,
+          toleranceFor(expected)
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Replays each tier's aggregation rules against its own source for every probe entity: the weighted
+ * average or weighted sum, the last-value columns, and the sample_count the hourly tier divides by.
+ * The bucket comes from the view itself, excluding the in-progress one, so a tier that materialized
+ * nothing fails on a missing bucket rather than comparing NULL against NULL.
  */
 export async function assertAggregateTierValues(pool: Pool, checks: Checks): Promise<void> {
   for (const tier of AGGREGATE_TIERS) {
-    const keyPredicate = tier.keyColumns.map((column, index) => `${column} = $${index + 1}`).join(' AND ');
-    const bucketWidth = `INTERVAL '1 ${tier.bucketUnit}'`;
-    const probeCte = `probe AS (
-      SELECT max(time) AS bucket FROM ${tier.view}
-      WHERE ${keyPredicate} AND time < date_trunc('${tier.bucketUnit}', now())
-    )`;
-    const sourceFrom = `${tier.sourceTable}, probe`;
-    const sourceWhere = `${keyPredicate} AND time >= probe.bucket AND time < probe.bucket + ${bucketWidth}`;
-    const viewFrom = `${tier.view}, probe`;
-    const viewWhere = `${keyPredicate} AND time = probe.bucket`;
+    for (const probe of tier.probes) {
+      await assertTierProbe(pool, checks, tier, probe);
+    }
+  }
+}
 
-    const probe = await selectRow<{ bucket: Date | null }>(
-      pool,
-      `WITH ${probeCte} SELECT bucket FROM probe`,
-      tier.probeKey
+async function assertTierProbe(
+  pool: Pool,
+  checks: Checks,
+  tier: AggregateTier,
+  probe: TierProbe
+): Promise<void> {
+  const keyPredicate = keyPredicateFor(tier);
+  const probeCte = probeCteFor(tier);
+  const bucketWidth = `INTERVAL '1 ${tier.bucketUnit}'`;
+  const sourceFrom = `${tier.sourceTable}, probe`;
+  const sourceWhere = `${keyPredicate} AND time >= probe.bucket AND time < probe.bucket + ${bucketWidth}`;
+  const viewFrom = `${tier.view}, probe`;
+  const viewWhere = `${keyPredicate} AND time = probe.bucket`;
+  const suffix = `[${probeLabel(probe)}]`;
+
+  const found = await selectRow<{ bucket: Date | null }>(
+    pool,
+    `WITH ${probeCte} SELECT bucket FROM probe`,
+    probe.key
+  );
+  if (found?.bucket == null) {
+    checks.record(
+      `${tier.view} materialized a closed bucket for ${probeLabel(probe)}`,
+      false,
+      'the view holds no bucket for the probe entity'
     );
-    if (probe?.bucket == null) {
+    return;
+  }
+
+  const counts = await selectRow<{ view_value: string | null; expected: string | null }>(
+    pool,
+    `WITH ${probeCte}
+     SELECT
+       (SELECT sample_count FROM ${viewFrom} WHERE ${viewWhere}) AS view_value,
+       (SELECT sum(${tier.sourceWeight}) FROM ${sourceFrom} WHERE ${sourceWhere}) AS expected`,
+    probe.key
+  );
+  if (counts?.view_value == null || counts.expected == null) {
+    checks.record(
+      `${tier.view}.sample_count ${suffix} and its source total are both populated`,
+      false,
+      `view=${counts?.view_value} source=${counts?.expected}`
+    );
+  } else {
+    checks.equal(
+      `${tier.view}.sample_count ${suffix} totals the source weights`,
+      Number(counts.view_value),
+      Number(counts.expected)
+    );
+  }
+
+  const weightedSum = tier.weightedColumnShape === 'weighted_sum';
+  for (const column of probe.weightedAverageColumns) {
+    const viewColumn = viewColumnFor(tier, column);
+    const divisor = weightedSum ? '' : ' / NULLIF(sum(weight), 0)';
+    const row = await selectRow<{ view_value: string | null; expected: string | null }>(
+      pool,
+      `WITH ${probeCte},
+       source_rows AS (
+         SELECT ${column} AS value, ${tier.sourceWeight} AS weight
+         FROM ${sourceFrom} WHERE ${sourceWhere} AND ${column} IS NOT NULL
+       )
+       SELECT
+         (SELECT ${viewColumn} FROM ${viewFrom} WHERE ${viewWhere}) AS view_value,
+         (SELECT sum(value * weight)${divisor} FROM source_rows) AS expected`,
+      probe.key
+    );
+
+    const label = `${tier.view}.${viewColumn} ${suffix}`;
+    if (row?.view_value == null || row.expected == null) {
       checks.record(
-        `${tier.view} materialized a closed bucket for the probe entity`,
+        `${label} and its source expectation are both populated`,
         false,
-        'the view holds no bucket for the probe entity'
+        `view=${row?.view_value} source=${row?.expected}`
       );
       continue;
     }
+    const expected = Number(row.expected);
+    checks.closeTo(
+      weightedSum
+        ? `${label} is the sample-count weighted sum of its source`
+        : `${label} is the bucket mean of its source`,
+      Number(row.view_value),
+      expected,
+      toleranceFor(expected)
+    );
+  }
 
-    const counts = await selectRow<{ view_value: string | null; expected: string | null }>(
+  for (const column of probe.lastValueColumns) {
+    const row = await selectRow<{ view_value: string | null; expected: string | null }>(
       pool,
       `WITH ${probeCte}
        SELECT
-         (SELECT sample_count FROM ${viewFrom} WHERE ${viewWhere}) AS view_value,
-         (SELECT sum(${tier.sourceWeight}) FROM ${sourceFrom} WHERE ${sourceWhere}) AS expected`,
-      tier.probeKey
-    );
-    const expectedWeight = Number(counts?.expected);
-    checks.equal(
-      `${tier.view}.sample_count totals the source weights`,
-      Number(counts?.view_value),
-      expectedWeight
+         (SELECT ${column}::text FROM ${viewFrom} WHERE ${viewWhere}) AS view_value,
+         (SELECT ${column}::text FROM ${sourceFrom} WHERE ${sourceWhere}
+          ORDER BY time DESC LIMIT 1) AS expected`,
+      probe.key
     );
 
-    for (const column of tier.weightedAverageColumns) {
-      const weightedSum = tier.weightedColumnShape === 'weighted_sum';
-      const viewColumn = weightedSum ? `${column}_sum` : column;
-      const divisor = weightedSum ? '' : ' / NULLIF(sum(weight), 0)';
-      const row = await selectRow<{ view_value: string | null; expected: string | null }>(
-        pool,
-        `WITH ${probeCte},
-         source_rows AS (
-           SELECT ${column} AS value, ${tier.sourceWeight} AS weight
-           FROM ${sourceFrom} WHERE ${sourceWhere} AND ${column} IS NOT NULL
-         )
-         SELECT
-           (SELECT ${viewColumn} FROM ${viewFrom} WHERE ${viewWhere}) AS view_value,
-           (SELECT sum(value * weight)${divisor} FROM source_rows) AS expected`,
-        tier.probeKey
+    const label = `${tier.view}.${column} ${suffix}`;
+    if (row?.view_value == null || row.expected == null) {
+      checks.record(
+        `${label} and its source expectation are both populated`,
+        false,
+        `view=${row?.view_value} source=${row?.expected}`
       );
-
-      const label = `${tier.view}.${viewColumn}`;
-      if (row?.view_value == null || row.expected == null) {
-        checks.record(
-          `${label} and its source expectation are both populated`,
-          false,
-          `view=${row?.view_value} source=${row?.expected}`
-        );
-        continue;
-      }
-      const expected = Number(row.expected);
-      checks.closeTo(
-        weightedSum
-          ? `${label} is the sample-count weighted sum of its source`
-          : `${label} is the bucket mean of its source`,
-        Number(row.view_value),
-        expected,
-        toleranceFor(expected)
-      );
+      continue;
     }
-
-    for (const column of tier.lastValueColumns) {
-      const row = await selectRow<{ view_value: string | null; expected: string | null }>(
-        pool,
-        `WITH ${probeCte}
-         SELECT
-           (SELECT ${column}::text FROM ${viewFrom} WHERE ${viewWhere}) AS view_value,
-           (SELECT ${column}::text FROM ${sourceFrom} WHERE ${sourceWhere}
-            ORDER BY time DESC LIMIT 1) AS expected`,
-        tier.probeKey
-      );
-
-      const label = `${tier.view}.${column}`;
-      if (row?.view_value == null || row.expected == null) {
-        checks.record(
-          `${label} and its source expectation are both populated`,
-          false,
-          `view=${row?.view_value} source=${row?.expected}`
-        );
-        continue;
-      }
-      checks.equal(
-        `${label} carries the bucket LAST value`,
-        row.view_value,
-        row.expected
-      );
-    }
+    checks.equal(`${label} carries the bucket LAST value`, row.view_value, row.expected);
   }
 }
 

--- a/scripts/migration-verify/assertions.ts
+++ b/scripts/migration-verify/assertions.ts
@@ -39,20 +39,6 @@ const FIXTURE_HOUR_CTE = `bounds AS (
   FROM docker_stats WHERE host = $1 AND container_id = $2
 )`;
 
-/**
- * Scaffolding: substitutes the number a regressed aggregate would report so every value check
- * below can be watched to fail in CI. Set MIGRATION_VERIFY_SIMULATE_REGRESSION=true to arm it.
- */
-const SIMULATE_REGRESSION = process.env.MIGRATION_VERIFY_SIMULATE_REGRESSION === 'true';
-
-function observed(actual: number, regression: number): number {
-  return SIMULATE_REGRESSION ? regression : actual;
-}
-
-function observedText(actual: string | null, regression: string): string | null {
-  return SIMULATE_REGRESSION ? regression : actual;
-}
-
 function toleranceFor(expected: number): number {
   return Math.max(1e-9, Math.abs(expected) * RELATIVE_EPSILON);
 }
@@ -389,12 +375,12 @@ export async function assertRollupBackfill(pool: Pool, checks: Checks): Promise<
   for (const source of ROLLUP_SOURCES) {
     checks.equal(
       `${source} raw rows are dropped after 24 hours`,
-      observedText(dropAfter.get(source) ?? 'none', 'none'),
+      dropAfter.get(source) ?? 'none',
       '24 hours'
     );
     checks.equal(
       `${source}_1m rows are dropped after 30 days`,
-      observedText(dropAfter.get(`${source}_1m`) ?? 'none', 'none'),
+      dropAfter.get(`${source}_1m`) ?? 'none',
       '30 days'
     );
     checks.equal(`${source}_1h keeps its rows forever`, dropAfter.has(`${source}_1h`), false);
@@ -473,7 +459,7 @@ export async function assertWeightedRollup(pool: Pool, checks: Checks): Promise<
     checks.record('docker_stats_1h_avg holds the sparse hour bucket', false, 'cpu_percent is NULL or the bucket is missing');
     return;
   }
-  const hourlyCpu = observed(Number(rolled.hourly_cpu), sparseHourNaiveAverage());
+  const hourlyCpu = Number(rolled.hourly_cpu);
   checks.closeTo(
     'docker_stats_1h_avg.cpu_percent equals the raw average',
     hourlyCpu,
@@ -553,7 +539,7 @@ export async function assertCumulativeCounters(pool: Pool, checks: Checks): Prom
     }
 
     const rawAvg = Number(row.raw_avg);
-    const tierValue = observed(Number(row.tier_value), rawAvg);
+    const tierValue = Number(row.tier_value);
     checks.equal(
       `proxmox_stats_1m.${column} carries the bucket LAST value`,
       tierValue,
@@ -637,7 +623,7 @@ export async function assertNullMetricDilution(pool: Pool, checks: Checks): Prom
     return;
   }
 
-  const hourlyCpu = observed(Number(row.hourly_cpu), nullMetricRawAverage());
+  const hourlyCpu = Number(row.hourly_cpu);
   checks.closeTo(
     `docker_stats_1h_avg.cpu_percent is diluted to ${populatedMinutes}/${NULL_METRIC_HOUR.minutes} of the populated average`,
     hourlyCpu,
@@ -654,7 +640,7 @@ export async function assertNullMetricDilution(pool: Pool, checks: Checks): Prom
   const rawMemoryAvg = Number(row.raw_memory_avg);
   checks.closeTo(
     'a metric populated on every row is undiluted in the same hour',
-    observed(Number(row.hourly_memory), rawMemoryAvg * 1.5 + 1),
+    Number(row.hourly_memory),
     rawMemoryAvg,
     toleranceFor(rawMemoryAvg)
   );
@@ -716,7 +702,7 @@ export async function assertAggregateTierValues(pool: Pool, checks: Checks): Pro
     const expectedWeight = Number(counts?.expected);
     checks.equal(
       `${tier.view}.sample_count totals the source weights`,
-      observed(Number(counts?.view_value), expectedWeight + 1),
+      Number(counts?.view_value),
       expectedWeight
     );
 
@@ -751,7 +737,7 @@ export async function assertAggregateTierValues(pool: Pool, checks: Checks): Pro
         weightedSum
           ? `${label} is the sample-count weighted sum of its source`
           : `${label} is the bucket mean of its source`,
-        observed(Number(row.view_value), expected * 1.5 + 1),
+        Number(row.view_value),
         expected,
         toleranceFor(expected)
       );
@@ -779,7 +765,7 @@ export async function assertAggregateTierValues(pool: Pool, checks: Checks): Pro
       }
       checks.equal(
         `${label} carries the bucket LAST value`,
-        observedText(row.view_value, 'simulated-regression'),
+        row.view_value,
         row.expected
       );
     }

--- a/scripts/migration-verify/checks.ts
+++ b/scripts/migration-verify/checks.ts
@@ -18,6 +18,15 @@ export class Checks {
   }
 
   equal(name: string, actual: unknown, expected: unknown): void {
+    // Object.is treats NaN as equal to itself, so a Number(missing) on both sides would pass.
+    if (isNaNValue(actual)) {
+      this.record(name, false, `actual is NaN (expected ${format(expected)})`);
+      return;
+    }
+    if (isNaNValue(expected)) {
+      this.record(name, false, `expected is NaN (got ${format(actual)})`);
+      return;
+    }
     const ok = Object.is(actual, expected);
     this.record(name, ok, ok ? '' : `expected ${format(expected)}, got ${format(actual)}`);
   }
@@ -77,6 +86,10 @@ export class Checks {
       );
     }
   }
+}
+
+function isNaNValue(value: unknown): boolean {
+  return typeof value === 'number' && Number.isNaN(value);
 }
 
 function format(value: unknown): string {

--- a/scripts/migration-verify/db.ts
+++ b/scripts/migration-verify/db.ts
@@ -27,8 +27,10 @@ export async function recreateDatabase(name: string): Promise<void> {
     await pool.query(`DROP DATABASE IF EXISTS ${quoteIdent(name)} WITH (FORCE)`);
     await pool.query(`CREATE DATABASE ${quoteIdent(name)}`);
     // A continuous-aggregate refresh logs two lines per chunk and buries the harness report; LOG
-    // outranks ERROR in the log_min_messages scale, so silencing it takes 'fatal'. That also drops
-    // every server ERROR and WARNING here, which assertRollupBackfill's job_errors read replaces.
+    // outranks ERROR in the log_min_messages scale, so silencing it takes 'fatal'. The cost is
+    // every server ERROR and WARNING in this database, so a failed retention job is read back from
+    // timescaledb_information.job_stats instead. Policy background workers log regardless of this
+    // setting; the service container's own log cap is what keeps their output off the job log.
     await pool.query(`ALTER DATABASE ${quoteIdent(name)} SET log_min_messages = 'fatal'`);
   } finally {
     await pool.end();

--- a/scripts/migration-verify/db.ts
+++ b/scripts/migration-verify/db.ts
@@ -23,6 +23,10 @@ export async function recreateDatabase(name: string): Promise<void> {
   try {
     await pool.query(`DROP DATABASE IF EXISTS ${quoteIdent(name)} WITH (FORCE)`);
     await pool.query(`CREATE DATABASE ${quoteIdent(name)}`);
+    // A continuous-aggregate refresh logs two lines per chunk, which buries the harness's own
+    // report under thousands of lines when CI dumps the service container log. LOG outranks ERROR
+    // in the log_min_messages scale, so silencing it takes 'fatal'.
+    await pool.query(`ALTER DATABASE ${quoteIdent(name)} SET log_min_messages = 'fatal'`);
   } finally {
     await pool.end();
   }

--- a/scripts/migration-verify/db.ts
+++ b/scripts/migration-verify/db.ts
@@ -32,6 +32,19 @@ export async function recreateDatabase(name: string): Promise<void> {
   }
 }
 
+/**
+ * TimescaleDB fires a policy job as soon as its policy is created, so the refresh and compression
+ * schedulers otherwise race the assertions for the same buckets and flood the service container log
+ * that CI dumps at teardown. Every aggregate this harness reads is materialized by the backfill task
+ * it calls directly. Job ids below 1000 are the built-in internal jobs.
+ */
+export async function disableBackgroundJobs(pool: Pool): Promise<void> {
+  await pool.query(
+    `SELECT alter_job(job_id, scheduled => false)
+     FROM timescaledb_information.jobs WHERE job_id >= 1000`
+  );
+}
+
 export async function waitForDatabase(attempts = 30, delayMs = 2000): Promise<void> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {

--- a/scripts/migration-verify/db.ts
+++ b/scripts/migration-verify/db.ts
@@ -11,6 +11,9 @@ function baseConfig(): PoolConfig {
     password: process.env.POSTGRES_PASSWORD ?? 'postgres',
     max: 4,
     connectionTimeoutMillis: 10_000,
+    // The fixtures anchor hours with date_trunc, which truncates in the session timezone, and that
+    // has to agree with time_bucket's UTC-epoch alignment.
+    options: '-c timezone=UTC',
   };
 }
 
@@ -23,9 +26,9 @@ export async function recreateDatabase(name: string): Promise<void> {
   try {
     await pool.query(`DROP DATABASE IF EXISTS ${quoteIdent(name)} WITH (FORCE)`);
     await pool.query(`CREATE DATABASE ${quoteIdent(name)}`);
-    // A continuous-aggregate refresh logs two lines per chunk, which buries the harness's own
-    // report under thousands of lines when CI dumps the service container log. LOG outranks ERROR
-    // in the log_min_messages scale, so silencing it takes 'fatal'.
+    // A continuous-aggregate refresh logs two lines per chunk and buries the harness report; LOG
+    // outranks ERROR in the log_min_messages scale, so silencing it takes 'fatal'. That also drops
+    // every server ERROR and WARNING here, which assertRollupBackfill's job_errors read replaces.
     await pool.query(`ALTER DATABASE ${quoteIdent(name)} SET log_min_messages = 'fatal'`);
   } finally {
     await pool.end();

--- a/scripts/migration-verify/db.ts
+++ b/scripts/migration-verify/db.ts
@@ -32,19 +32,6 @@ export async function recreateDatabase(name: string): Promise<void> {
   }
 }
 
-/**
- * TimescaleDB fires a policy job as soon as its policy is created, so the refresh and compression
- * schedulers otherwise race the assertions for the same buckets and flood the service container log
- * that CI dumps at teardown. Every aggregate this harness reads is materialized by the backfill task
- * it calls directly. Job ids below 1000 are the built-in internal jobs.
- */
-export async function disableBackgroundJobs(pool: Pool): Promise<void> {
-  await pool.query(
-    `SELECT alter_job(job_id, scheduled => false)
-     FROM timescaledb_information.jobs WHERE job_id >= 1000`
-  );
-}
-
 export async function waitForDatabase(attempts = 30, delayMs = 2000): Promise<void> {
   let lastError: unknown;
   for (let attempt = 1; attempt <= attempts; attempt += 1) {

--- a/scripts/migration-verify/fixture.ts
+++ b/scripts/migration-verify/fixture.ts
@@ -92,11 +92,39 @@ export const COUNTER_GUEST = {
 /** Counter rows are one per second, so a whole minute bucket holds 60 of them. */
 export const COUNTER_BUCKET_SAMPLES = Math.min(COUNTER_GUEST.samples, 60);
 
+/**
+ * The one entity type whose gauges are NULL and whose storage_* columns are not, which is the
+ * NULL pattern migration 032 claims is fixed per entity_type and therefore constant within a
+ * rollup group.
+ */
+export const PROXMOX_STORAGE_ENTITY = {
+  entityType: 'storage',
+  entityId: 'ci-node-1/local',
+  entityName: 'local',
+  node: 'ci-node-1',
+} as const;
+
+export const PROXMOX_CLUSTER_ENTITY = {
+  entityType: 'cluster',
+  entityId: 'ci-cluster',
+  entityName: 'ci-cluster',
+  node: null,
+} as const;
+
+export const PROXMOX_STORAGE_VALUES = {
+  storageType: 'dir',
+  storageContent: 'images,iso',
+  storageShared: false,
+};
+
+/** `proxmox_stats.cluster_version` is INT, matching the numeric `version` the collector reads. */
+export const PROXMOX_CLUSTER_VERSION = 8;
+
 export const PROXMOX_SUPPORTING_ENTITIES = [
-  { entityType: 'cluster', entityId: 'ci-cluster', entityName: 'ci-cluster', node: null },
+  PROXMOX_CLUSTER_ENTITY,
   { entityType: 'node', entityId: 'ci-node-1', entityName: 'ci-node-1', node: 'ci-node-1' },
   { entityType: 'lxc', entityId: '201', entityName: 'ci-lxc', node: 'ci-node-1' },
-  { entityType: 'storage', entityId: 'ci-node-1/local', entityName: 'local', node: 'ci-node-1' },
+  PROXMOX_STORAGE_ENTITY,
 ] as const;
 
 export const PROXMOX_SUPPORTING_SAMPLES = 60;
@@ -154,4 +182,21 @@ export function nullMetricRawAverage(): number {
 export function nullMetricDilutedAverage(): number {
   const populated = NULL_METRIC_HOUR.minutes - NULL_METRIC_HOUR.nullMinutes;
   return (NULL_METRIC_HOUR.cpuPercent * populated) / NULL_METRIC_HOUR.minutes;
+}
+
+/** How far apart a correct and an incorrect rollup must land for an assertion to tell them apart. */
+export const MIN_ROLLUP_DISCRIMINATION = 0.5;
+
+if (Math.abs(sparseHourNaiveAverage() - sparseHourRawAverage()) < MIN_ROLLUP_DISCRIMINATION) {
+  throw new Error(
+    `SPARSE_HOUR no longer discriminates weighted from naive rollups: ` +
+      `naive ${sparseHourNaiveAverage()} vs raw ${sparseHourRawAverage()}`
+  );
+}
+
+if (Math.abs(nullMetricDilutedAverage() - nullMetricRawAverage()) < MIN_ROLLUP_DISCRIMINATION) {
+  throw new Error(
+    `NULL_METRIC_HOUR no longer discriminates a diluted average from an undiluted one: ` +
+      `diluted ${nullMetricDilutedAverage()} vs raw ${nullMetricRawAverage()}`
+  );
 }

--- a/scripts/migration-verify/fixture.ts
+++ b/scripts/migration-verify/fixture.ts
@@ -39,6 +39,24 @@ export const SPARSE_HOUR = {
   shortCpuPercent: 90,
 };
 
+/**
+ * One hour where `cpu_percent` is NULL for `nullMinutes` whole minutes and populated for the
+ * rest, with every minute carrying the same sample count. `_1h` sums `metric * sample_count`
+ * (NULL minutes contribute nothing) over `SUM(sample_count)` (which still counts them), so the
+ * hourly average comes out scaled by the populated fraction. Every other metric stays populated,
+ * which keeps the dilution measurable per column instead of per row.
+ */
+export const NULL_METRIC_HOUR = {
+  containerId: 'ci-container-null-metric',
+  containerName: 'ci-null-metric-agent',
+  image: 'ghcr.io/example/gap:1.2.0',
+  hoursAgo: 3,
+  minutes: 60,
+  samplesPerMinute: 60,
+  nullMinutes: 30,
+  cpuPercent: 40,
+};
+
 export const ZFS_ENTITIES = [
   { entity: 'ci-tank', entityType: 'pool', indent: 0 },
   { entity: 'mirror-0', entityType: 'vdev', indent: 2 },
@@ -127,4 +145,13 @@ export function sparseHourNaiveAverage(): number {
   const total =
     SPARSE_HOUR.fullMinutes * SPARSE_HOUR.fullCpuPercent + SPARSE_HOUR.shortCpuPercent;
   return total / (SPARSE_HOUR.fullMinutes + 1);
+}
+
+export function nullMetricRawAverage(): number {
+  return NULL_METRIC_HOUR.cpuPercent;
+}
+
+export function nullMetricDilutedAverage(): number {
+  const populated = NULL_METRIC_HOUR.minutes - NULL_METRIC_HOUR.nullMinutes;
+  return (NULL_METRIC_HOUR.cpuPercent * populated) / NULL_METRIC_HOUR.minutes;
 }

--- a/scripts/migration-verify/run.ts
+++ b/scripts/migration-verify/run.ts
@@ -31,11 +31,13 @@ import {
   assertAggregateRegistry,
   assertAggregateTierValues,
   assertCumulativeCounters,
+  assertHourlyAverageViews,
   assertIdleContainerIdentity,
   assertNullMetricDilution,
   assertRollupBackfill,
   assertRowCountsPreserved,
   assertSchema,
+  assertTierColumnCoverage,
   assertWeightedRollup,
   captureRowCounts,
 } from './assertions';
@@ -78,6 +80,7 @@ async function runFresh(): Promise<void> {
 
     await assertSchema(pool, checks);
     await assertAggregateRegistry(pool, checks);
+    await assertTierColumnCoverage(pool, checks);
     checks.report();
   } finally {
     await pool.end();
@@ -132,12 +135,16 @@ async function runUpgrade(): Promise<void> {
     // rows assertIdleContainerIdentity resolves a name from.
     await runStatsRollupBackfill(asDatabaseClient(pool));
 
+    // Registry and column coverage first: they name the views every later assertion queries by
+    // interpolation, so a missing or renamed one reports as a failed check instead of a throw.
+    await assertAggregateRegistry(pool, checks);
+    await assertTierColumnCoverage(pool, checks);
     await assertRollupBackfill(pool, checks);
     await assertWeightedRollup(pool, checks);
     await assertCumulativeCounters(pool, checks);
     await assertNullMetricDilution(pool, checks);
-    await assertAggregateRegistry(pool, checks);
     await assertAggregateTierValues(pool, checks);
+    await assertHourlyAverageViews(pool, checks);
     checks.report();
   } finally {
     await pool.end();

--- a/scripts/migration-verify/run.ts
+++ b/scripts/migration-verify/run.ts
@@ -4,8 +4,8 @@
  *
  * Scenarios:
  *   fresh       apply every migration to an empty database, assert the schema
- *   upgrade     apply the merge-base migrations, seed data, apply the rest,
- *               assert nothing was lost and the aggregation rules still hold
+ *   upgrade     apply the merge-base migrations, seed data, apply the rest, run the rollup
+ *               backfill, assert nothing was lost and the aggregation rules still hold
  *   idempotent  apply the full set twice, assert the second run applies nothing
  *
  * The idempotent scenario relies on the migration ledger, so it cannot observe
@@ -26,10 +26,14 @@ import { pathToFileURL } from 'node:url';
 import type { Pool } from 'pg';
 import type { DatabaseClient } from '@/lib/clients/database-client';
 import { runMigrations } from '@/lib/database/migrate';
+import { runStatsRollupBackfill } from '@/lib/database/stats-rollup-backfill';
 import {
-  assertAggregateTiers,
+  assertAggregateRegistry,
+  assertAggregateTierValues,
   assertCumulativeCounters,
   assertIdleContainerIdentity,
+  assertNullMetricDilution,
+  assertRollupBackfill,
   assertRowCountsPreserved,
   assertSchema,
   assertWeightedRollup,
@@ -73,7 +77,7 @@ async function runFresh(): Promise<void> {
     checks.sameSet('every migration file was applied', applied, migrationFiles(REPO_ROOT));
 
     await assertSchema(pool, checks);
-    await assertAggregateTiers(pool, checks);
+    await assertAggregateRegistry(pool, checks);
     checks.report();
   } finally {
     await pool.end();
@@ -122,9 +126,18 @@ async function runUpgrade(): Promise<void> {
 
     await assertSchema(pool, checks);
     await assertIdleContainerIdentity(pool, checks);
+
+    // Both of the above read state the backfill changes: it adds the retention policies that
+    // assertSchema requires the migrations not to add, and raw retention covers the 31-day-old
+    // rows assertIdleContainerIdentity resolves a name from.
+    await runStatsRollupBackfill(asDatabaseClient(pool));
+
+    await assertRollupBackfill(pool, checks);
     await assertWeightedRollup(pool, checks);
     await assertCumulativeCounters(pool, checks);
-    await assertAggregateTiers(pool, checks);
+    await assertNullMetricDilution(pool, checks);
+    await assertAggregateRegistry(pool, checks);
+    await assertAggregateTierValues(pool, checks);
     checks.report();
   } finally {
     await pool.end();

--- a/scripts/migration-verify/run.ts
+++ b/scripts/migration-verify/run.ts
@@ -40,7 +40,7 @@ import {
   captureRowCounts,
 } from './assertions';
 import { Checks } from './checks';
-import { createPool, recreateDatabase, waitForDatabase } from './db';
+import { createPool, disableBackgroundJobs, recreateDatabase, waitForDatabase } from './db';
 import { seed } from './seed';
 
 type MigrationRunner = (db: DatabaseClient) => Promise<void>;
@@ -72,6 +72,7 @@ async function runFresh(): Promise<void> {
   const pool = await freshDatabase('fresh');
   try {
     await runMigrations(asDatabaseClient(pool));
+    await disableBackgroundJobs(pool);
 
     const applied = await appliedMigrations(pool);
     checks.sameSet('every migration file was applied', applied, migrationFiles(REPO_ROOT));
@@ -105,6 +106,7 @@ async function runUpgrade(): Promise<void> {
 
     const baseRunner = baseRoot ? await loadBaseRunner(baseRoot) : runMigrations;
     await baseRunner(asDatabaseClient(pool));
+    await disableBackgroundJobs(pool);
     const ledgerBefore = await appliedMigrations(pool);
     checks.sameSet('base revision applied its own migrations', ledgerBefore, baseFiles);
 
@@ -113,6 +115,7 @@ async function runUpgrade(): Promise<void> {
     console.info(`[upgrade] seeded ${Object.values(before).reduce((a, b) => a + b, 0)} rows`);
 
     await runMigrations(asDatabaseClient(pool));
+    await disableBackgroundJobs(pool);
     const ledgerAfter = await appliedMigrations(pool);
     checks.containsAll('head migrations are all recorded', ledgerAfter, headFiles);
     checks.sameSet(
@@ -149,6 +152,7 @@ async function runIdempotent(): Promise<void> {
   const pool = await freshDatabase('idempotent');
   try {
     await runMigrations(asDatabaseClient(pool));
+    await disableBackgroundJobs(pool);
     const first = await migrationLedger(pool);
     checks.equal('first run applied every migration', first.length, migrationFiles(REPO_ROOT).length);
 

--- a/scripts/migration-verify/run.ts
+++ b/scripts/migration-verify/run.ts
@@ -40,7 +40,7 @@ import {
   captureRowCounts,
 } from './assertions';
 import { Checks } from './checks';
-import { createPool, disableBackgroundJobs, recreateDatabase, waitForDatabase } from './db';
+import { createPool, recreateDatabase, waitForDatabase } from './db';
 import { seed } from './seed';
 
 type MigrationRunner = (db: DatabaseClient) => Promise<void>;
@@ -72,7 +72,6 @@ async function runFresh(): Promise<void> {
   const pool = await freshDatabase('fresh');
   try {
     await runMigrations(asDatabaseClient(pool));
-    await disableBackgroundJobs(pool);
 
     const applied = await appliedMigrations(pool);
     checks.sameSet('every migration file was applied', applied, migrationFiles(REPO_ROOT));
@@ -106,7 +105,6 @@ async function runUpgrade(): Promise<void> {
 
     const baseRunner = baseRoot ? await loadBaseRunner(baseRoot) : runMigrations;
     await baseRunner(asDatabaseClient(pool));
-    await disableBackgroundJobs(pool);
     const ledgerBefore = await appliedMigrations(pool);
     checks.sameSet('base revision applied its own migrations', ledgerBefore, baseFiles);
 
@@ -115,7 +113,6 @@ async function runUpgrade(): Promise<void> {
     console.info(`[upgrade] seeded ${Object.values(before).reduce((a, b) => a + b, 0)} rows`);
 
     await runMigrations(asDatabaseClient(pool));
-    await disableBackgroundJobs(pool);
     const ledgerAfter = await appliedMigrations(pool);
     checks.containsAll('head migrations are all recorded', ledgerAfter, headFiles);
     checks.sameSet(
@@ -152,7 +149,6 @@ async function runIdempotent(): Promise<void> {
   const pool = await freshDatabase('idempotent');
   try {
     await runMigrations(asDatabaseClient(pool));
-    await disableBackgroundJobs(pool);
     const first = await migrationLedger(pool);
     checks.equal('first run applied every migration', first.length, migrationFiles(REPO_ROOT).length);
 

--- a/scripts/migration-verify/seed.ts
+++ b/scripts/migration-verify/seed.ts
@@ -5,7 +5,9 @@ import {
   DOCKER_HOST,
   IDLE_CONTAINER,
   NULL_METRIC_HOUR,
+  PROXMOX_CLUSTER_VERSION,
   PROXMOX_HOST,
+  PROXMOX_STORAGE_VALUES,
   PROXMOX_SUPPORTING_ENTITIES,
   PROXMOX_SUPPORTING_GAP_MINUTES,
   PROXMOX_SUPPORTING_SAMPLES,
@@ -225,7 +227,8 @@ async function seedZfs(pool: Pool): Promise<void> {
 
 const PROXMOX_COLUMNS = `(
   time, host, entity_type, node, entity_id, entity_name, status,
-  cpu, max_cpu, mem, max_mem, disk, max_disk, uptime, vmid, netin, netout
+  cpu, max_cpu, mem, max_mem, disk, max_disk, uptime, vmid, netin, netout,
+  storage_type, storage_content, storage_avail, storage_shared, cluster_version
 )`;
 
 // Anchored to the last second of the previous whole hour, which pins two things the counter
@@ -238,12 +241,17 @@ async function seedProxmoxCounters(pool: Pool): Promise<void> {
      SELECT
        date_trunc('hour', now()) - make_interval(secs => s + 1),
        $1, $2, $3, $4, $5, 'running',
-       0.15 + 0.05 * sin(s / 20.0), 4,
-       2147483648, 4294967296, 10737418240, 53687091200,
+       0.15 + 0.05 * sin(s / 20.0),
+       4 + (s % 3),
+       2147483648 + (s % 48)::bigint * 1048576,
+       4294967296 + (s % 16)::bigint * 1048576,
+       10737418240 + (s % 32)::bigint * 1048576,
+       53687091200 + (s % 24)::bigint * 1048576,
        $6::bigint + ($7::int - 1 - s) * $8::bigint,
        $9::int,
        $10::bigint + ($7::int - 1 - s) * $11::bigint,
-       $12::bigint + ($7::int - 1 - s) * $13::bigint
+       $12::bigint + ($7::int - 1 - s) * $13::bigint,
+       NULL, NULL, NULL, NULL, NULL
      FROM generate_series(0, $7::int - 1) AS s`,
     [
       PROXMOX_HOST,
@@ -263,19 +271,65 @@ async function seedProxmoxCounters(pool: Pool): Promise<void> {
   );
 }
 
-async function seedProxmoxSupporting(pool: Pool): Promise<void> {
-  for (const entity of PROXMOX_SUPPORTING_ENTITIES) {
-    await pool.query(
-      `INSERT INTO proxmox_stats ${PROXMOX_COLUMNS}
-       SELECT
-         now() - make_interval(mins => s * $6::int),
-         $1, $2, $3, $4, $5, 'running',
+const PROXMOX_SUPPORTING_GAUGES = `'running',
          0.2 + 0.05 * sin(s / 8.0), 8,
          4294967296, 17179869184, 21474836480, 107374182400,
          604800 - s * 60,
          NULL,
          2000000 + (($7::int - 1 - s) * 8192)::bigint,
-         1000000 + (($7::int - 1 - s) * 4096)::bigint
+         1000000 + (($7::int - 1 - s) * 4096)::bigint`;
+
+const PROXMOX_STORAGE_GAUGES = `'active',
+         NULL, NULL,
+         NULL, NULL, NULL, NULL,
+         NULL,
+         NULL,
+         NULL, NULL`;
+
+/**
+ * Migration 032 rolls up a column the same way for every row of an entity_type, so each type is
+ * seeded with the NULL pattern its collector produces: storage rows carry storage_avail and no
+ * gauges, everything else the inverse.
+ */
+function proxmoxSupportingShape(entityType: string): { metrics: string; params: unknown[] } {
+  if (entityType === 'storage') {
+    return {
+      metrics: `${PROXMOX_STORAGE_GAUGES},
+         $8::text, $9::text,
+         5497558138880 + (s % 24)::bigint * 1073741824,
+         $10::boolean, NULL`,
+      params: [
+        PROXMOX_STORAGE_VALUES.storageType,
+        PROXMOX_STORAGE_VALUES.storageContent,
+        PROXMOX_STORAGE_VALUES.storageShared,
+      ],
+    };
+  }
+  if (entityType === 'cluster') {
+    return {
+      metrics: `${PROXMOX_SUPPORTING_GAUGES},
+         NULL, NULL, NULL, NULL, $8::int`,
+      params: [PROXMOX_CLUSTER_VERSION],
+    };
+  }
+  return {
+    metrics: `${PROXMOX_SUPPORTING_GAUGES},
+         NULL, NULL, NULL, NULL, NULL`,
+    params: [],
+  };
+}
+
+// Anchored to the previous whole hour for the same reason as the counter guest: seeding back from
+// now() puts every row in the in-progress hour whenever a run starts in the last minute of one, and
+// the storage and cluster probes need a closed `_1h` bucket to compare against.
+async function seedProxmoxSupporting(pool: Pool): Promise<void> {
+  for (const entity of PROXMOX_SUPPORTING_ENTITIES) {
+    const shape = proxmoxSupportingShape(entity.entityType);
+    await pool.query(
+      `INSERT INTO proxmox_stats ${PROXMOX_COLUMNS}
+       SELECT
+         date_trunc('hour', now()) - make_interval(mins => (s + 1) * $6::int),
+         $1, $2, $3, $4, $5, ${shape.metrics}
        FROM generate_series(0, $7::int - 1) AS s`,
       [
         PROXMOX_HOST,
@@ -285,6 +339,7 @@ async function seedProxmoxSupporting(pool: Pool): Promise<void> {
         entity.entityName,
         PROXMOX_SUPPORTING_GAP_MINUTES,
         PROXMOX_SUPPORTING_SAMPLES,
+        ...shape.params,
       ]
     );
   }

--- a/scripts/migration-verify/seed.ts
+++ b/scripts/migration-verify/seed.ts
@@ -4,6 +4,7 @@ import {
   COUNTER_GUEST,
   DOCKER_HOST,
   IDLE_CONTAINER,
+  NULL_METRIC_HOUR,
   PROXMOX_HOST,
   PROXMOX_SUPPORTING_ENTITIES,
   PROXMOX_SUPPORTING_GAP_MINUTES,
@@ -37,6 +38,7 @@ export async function seed(pool: Pool): Promise<void> {
   await seedDockerActive(pool);
   await seedDockerIdle(pool);
   await seedDockerSparseHour(pool);
+  await seedDockerNullMetricHour(pool);
   await seedZfs(pool);
   await seedProxmoxCounters(pool);
   await seedProxmoxSupporting(pool);
@@ -144,6 +146,35 @@ async function seedDockerSparseHour(pool: Pool): Promise<void> {
   );
 }
 
+async function seedDockerNullMetricHour(pool: Pool): Promise<void> {
+  for (const [fromMinute, toMinute, cpu] of [
+    [0, NULL_METRIC_HOUR.nullMinutes - 1, null],
+    [NULL_METRIC_HOUR.nullMinutes, NULL_METRIC_HOUR.minutes - 1, NULL_METRIC_HOUR.cpuPercent],
+  ] as const) {
+    await pool.query(
+      `INSERT INTO docker_stats ${DOCKER_COLUMNS}
+       SELECT
+         date_trunc('hour', now()) - make_interval(hours => $5::int)
+           + make_interval(mins => m, secs => s),
+         $1, $2, $3, $4,
+         $6::double precision,
+         ${DOCKER_METRICS}
+       FROM generate_series($7::int, $8::int) AS m, generate_series(0, $9::int - 1) AS s`,
+      [
+        DOCKER_HOST,
+        NULL_METRIC_HOUR.containerId,
+        NULL_METRIC_HOUR.containerName,
+        NULL_METRIC_HOUR.image,
+        NULL_METRIC_HOUR.hoursAgo,
+        cpu,
+        fromMinute,
+        toMinute,
+        NULL_METRIC_HOUR.samplesPerMinute,
+      ]
+    );
+  }
+}
+
 const ZFS_COLUMNS = `(
   time, host, pool, entity, entity_type, indent,
   capacity_alloc, capacity_free,
@@ -197,13 +228,15 @@ const PROXMOX_COLUMNS = `(
   cpu, max_cpu, mem, max_mem, disk, max_disk, uptime, vmid, netin, netout
 )`;
 
-// Anchored to the last second of the previous whole minute: seeding up to now() leaves the newest
-// bucket holding only the seconds elapsed past it, and under 4 samples its AVG converges on its LAST.
+// Anchored to the last second of the previous whole hour, which pins two things the counter
+// assertions read: the newest minute bucket is whole (seeding up to now() leaves it holding only
+// the seconds elapsed past it, and under 4 samples its AVG converges on its LAST), and every row
+// falls inside one already-closed hour bucket, which is the only kind `_1h` materializes.
 async function seedProxmoxCounters(pool: Pool): Promise<void> {
   await pool.query(
     `INSERT INTO proxmox_stats ${PROXMOX_COLUMNS}
      SELECT
-       date_trunc('minute', now()) - make_interval(secs => s + 1),
+       date_trunc('hour', now()) - make_interval(secs => s + 1),
        $1, $2, $3, $4, $5, 'running',
        0.15 + 0.05 * sin(s / 20.0), 4,
        2147483648, 4294967296, 10737418240, 53687091200,


### PR DESCRIPTION
## What and why

The `migrations` CI job proved six continuous aggregates exist and nothing about what they compute. Three assertions created the appearance of coverage while reading only the raw hypertables, and no aggregate was ever refreshed, so all six views were empty anyway. This makes the rollup math actually verified and settles the NULL-dilution premise from #373 ("Make `assertAggregateTiers`'s per-tier loops usable. **The aggregate math remains unverified.**" plus "`docker_stats_1h` NULL dilution, documented at `030:44-48`").

### The three tautologies removed

1. **`assertWeightedRollup`** queried `docker_stats`, the raw hypertable, computed `sum(avg_cpu * sample_count) / sum(sample_count)` in its own CTE and asserted that result equalled `avg(cpu_percent)` over the same rows. That is an arithmetic identity over the fixture, true whatever `docker_stats_1h` contains. It now reads `docker_stats_1h_avg`.
2. **`assertCumulativeCounters`** did the same against raw `proxmox_stats`: it computed last, avg and max itself and asserted they differ. It never checked that `proxmox_stats_1m` used `last(netin)` rather than `AVG(netin)`, the one mistake the design exists to prevent. It now reads `proxmox_stats_1m`.
3. **`assertAggregateTiers`** was the only assertion touching `tier.view`, but all six tiers declared `weightedAverageColumns: []` and `lastValueColumns: []`, so both inner loops were no-ops and only the `sameSet` on view names ran. The docstring explaining why the lists were empty is gone with the reasons: each tier now declares its own key columns, bucket unit, source weight and view/source column shape.

On top of that the migrations create every aggregate `WITH NO DATA` and nothing in the harness called `refresh_continuous_aggregate`, so the views were empty at assertion time regardless.

## Flow

```text
base migrations -> seed (docker/zfs/proxmox) -> head migrations -> runStatsRollupBackfill
  -> assertRollupBackfill      (six views non-empty, retention landed: raw 24h, _1m 30d, _1h none)
  -> assertWeightedRollup      docker_stats_1h_avg.cpu_percent == raw average, != naive average
  -> assertCumulativeCounters  proxmox_stats_1m.{netin,netout,uptime} == bucket LAST, != bucket AVG
  -> assertNullMetricDilution  measures the 030:44-48 limitation, per column
  -> assertAggregateTierValues replays each of the six tiers against its own source
```

Materialization comes from `runStatsRollupBackfill` (`src/lib/database/stats-rollup-backfill.ts`), the startup task `initServer()` fires, rather than a direct `refresh_continuous_aggregate`: its window sizing had never run against a live TimescaleDB either. It swallows a per-source failure and only skips that source's retention, so `assertRollupBackfill` treats an empty view or a missing policy as the failure signal. Ordering matters and is commented in `run.ts`: the backfill adds the retention policies `assertSchema` requires the migrations not to add, and raw retention covers the 31-day-old rows `assertIdleContainerIdentity` reads, so both run before it.

Per-tier probes take their bucket from the view itself, excluding the in-progress one, and a tier that materialized nothing fails on a missing bucket instead of comparing `NULL` against `NULL`. Hour bounds for the single-hour docker fixtures come from `min(time)` of their own rows, not from `now() - N hours`, so a run that crosses an hour boundary after seeding still finds its bucket.

## What else this touches

Nothing outside `scripts/migration-verify/` and the `migrations` job in `.github/workflows/ci.yml`. No migration is added or changed, no aggregate definition is touched, and `src/` is untouched apart from the harness importing `runStatsRollupBackfill`.

Fixture changes: a new `NULL_METRIC_HOUR` docker container (`cpu_percent` NULL for 30 of 60 minutes, every other metric populated), and the proxmox counter guest re-anchored from `date_trunc('minute', now())` to `date_trunc('hour', now())` so its 600 samples sit inside one already-closed hour bucket, which is the only kind `_1h` materializes. `sparseHourRawAverage()` and `sparseHourNaiveAverage()` were already exported and unused; they are now the expected values.

Two CI-side changes came out of debugging this job: the service container gets `--log-opt max-size=8k`, because CI dumps that container's whole log after the last step and the policy schedulers write a line per chunk they touch, which pushed the harness's own report thousands of lines out of the job log tail; and the job gets `timeout-minutes: 15`, after a discarded attempt at disabling the policy jobs hung on `alter_job` (it blocks on a job that is already running, and TimescaleDB starts one the moment a policy is created).

## Verification

**Watched to fail first.** Run [30234704095](https://github.com/jaredglaser/homelab-manager/actions/runs/30234704095/job/89880202043) (commit `2fb302c`) ran with `MIGRATION_VERIFY_SIMULATE_REGRESSION=true`, which substituted the number a regressed aggregate would report into each new value check: **63/128 checks passed, 65 failed.** Every new assertion failed, with the expected values computed live from the source data:

```text
FAIL docker_stats_1h_avg.cpu_percent equals the raw average
     (expected 10.27027027027027 +/- 1.027e-8, got 11.333333333333334 (delta 1.0630630630630638))
FAIL docker_stats_1h_avg.cpu_percent is not the equal-weighted average of the minute averages
     (expected the two values to differ by at least 0.5, got 0)
FAIL proxmox_stats_1m.netin  carries the bucket LAST value (expected 3453504, got 3332672)
FAIL proxmox_stats_1m.netout carries the bucket LAST value (expected 1726752, got 1666336)
FAIL proxmox_stats_1m.uptime carries the bucket LAST value (expected 86999, got 86969.5)
FAIL proxmox_stats_1m.{netin,netout,uptime} is not the bucket average
     (expected the two values to differ by at least 1, got 0)
FAIL docker_stats_1h_avg.cpu_percent is diluted to 30/60 of the populated average
     (expected 20 +/- 2e-8, got 40 (delta 20))
FAIL the diluted hourly average is not the populated average (... got 0)
FAIL a metric populated on every row is undiluted in the same hour
     (expected 26.4404296875 +/- 2.644e-8, got 40.66064453125 (delta 14.22021484375))
FAIL docker_stats raw rows are dropped after 24 hours (expected "24 hours", got "none")
FAIL docker_stats_1m rows are dropped after 30 days (expected "30 days", got "none")
     (and the same pair for zfs_stats and proxmox_stats)
FAIL docker_stats_1h.cpu_percent_sum is the sample-count weighted sum of its source
     (expected 36480 +/- 3.6e-5, got 54721 (delta 18241))
FAIL docker_stats_1h.sample_count totals the source weights (expected 3552, got 3553)
     (and 49 more across the six tiers: sample_count, weighted columns, last-value columns)
```

The 1.063 miss on the weighted rollup is exactly the sparse-hour fixture's documented discriminating margin, and the three counter values the simulation substituted are precisely each bucket's average, the failure mode `last()` exists to avoid.

**Then to pass.** Run [30234818630](https://github.com/jaredglaser/homelab-manager/actions/runs/30234818630/job/89880541972) (commit `60d961f`, simulation and its scaffolding removed) is green on all three scenarios: `[fresh]`, `[upgrade]` with the same 128 checks, and `[idempotent] 3/3`. `Checks.report()` throws on any failure and skips the later steps, so the idempotent report only appears when the upgrade scenario passed all 128. The other five jobs on that run are green as well.

Locally: `bun run typecheck` clean. No `src/` change, so the unit suites are untouched; the local suite is unusable here anyway (Bun 1.3.11 against the pinned 1.3.14).

## Item 2: the NULL-dilution premise holds, and the test stays as a boundary marker

Migration `030:44-48` documents that `SUM(metric * sample_count)` skips minutes where the metric is NULL while `SUM(sample_count)` still counts them, and justifies it with a premise: "The collector writes every metric on every row, so in practice a column is NULL for all of an entity's minutes or none of them."

**The dilution is real and now measured.** For the new fixture container, `docker_stats_1h_avg.cpu_percent` reports **20.0** where the average over the populated rows is **40.0**: exactly `populated_minutes / total_minutes` = 30/60. In the same hour and the same row, `memory_percent`, which every raw row carries, comes out at **26.4404296875**, equal to the raw average. So the error is per column, not per row, and its magnitude is the populated fraction.

**The collectors cannot produce that state.** Read at `60d961f`:

- **docker**: `agent/src/routes/stats.ts` `computeMetrics()` returns all eight metrics through `safeNum()` (NaN/Infinity become 0), so no field is ever absent; `src/worker/collectors/agent-stats-collector.ts` `toNewDockerStat()` copies them one to one.
- **zfs**: `src/lib/parsers/zfs-iostat-parser.ts` maps `-` to 0 and returns `null` for any line where a numeric field parses to NaN, dropping the whole row rather than nulling one column. `NewZFSStat`'s numeric fields are non-nullable and the insert arrays are `number[]`.
- **proxmox**: `src/lib/utils/proxmox-overview-converter.ts` gives every nullable metric either `?? 0` or a literal `null` fixed by entity type (cluster/node/qemu/lxc carry cpu/mem/disk and a NULL `storage_avail`; storage rows carry NULL cpu/mem and a real `storage_avail`). `entity_type` is part of the aggregate's `GROUP BY`, so within a group the NULL pattern is constant, which is what `032:44-47` already claims.
- No migration has ever added a metric column to an existing stats table (only `seq` in 003, removed in 006, and `zfs_stats.host` in 004 with `NOT NULL DEFAULT`), so the "column appears mid-history" path that would straddle one hour does not exist in the current set.

**No bug to file.** The one residual path is not reachable by anything shipped: `agent-stats-collector.ts` casts the SSE frame (`frame as AgentStatsEvent`) with no validation, so an agent build that stopped emitting a metric field, restarted into mid-hour, would write NULL for part of an hour. Nothing in `agent/` does that, and a version that never emits the field dilutes nothing because the column is then NULL for every minute. The assertion stays as a regression guard that states the boundary in numbers rather than prose: if a future collector or migration makes a per-metric NULL possible for part of an hour, the 20-versus-40 result is already written down.
