### PR TITLE
ci: fix zizmor findings in the three workflow files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,16 +17,23 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-test:
     name: Build, Test & License Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # paths-filter calls pulls.listFiles on pull_request events
 
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Detect dependency changes
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -39,6 +46,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -87,6 +96,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -117,12 +128,16 @@ jobs:
   agent:
     name: Agent Test & License Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # paths-filter calls pulls.listFiles on pull_request events
 
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Detect dependency changes
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -135,6 +150,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
 
       - name: Install dependencies
         run: cd agent && bun install --frozen-lockfile
@@ -173,12 +190,16 @@ jobs:
   agent-updater:
     name: Agent Updater Test & License Check
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read   # paths-filter calls pulls.listFiles on pull_request events
 
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 2
+          persist-credentials: false
 
       - name: Detect dependency changes
         uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v4.0.2
@@ -191,6 +212,8 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
 
       - name: Install dependencies
         run: cd agent-updater && bun install --frozen-lockfile
@@ -233,9 +256,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -277,20 +304,27 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Check out the merge base
         id: base
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            BASE_SHA="$PR_BASE_SHA"
           else
-            BASE_SHA="${{ github.event.before }}"
+            BASE_SHA="$PUSH_BEFORE_SHA"
           fi
           if [ -z "$BASE_SHA" ] || ! git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
             echo "No usable base commit, comparing HEAD against itself"
@@ -323,6 +357,7 @@ jobs:
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: SonarQube Scan
         uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
@@ -341,6 +376,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
@@ -458,9 +495,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
+        with:
+          no-cache: true
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,9 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions:
+  contents: read
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/sonarqube-autofix.yml
+++ b/.github/workflows/sonarqube-autofix.yml
@@ -28,6 +28,9 @@ on:
         default: "jaredglaser"
         type: string
 
+permissions:
+  contents: read
+
 jobs:
   autofix:
     name: Fetch → Triage → Fix → PR
@@ -77,8 +80,10 @@ jobs:
       - name: Check for issues to fix
         id: check-issues
         if: ${{ !inputs.dry_run && steps.triage.outcome == 'success' }}
+        env:
+          ISSUE_COUNT: ${{ steps.triage.outputs.issue_count }}
         run: |
-          if [ "${{ steps.triage.outputs.issue_count }}" != "0" ]; then
+          if [ "$ISSUE_COUNT" != "0" ]; then
             echo "has_issues=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_issues=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## What and why

`zizmor` reports 28 findings against the three workflow files on `main`. This fixes the ones that can be fixed without changing what any job does, taking the default-persona count to 5 and the auditor-persona count from 46 to 18. Four rules are cleared: `excessive-permissions` (7 to 0), `template-injection` (4 to 0 across default and pedantic), `artipacked` (10 to 2) and `cache-poisoning` (8 to 1).

This is the zizmor half of #379. #393 did the SHA-pinning half and merged while this was in progress, so this branch was restacked from `claude/actions-sha-pinning` onto `main` and targets `main`. No `uses:` line appears in the diff.

## Flow

CI trigger (`push` to `main` or a `v*.*.*` tag, `pull_request`, `workflow_dispatch`) -> GitHub mints a `GITHUB_TOKEN` scoped by the effective `permissions:` -> `actions/checkout` writes the workspace -> steps run.

Before: no workflow declared a top-level `permissions:`, so every job without its own block (`build-test`, `agent`, `agent-updater`, `demo-build`, `migrations`, `sonarcloud`) got the repository default. Eight of the nine `ci.yml` checkouts left the token in `.git/config`, reachable by every later step in the job and by anything that archives the workspace. Two `run:` blocks pasted context values straight into shell source.

After: each workflow defaults to `contents: read` and each job holds only what its own steps call. Checkouts that never reach GitHub with the ambient credential drop it. The two `run:` blocks read their values from `env:`.

## What else this touches

Nothing outside the three workflow files. No `uses:` reference, SHA, version comment, job, step name, `needs:`, `if:`, service, or step ordering changed. `publish` and `deploy-demo` already declared their own `permissions:` blocks and those blocks are untouched, so the release path's scopes are exactly what `main` already ships.

### `persist-credentials` per job

`persist-credentials: false` is set only where the job provably never reaches GitHub with the git credential. zizmor's own auto-fix wants it on all ten checkouts; two of those would break the job, so the auto-fix was not taken wholesale.

| Job (file) | Set to `false` | Evidence |
| --- | --- | --- |
| `build-test` (ci) | yes | `dorny/paths-filter` has its own `token:` input defaulting to `${{ github.token }}` and calls `pulls.listFiles` through Octokit on `pull_request`. On `push` it falls back to `git fetch --depth=1 --no-tags origin <sha>`, which is anonymous-capable: the repo is public. Nothing else in the job talks to GitHub. |
| `e2e` (ci) | already was | Pre-existing, unchanged. |
| `agent` (ci) | yes | Same step set as `build-test`. |
| `agent-updater` (ci) | yes | Same step set as `build-test`. |
| `demo-build` (ci) | yes | checkout, setup-bun, `bun install`, `bun run build:demo`. No network git, no `gh`, no API. |
| `migrations` (ci) | yes | The merge-base step runs `git cat-file`, `git merge-base`, `git rev-parse` and `git worktree add` only. All local, and `fetch-depth: 0` already put every object on disk. |
| `sonarcloud` (ci) | yes | `SonarSource/sonarqube-scan-action` at the pinned SHA declares no `token` input and never calls the GitHub API; it reads SCM history locally and authenticates to SonarCloud with `SONAR_TOKEN`. PR decoration is done server-side by the SonarCloud GitHub App, not by this job. |
| `publish` (ci) | yes | `docker/login-action` receives the registry password as an explicit `${{ secrets.GITHUB_TOKEN }}` input; `metadata-action` reads the `github` context; `build-push-action` builds from a local context. None of them read `.git/config`. |
| `deploy-demo` (ci) | yes | `actions/configure-pages` and `actions/deploy-pages` each declare `token:` with `default: ${{ github.token }}` at their pinned SHAs, so they get the token as an input. `upload-pages-artifact` uses the artifact runtime token. |
| `claude` (claude.yml) | **no** | `anthropics/claude-code-action` runs Claude inside the checked-out repo and commits and pushes from there; the job holds `contents: write` for exactly that. Removing the credential risks breaking the push. |
| `autofix` (sonarqube-autofix.yml) | **no** | The "Commit fixes" step runs `git push origin "$BRANCH"` directly. |

### Permission derivation

Top level in all three files: `contents: read`.

`build-test`, `agent` and `agent-updater` additionally get `pull-requests: read`, because `paths-filter` calls `GET /repos/{owner}/{repo}/pulls/{n}/files` on `pull_request` events and that endpoint documents Pull requests: read. Granting it explicitly rather than relying on public-repo read fallthrough. `demo-build`, `migrations` and `sonarcloud` inherit `contents: read` with no block of their own; a single restrictive top-level default is what clears zizmor's per-job findings, so no extra blocks were added for the scanner's sake.

`e2e` (`contents: read`), `publish` and `deploy-demo` already had explicit blocks and are not modified. Their scopes are reproduced here with the API each step calls, because **CI on this PR cannot validate them**: `publish` is gated on `if: github.event_name == 'push'` and `deploy-demo` on `github.event_name == 'push' && github.ref == 'refs/heads/main'`, so both report as skipped on a `pull_request` run. A wrong scope on either would first surface as a 403 at release time.

`publish`, currently `contents: read` + `packages: write`:

| Step | API called | Scope that covers it |
| --- | --- | --- |
| Checkout code | git fetch over HTTPS | `contents: read` |
| Log in to GHCR | `POST https://ghcr.io/v2/token` with the token as password | `packages: write` (write is needed because the token is later used to push, not just pull) |
| Set up Docker Buildx | none; installs the buildx plugin | none |
| Extract metadata (4 steps) | none; reads the `github` context from env | none |
| Build and push (4 steps) | `PUT /v2/<image>/manifests/<tag>` and blob uploads on `ghcr.io`; `cache-from`/`cache-to: type=gha` uses the Actions cache service via `ACTIONS_RUNTIME_TOKEN` | `packages: write` for the registry writes; the GHA cache is authorized by the runtime token, not by a `permissions:` scope |

`deploy-demo`, currently `contents: read` + `pages: write` + `id-token: write`:

| Step | API called | Scope that covers it |
| --- | --- | --- |
| Checkout code | git fetch over HTTPS | `contents: read` |
| Setup Bun, Install dependencies, Build demo, rename `_shell.html` | none | none |
| Configure Pages | `GET /repos/{o}/{r}/pages` (and `POST` only when `enablement: true`, which is not set) | `pages: write` |
| Upload Pages artifact | Actions artifact upload via `ACTIONS_RUNTIME_TOKEN` | none |
| Deploy to GitHub Pages | `POST /repos/{o}/{r}/pages/deployments`, then polls `GET .../deployments/{id}/status`; the deployment is authenticated with an OIDC ID token | `pages: write` plus `id-token: write` |

Both blocks match what their steps need, which is why neither is changed. No scope was narrowed on either job, so nothing about the release path is being guessed at.

### Findings deliberately not fixed

5 default-persona findings remain, all pre-existing:

| Rule | Location | Why not fixed |
| --- | --- | --- |
| `artipacked` (Medium) | `claude.yml:34` | The job pushes commits through the checked-out repo. See the table above. |
| `artipacked` (Medium) | `sonarqube-autofix.yml:44` | The job runs `git push origin "$BRANCH"`. See the table above. |
| `bot-conditions` (High) | `claude.yml:19`, `github.actor == 'github-actions[bot]'` | zizmor's remediation is `github.event.pull_request.user.login`, which does not exist for this workflow's triggers (`issue_comment`, `issues`, `pull_request_review_comment`, `pull_request_review`); there is no `pull_request` context to read. The documented attack is a `pull_request_target` auto-merge flow where `github.actor` is the last pusher rather than the PR author; on comment and review events `github.actor` is the authenticated author of the triggering action, and `github-actions[bot]` is not a registrable username. The per-event equivalents diverge in meaning (on `issues: assigned` the actor is the assigner, not `github.event.issue.user.login`), so rewriting the gate could silently stop the workflow from triggering. Whether the `github-actions[bot]` clause is still wanted is a repo-owner call; left for a follow-up. |
| `cache-poisoning` (High) | `ci.yml:106`, the `e2e` Playwright `actions/cache` step | The recognized fix is `lookup-only: true`, which disables both the restore and the save. That leaves the step in place doing nothing while `bunx playwright install` re-downloads Chromium on every run, roughly a minute added to each `e2e` job. Deleting the step outright is a restructure. `e2e` publishes nothing, so the residual exposure is a gate job. |
| `adhoc-packages` (Low) | `sonarqube-autofix.yml:59`, `npm install -g @anthropic-ai/claude-code@1` | The remediation is to move the CLI into a committed manifest with a lockfile, which pins an automation tool that is deliberately tracking the v1 line. That is a dependency-management decision, not workflow hardening. |

At `--persona=auditor` a further 13 findings remain, all opt-in personas and all pre-existing: `undocumented-permissions` (4, on permission lines inside blocks this PR does not touch), `secrets-outside-env` (6, wants a dedicated GitHub environment per secret), `concurrency-limits` (2) and `anonymous-definition` (1). Rule 14 in `CLAUDE.md` governs comments, so `contents: read` gets none; the three `pull-requests: read` lines carry a one-line reason in the trailing-comment style `claude.yml` already uses, which also keeps `undocumented-permissions` at its pre-existing 4 rather than 7.

### Where zizmor disagreed with the hand-written list on #379

The prior pass flagged the `migrations` merge-base interpolations as `template-injection`. zizmor does not report them at the default persona, only at `--persona=pedantic` (Low/High, `ci.yml:290`, `:291`, `:293`), because it does not model `github.event_name` or a base SHA as attacker-controllable. They are fixed anyway: the change is mechanical, and it removes the string-termination surface regardless of who can reach it today.

The prior pass also listed `persist-credentials` as missing on 8 of 9 `ci.yml` checkouts, which matched exactly. It did not mention `cache-poisoning`, `bot-conditions` or `adhoc-packages`, which zizmor reports on top.

## Verification

No application code changed, so `typecheck` and the test suites are not implicated. What was run, with `zizmor` 1.28.0 via `uvx`:

Baseline, `.github/workflows/` at `origin/main` (`c3c9b28`):

```
28 findings: 1 informational, 1 low, 17 medium, 9 high      # default persona
46 findings: 2 informational, 10 low, 25 medium, 9 high     # --persona=auditor
```

After:

```
18 findings (13 suppressed): 0 informational, 1 low, 2 medium, 2 high   # default persona
18 findings: 1 informational, 7 low, 8 medium, 2 high                   # --persona=auditor
```

By rule, at `--persona=auditor` so nothing is hidden:

| Rule | Severity | Persona | Before | After |
| --- | --- | --- | --- | --- |
| `adhoc-packages` | Low | Regular | 1 | 1 |
| `anonymous-definition` | Informational | Pedantic | 1 | 1 |
| `artipacked` | Medium | Regular | 10 | 2 |
| `bot-conditions` | High | Regular | 1 | 1 |
| `cache-poisoning` | High | Regular | 8 | 1 |
| `concurrency-limits` | Low | Pedantic | 2 | 2 |
| `excessive-permissions` | Medium | Pedantic | 2 | **0** |
| `excessive-permissions` | Medium | Regular | 7 | **0** |
| `secrets-outside-env` | Medium | Auditor | 6 | 6 |
| `template-injection` | Informational | Regular | 1 | **0** |
| `template-injection` | Low | Pedantic | 3 | **0** |
| `undocumented-permissions` | Low | Pedantic | 4 | 4 |
| **total** | | | **46** | **18** |

Also run:

- `python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]" .github/workflows/*.yml`: all three parse.
- `git diff origin/main -- .github/workflows/ | grep -cE '^[+-].*uses:'`: `0`. No `uses:` line, SHA, or version comment is in the diff, including through the restack, where every conflict was a version comment on a `uses:` line adjacent to an added `with:` block and was resolved to `main`'s text.
- Dash scan over the diff: no match.
- Added comment lines in the diff: three, each a one-line reason on a `pull-requests: read` scope.
- `git status`: only the three workflow files.

### The rewritten `run:` blocks are behaviorally identical

`sonarqube-autofix.yml`, "Check for issues to fix": `${{ steps.triage.outputs.issue_count }}` became `ISSUE_COUNT` in `env:` and `"$ISSUE_COUNT"` in the test. Same name the "Commit fixes" and "Open PR" steps already use for the same output. One comparison, same operand, same branches.

`ci.yml`, "Check out the merge base": the three interpolations became `EVENT_NAME`, `PR_BASE_SHA` and `PUSH_BEFORE_SHA`. A missing context expands to the empty string either way, as an inline expansion or as an `env:` value, so the `[ -z "$BASE_SHA" ]` guard sees the same thing. Per event:

- `pull_request`: `EVENT_NAME` is `pull_request`, so `BASE_SHA` takes `github.event.pull_request.base.sha`, exactly the old `then` branch.
- `push` to `main`: `EVENT_NAME` is `push`, `PR_BASE_SHA` is empty because the payload has no `pull_request`, so the `else` branch takes `github.event.before`, exactly as before.
- `push` of a `v*.*.*` tag: same `else` branch. `before` is the all-zeros SHA, `git cat-file -e "0000...^{commit}"` fails, and the block falls back to `git rev-parse HEAD`. Identical to the old behavior, which interpolated the same all-zeros literal.
- Any other event: `else` branch with an empty `PUSH_BEFORE_SHA`, caught by `-z`, falls back to `HEAD`. Same as before.

The only behavioral difference is the intended one: a value containing a quote or a shell metacharacter can no longer terminate the string literal and run as code.

The `no-cache: true` additions are the input `oven-sh/setup-bun` documents as "Disable caching of bun executable" at the pinned SHA, so the seven affected jobs re-download the bun tarball instead of restoring it from the Actions cache. `permissions` on `publish` and `deploy-demo` cannot be exercised by this PR, as noted above.

Refs #379 (the zizmor half; #393 did the pinning half).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PrXhCR7eoQ1fLkuCPAFCJR)_