### PR TITLE
feat(mobile): touch-friendly navigation and a responsive shell foundation

### DIFF
--- a/e2e/navigation.mobile.e2e.ts
+++ b/e2e/navigation.mobile.e2e.ts
@@ -1,0 +1,43 @@
+import { test, expect } from './fixtures';
+
+test('the tab bar is replaced by a drawer trigger', async ({ page }) => {
+  await page.goto('/docker');
+
+  await expect(page.getByRole('button', { name: 'Open navigation menu' })).toBeVisible();
+  await expect(page.getByRole('tab', { name: 'Stacks' })).toHaveCount(0);
+});
+
+test('the drawer navigates between sections', async ({ page }) => {
+  await page.goto('/docker');
+
+  await page.getByRole('button', { name: 'Open navigation menu' }).click();
+  await page.getByRole('link', { name: 'Stacks' }).click();
+
+  await expect(page).toHaveURL(/\/stacks$/);
+  await expect(page.getByText('Stacks Overview')).toBeVisible();
+  await expect(page.getByRole('link', { name: 'ZFS' })).toHaveCount(0);
+});
+
+test('the drawer exposes submenus that desktop opens on hover', async ({ page }) => {
+  await page.goto('/stacks');
+
+  await page.getByRole('button', { name: 'Open navigation menu' }).click();
+  await page.getByRole('button', { name: /expand settings menu/i }).click();
+
+  await expect(page.getByRole('menuitem', { name: 'Managed Hosts' })).toBeVisible();
+});
+
+// Route bodies are widened by their tables and are covered by the per-route
+// mobile specs; this only pins the shell chrome, which every route inherits.
+test('the header fits the viewport on every route', async ({ page }) => {
+  for (const path of ['/docker', '/stacks', '/zfs', '/proxmox', '/settings']) {
+    await page.goto(path);
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+
+    const header = page.locator('header').first();
+    const box = await header.boundingBox();
+    const viewport = page.viewportSize();
+    expect(box, `${path} has no header`).not.toBeNull();
+    expect(box!.width, `${path} header overflows`).toBeLessThanOrEqual(viewport!.width);
+  }
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,8 +23,13 @@ export default defineConfig({
     {
       name: 'app',
       testMatch: /.*\.e2e\.ts$/,
-      testIgnore: /.*\.demo\.e2e\.ts$/,
+      testIgnore: /.*\.(demo|mobile)\.e2e\.ts$/,
       use: { ...devices['Desktop Chrome'], baseURL: `http://localhost:${APP_PORT}` },
+    },
+    {
+      name: 'mobile',
+      testMatch: /.*\.mobile\.e2e\.ts$/,
+      use: { ...devices['Pixel 7'], baseURL: `http://localhost:${APP_PORT}` },
     },
     {
       name: 'demo',

--- a/src/App.css
+++ b/src/App.css
@@ -200,6 +200,22 @@ body {
   display: none !important;
 }
 
+/* Expands a control's hit area to the 44px WCAG target-size minimum without
+   changing its painted size. The overlay is centered on the control, so a
+   32px icon button gains 6px of slop on every side. */
+.tap-target {
+  position: relative;
+}
+.tap-target::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  width: max(100%, 44px);
+  height: max(100%, 44px);
+}
+
 /* Themed scrollbar for drawer panels: tints the foreground token for theme adaptation */
 .themed-scrollbar {
   &::-webkit-scrollbar {

--- a/src/components/__tests__/header/Header.mobile.test.tsx
+++ b/src/components/__tests__/header/Header.mobile.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect, mock, beforeAll, afterAll } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+mock.module('@tanstack/react-router', () => ({
+  Link: ({ children, to, hash, onClick, ...rest }: {
+    children: React.ReactNode
+    to: string
+    hash?: string
+    onClick?: () => void
+    [key: string]: unknown
+  }) => {
+    const href = hash ? `${to}#${hash}` : to
+    return <a href={href} onClick={onClick} {...rest}>{children}</a>
+  },
+  useLocation: ({ select }: { select: (l: { pathname: string }) => string }) =>
+    select({ pathname: '/zfs' }),
+}))
+
+mock.module('@/lib/query-client', () => ({
+  queryClient: { prefetchQuery: mock(() => Promise.resolve()) },
+}))
+
+mock.module('@/data/stacks/functions', () => ({
+  listStacks: mock(() => Promise.resolve([])),
+  listManagedHostNames: mock(() => Promise.resolve([])),
+  createStack: mock(() => Promise.resolve({})),
+}))
+
+mock.module('@/lib/constants/preload-queries', () => ({
+  DOCKER_PRELOAD_KEY: ['preload', 'docker-stats'],
+  ZFS_PRELOAD_KEY: ['preload', 'zfs-stats'],
+  PROXMOX_PRELOAD_KEY: ['preload', 'proxmox-stats'],
+  preloadDockerStats: mock(() => Promise.resolve([])),
+  preloadZFSStats: mock(() => Promise.resolve([])),
+  preloadProxmoxStats: mock(() => Promise.resolve([])),
+}))
+
+mock.module('@/lib/utils/icon-resolver', () => ({
+  getIconUrl: (icon: string) => `/icons/${icon}.png`,
+  FALLBACK_ICON_URL: '/fallback.png',
+  AVAILABLE_ICONS: [],
+}))
+
+mock.module('@/components/ModeToggle', () => ({
+  default: () => <button aria-label="Toggle dark mode" />,
+}))
+
+mock.module('@/lib/constants/demo', () => ({ IS_DEMO_MODE: false }))
+
+const originalMatchMedia = window.matchMedia
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query === '(max-width: 767px)',
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  })
+})
+
+afterAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  })
+})
+
+const Header = (await import('@/components/header/Header')).default
+
+function renderHeader() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <Header />
+    </QueryClientProvider>,
+  )
+}
+
+describe('Header below the md breakpoint', () => {
+  it('replaces the tab bar with the drawer trigger', () => {
+    renderHeader()
+    expect(screen.getByRole('button', { name: 'Open navigation menu' })).not.toBeNull()
+    expect(screen.queryByRole('tab', { name: /docker/i })).toBeNull()
+  })
+
+  it('names the current route next to the trigger', () => {
+    renderHeader()
+    expect(screen.getByText('ZFS')).not.toBeNull()
+  })
+
+  it('still renders the color mode toggle', () => {
+    renderHeader()
+    expect(screen.getByRole('button', { name: 'Toggle dark mode' })).not.toBeNull()
+  })
+})

--- a/src/components/__tests__/header/Header.touch.test.tsx
+++ b/src/components/__tests__/header/Header.touch.test.tsx
@@ -1,0 +1,131 @@
+import { describe, it, expect, mock, beforeAll, afterAll } from 'bun:test'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+mock.module('@tanstack/react-router', () => ({
+  Link: ({ children, to, hash, onClick, ...rest }: {
+    children: React.ReactNode
+    to: string
+    hash?: string
+    onClick?: () => void
+    [key: string]: unknown
+  }) => {
+    const href = hash ? `${to}#${hash}` : to
+    return <a href={href} onClick={onClick} {...rest}>{children}</a>
+  },
+  useLocation: ({ select }: { select: (l: { pathname: string }) => string }) =>
+    select({ pathname: '/zfs' }),
+}))
+
+mock.module('@/lib/query-client', () => ({
+  queryClient: { prefetchQuery: mock(() => Promise.resolve()) },
+}))
+
+mock.module('@/data/stacks/functions', () => ({
+  listStacks: mock(() => Promise.resolve([])),
+  listManagedHostNames: mock(() => Promise.resolve(['tank'])),
+  createStack: mock(() => Promise.resolve({})),
+}))
+
+mock.module('@/lib/constants/preload-queries', () => ({
+  DOCKER_PRELOAD_KEY: ['preload', 'docker-stats'],
+  ZFS_PRELOAD_KEY: ['preload', 'zfs-stats'],
+  PROXMOX_PRELOAD_KEY: ['preload', 'proxmox-stats'],
+  preloadDockerStats: mock(() => Promise.resolve([])),
+  preloadZFSStats: mock(() => Promise.resolve([])),
+  preloadProxmoxStats: mock(() => Promise.resolve([])),
+}))
+
+mock.module('@/lib/utils/icon-resolver', () => ({
+  getIconUrl: (icon: string) => `/icons/${icon}.png`,
+  FALLBACK_ICON_URL: '/fallback.png',
+  AVAILABLE_ICONS: [],
+}))
+
+mock.module('@/components/ModeToggle', () => ({
+  default: () => <button aria-label="Toggle dark mode" />,
+}))
+
+mock.module('@/lib/constants/demo', () => ({ IS_DEMO_MODE: false }))
+
+const originalMatchMedia = window.matchMedia
+
+// Touch but wide enough to keep the tab bar: the tablet band, where the drawer
+// never renders and hover can never fire.
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query === '(hover: none), (pointer: coarse)',
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  })
+})
+
+afterAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  })
+})
+
+const Header = (await import('@/components/header/Header')).default
+
+function renderHeader() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <Header user={{ id: 1, email: 'alice@example.com', name: 'Alice', role: 'admin' }} />
+    </QueryClientProvider>,
+  )
+}
+
+describe('Header on a touch device above the compact breakpoint', () => {
+  it('keeps the tab bar rather than the drawer', () => {
+    renderHeader()
+    expect(screen.queryByRole('button', { name: 'Open navigation menu' })).toBeNull()
+    expect(screen.getByRole('tab', { name: /docker/i })).not.toBeNull()
+  })
+
+  it('does not open a submenu on hover, which touch can never fire', () => {
+    renderHeader()
+    const dockerTab = screen.getByRole('tab', { name: /docker/i })
+
+    fireEvent.mouseEnter(dockerTab)
+
+    expect(dockerTab.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('does not open a submenu on focus either', () => {
+    renderHeader()
+    const dockerTab = screen.getByRole('tab', { name: /docker/i })
+
+    fireEvent.focus(dockerTab)
+
+    expect(dockerTab.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('opens a submenu on tap, the only gesture touch has', () => {
+    renderHeader()
+    const dockerTab = screen.getByRole('tab', { name: /docker/i })
+
+    fireEvent.click(dockerTab)
+
+    expect(dockerTab.getAttribute('aria-expanded')).toBe('true')
+  })
+
+  it('leaves a route without a submenu unexpanded on tap', () => {
+    renderHeader()
+    const zfsTab = screen.getByRole('tab', { name: /zfs/i })
+
+    fireEvent.click(zfsTab)
+
+    expect(zfsTab.getAttribute('aria-expanded')).toBeNull()
+  })
+})

--- a/src/components/__tests__/header/Header.touch.test.tsx
+++ b/src/components/__tests__/header/Header.touch.test.tsx
@@ -79,6 +79,9 @@ function renderHeader() {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   })
+  // Seeded, not fetched: downstream the header derives which routes own a menu
+  // from this data, so an unresolved query renders every tab menu-less.
+  qc.setQueryData(['managed-host-names'], ['tank'])
   return render(
     <QueryClientProvider client={qc}>
       <Header user={{ id: 1, email: 'alice@example.com', name: 'Alice', role: 'admin' }} />

--- a/src/components/__tests__/header/Header.touch.test.tsx
+++ b/src/components/__tests__/header/Header.touch.test.tsx
@@ -123,6 +123,17 @@ describe('Header on a touch device above the compact breakpoint', () => {
     expect(dockerTab.getAttribute('aria-expanded')).toBe('true')
   })
 
+  it('closes an open submenu on an outside press', () => {
+    renderHeader()
+    const dockerTab = screen.getByRole('tab', { name: /docker/i })
+    fireEvent.click(dockerTab)
+    expect(dockerTab.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.click(document.body)
+
+    expect(dockerTab.getAttribute('aria-expanded')).toBe('false')
+  })
+
   it('leaves a route without a submenu unexpanded on tap', () => {
     renderHeader()
     const zfsTab = screen.getByRole('tab', { name: /zfs/i })

--- a/src/components/__tests__/header/MobileNav.test.tsx
+++ b/src/components/__tests__/header/MobileNav.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, mock } from 'bun:test'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+
+mock.module('@tanstack/react-router', () => ({
+  Link: ({ children, to, hash, onClick, ...rest }: {
+    children: React.ReactNode
+    to: string
+    hash?: string
+    onClick?: () => void
+    [key: string]: unknown
+  }) => {
+    const href = hash ? `${to}#${hash}` : to
+    return <a href={href} onClick={onClick} {...rest}>{children}</a>
+  },
+  useLocation: ({ select }: { select: (l: { pathname: string }) => string }) =>
+    select({ pathname: '/docker' }),
+}))
+
+const prefetchQuery = mock(() => Promise.resolve())
+mock.module('@/lib/query-client', () => ({ queryClient: { prefetchQuery } }))
+
+mock.module('@/data/stacks/functions', () => ({
+  listStacks: mock(() => Promise.resolve([])),
+  listManagedHostNames: mock(() => Promise.resolve(['tank', 'nas'])),
+  createStack: mock(() => Promise.resolve({})),
+}))
+
+mock.module('@/lib/constants/preload-queries', () => ({
+  DOCKER_PRELOAD_KEY: ['preload', 'docker-stats'],
+  ZFS_PRELOAD_KEY: ['preload', 'zfs-stats'],
+  PROXMOX_PRELOAD_KEY: ['preload', 'proxmox-stats'],
+  preloadDockerStats: mock(() => Promise.resolve([])),
+  preloadZFSStats: mock(() => Promise.resolve([])),
+  preloadProxmoxStats: mock(() => Promise.resolve([])),
+}))
+
+mock.module('@/lib/utils/icon-resolver', () => ({
+  getIconUrl: (icon: string) => `/icons/${icon}.png`,
+  FALLBACK_ICON_URL: '/fallback.png',
+  AVAILABLE_ICONS: [],
+}))
+
+const MobileNav = (await import('@/components/header/MobileNav')).default
+
+function renderNav() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  })
+  return render(
+    <QueryClientProvider client={qc}>
+      <MobileNav />
+    </QueryClientProvider>,
+  )
+}
+
+async function openDrawer() {
+  renderNav()
+  fireEvent.click(screen.getByRole('button', { name: 'Open navigation menu' }))
+  await screen.findByRole('link', { name: /docker/i })
+}
+
+describe('MobileNav', () => {
+  it('shows the current route label beside the trigger', () => {
+    renderNav()
+    expect(screen.getByText('Docker')).not.toBeNull()
+  })
+
+  it('keeps the drawer closed until the trigger is tapped', () => {
+    renderNav()
+    const trigger = screen.getByRole('button', { name: 'Open navigation menu' })
+    expect(trigger.getAttribute('aria-expanded')).toBe('false')
+    expect(screen.queryByText('Homelab Manager')).toBeNull()
+  })
+
+  it('opens a drawer listing every nav destination', async () => {
+    await openDrawer()
+
+    for (const label of ['Docker', 'Stacks', 'ZFS', 'Proxmox', 'Settings']) {
+      expect(screen.getByRole('link', { name: new RegExp(label, 'i') })).not.toBeNull()
+    }
+  })
+
+  it('marks the active route', async () => {
+    await openDrawer()
+    const dockerLink = screen.getByRole('link', { name: /docker/i })
+    expect(dockerLink.getAttribute('aria-current')).toBe('page')
+    expect(screen.getByRole('link', { name: /zfs/i }).getAttribute('aria-current')).toBeNull()
+  })
+
+  it('gives every nav link a 48px minimum tap target', async () => {
+    await openDrawer()
+    expect(screen.getByRole('link', { name: /zfs/i }).className).toContain('min-h-12')
+  })
+
+  it('auto-expands the submenu of the current route', async () => {
+    await openDrawer()
+    expect(await screen.findByRole('menuitem', { name: /tank/i })).not.toBeNull()
+  })
+
+  it('toggles a submenu from its disclosure button', async () => {
+    await openDrawer()
+    const toggle = screen.getByRole('button', { name: /expand stacks menu/i })
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+
+    fireEvent.click(toggle)
+
+    expect(
+      screen.getByRole('button', { name: /collapse stacks menu/i }).getAttribute('aria-expanded'),
+    ).toBe('true')
+  })
+
+  it('offers no disclosure button for routes without a submenu', async () => {
+    await openDrawer()
+    expect(screen.queryByRole('button', { name: /zfs menu/i })).toBeNull()
+  })
+
+  it('closes the drawer and prefetches when a destination is tapped', async () => {
+    await openDrawer()
+    prefetchQuery.mockClear()
+
+    fireEvent.click(screen.getByRole('link', { name: /zfs/i }))
+
+    await waitFor(() => expect(screen.queryByRole('link', { name: /zfs/i })).toBeNull())
+    expect(prefetchQuery).toHaveBeenCalled()
+  })
+
+  it('closes the drawer when a submenu entry is tapped', async () => {
+    await openDrawer()
+    const hostLink = await screen.findByRole('menuitem', { name: /nas/i })
+
+    fireEvent.click(hostLink)
+
+    await waitFor(() => expect(screen.queryByRole('menuitem', { name: /nas/i })).toBeNull())
+  })
+})

--- a/src/components/header/DemoBanner.tsx
+++ b/src/components/header/DemoBanner.tsx
@@ -9,7 +9,7 @@ export function DemoBanner() {
   const [visible, setVisible] = useState(true)
   if (!visible) return null
   return (
-    <div className="absolute left-1/2 -translate-x-1/2 top-full pt-2 pointer-events-auto w-fit">
+    <div className="absolute left-1/2 -translate-x-1/2 top-full pt-2 pointer-events-auto w-fit max-w-[calc(100vw-1rem)]">
       <Alert variant="info" className="pr-2">
         <AlertDescription className="grid-flow-col items-center">
           <span>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -15,6 +15,8 @@ import {
 import { useCurrentTab, useMenuController } from '@/components/header/useMenuController'
 import { AccountMenu, MenuContentFor, NavMenuCloseContext } from '@/components/header/menus'
 import { DemoBanner } from '@/components/header/DemoBanner'
+import MobileNav from '@/components/header/MobileNav'
+import { useIsCompactNav, useIsTouch } from '@/hooks/useMediaQuery'
 
 // Brand SVGs (Docker, Proxmox) lack the small transparent padding that lucide icons
 // bake into their viewBoxes, so they sit too close to the tab label. This set marks
@@ -25,6 +27,8 @@ const SPACED_ICON_ROUTES = new Set<RouteKey>(['/docker', '/proxmox'])
 export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
   const currentTab = useCurrentTab()
   const controller = useMenuController()
+  const isCompactNav = useIsCompactNav()
+  const isTouch = useIsTouch()
   const [anchors, setAnchors] = useState<Partial<Record<MenuRouteKey, HTMLElement>>>({})
 
   // Stable callback refs keyed by route, so each Tab keeps the same setter
@@ -43,69 +47,87 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
   }, [])
 
   return (
-    <header className="sticky top-0 z-50 px-4 pt-3 pb-2 pointer-events-none">
+    <header className="sticky top-0 z-50 px-2 pt-[max(0.5rem,env(safe-area-inset-top))] pb-2 pointer-events-none sm:px-4 sm:pt-3">
       <nav
         aria-label="Main navigation"
-        className="flex items-center rounded-2xl px-3 py-1 pointer-events-auto backdrop-blur-xl bg-card/75 border border-border/30 shadow-[0_8px_32px_rgba(0,0,0,0.1)]"
+        className="flex items-center min-w-0 rounded-2xl px-1.5 py-1 pointer-events-auto backdrop-blur-xl bg-card/75 border border-border/30 shadow-[0_8px_32px_rgba(0,0,0,0.1)] sm:px-3"
       >
-        <Tabs value={currentTab ?? null}>
-          <TabsList aria-label="Main navigation">
-            {NAV_ITEMS.map((item) => {
-              const { Icon } = item
-              return (
-                <TabsTrigger
-                  key={item.to}
-                  value={item.to}
-                  ref={refSetters[item.to as MenuRouteKey]}
-                  nativeButton={false}
-                  render={<Link to={item.to} />}
-                  aria-haspopup={item.hasMenu ? 'menu' : undefined}
-                  aria-expanded={item.hasMenu ? controller.openId === item.to : undefined}
-                  aria-controls={item.hasMenu ? `nav-menu-${item.to.slice(1)}` : undefined}
-                  onMouseEnter={() => {
-                    handlePrefetch(item.to)
-                    if (item.hasMenu) controller.requestOpen(item.to)
-                  }}
-                  onMouseLeave={() => {
-                    if (item.hasMenu) controller.requestClose()
-                  }}
-                  onFocus={() => {
-                    handlePrefetch(item.to)
-                    if (item.hasMenu) controller.requestOpen(item.to)
-                  }}
-                  onBlur={() => {
-                    if (item.hasMenu) controller.requestClose()
-                  }}
-                  onKeyDown={(e: React.KeyboardEvent) => {
-                    if (e.key === 'Escape' && item.hasMenu) controller.closeNow()
-                  }}
-                  className="py-2 uppercase"
-                >
-                  {SPACED_ICON_ROUTES.has(item.to)
-                    ? <span className="inline-flex mr-1"><Icon size={18} /></span>
-                    : <Icon size={18} />}
-                  <span className="inline-flex items-center gap-1 ml-1.5">
-                    {item.label}
-                    {item.hasMenu && <ChevronDown size={14} className="opacity-60" />}
-                  </span>
-                </TabsTrigger>
-              )
-            })}
-          </TabsList>
-        </Tabs>
+        {isCompactNav ? (
+          <MobileNav />
+        ) : (
+          <Tabs value={currentTab ?? null}>
+            <TabsList aria-label="Main navigation">
+              {NAV_ITEMS.map((item) => {
+                const { Icon } = item
+                return (
+                  <TabsTrigger
+                    key={item.to}
+                    value={item.to}
+                    ref={refSetters[item.to as MenuRouteKey]}
+                    nativeButton={false}
+                    render={<Link to={item.to} />}
+                    aria-haspopup={item.hasMenu ? 'menu' : undefined}
+                    aria-expanded={item.hasMenu ? controller.openId === item.to : undefined}
+                    aria-controls={item.hasMenu ? `nav-menu-${item.to.slice(1)}` : undefined}
+                    onMouseEnter={() => {
+                      if (isTouch) return
+                      handlePrefetch(item.to)
+                      if (item.hasMenu) controller.requestOpen(item.to)
+                    }}
+                    onMouseLeave={() => {
+                      if (isTouch) return
+                      if (item.hasMenu) controller.requestClose()
+                    }}
+                    onFocus={() => {
+                      if (isTouch) return
+                      handlePrefetch(item.to)
+                      if (item.hasMenu) controller.requestOpen(item.to)
+                    }}
+                    onBlur={() => {
+                      if (isTouch) return
+                      if (item.hasMenu) controller.requestClose()
+                    }}
+                    // A touch device never fires the hover that opens these menus, so
+                    // the tap that navigates to the route opens the menu as well.
+                    onClick={() => {
+                      if (!isTouch) return
+                      handlePrefetch(item.to)
+                      if (item.hasMenu) controller.requestOpen(item.to)
+                    }}
+                    onKeyDown={(e: React.KeyboardEvent) => {
+                      if (e.key === 'Escape' && item.hasMenu) controller.closeNow()
+                    }}
+                    className="py-2 uppercase"
+                  >
+                    {SPACED_ICON_ROUTES.has(item.to)
+                      ? <span className="inline-flex mr-1"><Icon size={18} /></span>
+                      : <Icon size={18} />}
+                    <span className="inline-flex items-center gap-1 ml-1.5">
+                      {item.label}
+                      {item.hasMenu && <ChevronDown size={14} className="opacity-60" />}
+                    </span>
+                  </TabsTrigger>
+                )
+              })}
+            </TabsList>
+          </Tabs>
+        )}
 
-        <div className="ml-auto pl-3 border-l border-border/30 flex items-center gap-1">
+        <div className="ml-auto shrink-0 pl-2 border-l border-border/30 flex items-center gap-1 sm:pl-3">
           {!IS_DEMO_MODE && user && <AccountMenu />}
           <ModeToggle />
         </div>
       </nav>
 
-      {NAV_ITEMS.filter((i) => i.hasMenu).map((item) => {
+      {!isCompactNav && NAV_ITEMS.filter((i) => i.hasMenu).map((item) => {
         const anchor = anchors[item.to]
         return (
           <Popover.Root
             key={item.to}
             open={controller.openId === item.to && Boolean(anchor)}
+            // Without this the popup has no way to close on an outside press,
+            // which is the only dismissal gesture a touch device has here.
+            onOpenChange={(next) => { if (!next) controller.closeNow() }}
             modal={false}
           >
             <Popover.Portal>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -31,16 +31,20 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
   const isTouch = useIsTouch()
   const [anchors, setAnchors] = useState<Partial<Record<MenuRouteKey, HTMLElement>>>({})
 
-  // Stable callback refs keyed by route, so each Tab keeps the same setter
-  // across renders. The null (unmount) case is ignored because these Tab
-  // elements are persistent; anchors only need to be set once on mount.
+  // One stable setter per route, so React never re-runs a ref callback just
+  // because its identity changed.
   const refSetters = useMemo(() => {
     const setters: Partial<Record<MenuRouteKey, (el: HTMLElement | null) => void>> = {}
     for (const item of NAV_ITEMS) {
       if (!item.hasMenu) continue
       setters[item.to] = (el) => {
-        if (!el) return
-        setAnchors((prev) => (prev[item.to] === el ? prev : { ...prev, [item.to]: el }))
+        setAnchors((prev) => {
+          if ((prev[item.to] ?? null) === el) return prev
+          const next = { ...prev }
+          if (el) next[item.to] = el
+          else delete next[item.to]
+          return next
+        })
       }
     }
     return setters

--- a/src/components/header/MobileNav.tsx
+++ b/src/components/header/MobileNav.tsx
@@ -1,0 +1,131 @@
+import { useEffect, useState } from 'react'
+import { Link, useLocation } from '@tanstack/react-router'
+import { ChevronDown, Menu } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet'
+import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible'
+import { NAV_ITEMS, handlePrefetch } from '@/components/header/nav-config'
+import type { MenuRouteKey, NavItem } from '@/components/header/nav-config'
+import { useCurrentTab } from '@/components/header/useMenuController'
+import { MenuContentFor, NavMenuCloseContext } from '@/components/header/menus'
+
+const NAV_LINK_CLASSES =
+  'flex flex-1 items-center gap-3 min-h-12 px-4 text-sm font-medium uppercase ' +
+  'tracking-[0.02857em] no-underline text-inherit'
+
+function MobileNavItem({
+  item,
+  isCurrent,
+  onNavigate,
+}: Readonly<{ item: NavItem; isCurrent: boolean; onNavigate: () => void }>) {
+  const [expanded, setExpanded] = useState(isCurrent && item.hasMenu)
+  const { Icon } = item
+
+  return (
+    <div className="border-b border-border/30 last:border-b-0">
+      <div
+        className={`flex items-center ${isCurrent ? 'bg-accent text-primary' : ''}`}
+      >
+        <Link
+          to={item.to}
+          className={NAV_LINK_CLASSES}
+          onClick={onNavigate}
+          aria-current={isCurrent ? 'page' : undefined}
+        >
+          <Icon size={20} />
+          <span>{item.label}</span>
+        </Link>
+        {item.hasMenu && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="mr-2 size-11 text-foreground"
+            aria-expanded={expanded}
+            aria-label={`${expanded ? 'Collapse' : 'Expand'} ${item.label} menu`}
+            onClick={() => setExpanded((prev) => !prev)}
+          >
+            <ChevronDown
+              size={18}
+              className={`transition-transform duration-150 ${expanded ? 'rotate-180' : ''}`}
+            />
+          </Button>
+        )}
+      </div>
+      {item.hasMenu && (
+        <Collapsible open={expanded}>
+          <CollapsibleContent>
+            <div className="bg-level1 pl-4" role="menu">
+              <NavMenuCloseContext value={onNavigate}>
+                <MenuContentFor to={item.to as MenuRouteKey} />
+              </NavMenuCloseContext>
+            </div>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Header navigation below the `md` breakpoint. The desktop tab bar opens its
+ * submenus on hover, which a touch device can never trigger, so the drawer
+ * turns each one into a tap-expandable section instead.
+ */
+export default function MobileNav() {
+  const [open, setOpen] = useState(false)
+  const currentTab = useCurrentTab()
+  const pathname = useLocation({ select: (l) => l.pathname })
+
+  useEffect(() => {
+    setOpen(false)
+  }, [pathname])
+
+  const currentLabel = NAV_ITEMS.find((item) => item.to === currentTab)?.label
+
+  return (
+    <>
+      <Button
+        variant="ghost"
+        size="icon"
+        className="size-11 text-foreground"
+        aria-label="Open navigation menu"
+        aria-expanded={open}
+        onClick={() => setOpen(true)}
+      >
+        <Menu size={22} />
+      </Button>
+      <span className="ml-1 truncate text-sm font-semibold uppercase tracking-[0.02857em]">
+        {currentLabel ?? 'Homelab Manager'}
+      </span>
+
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetContent side="left" aria-label="Main navigation">
+          <SheetHeader>
+            <SheetTitle>Homelab Manager</SheetTitle>
+          </SheetHeader>
+          <SheetBody>
+            <nav aria-label="Main navigation">
+              {NAV_ITEMS.map((item) => (
+                <MobileNavItem
+                  key={item.to}
+                  item={item}
+                  isCurrent={currentTab === item.to}
+                  onNavigate={() => {
+                    handlePrefetch(item.to)
+                    setOpen(false)
+                  }}
+                />
+              ))}
+            </nav>
+          </SheetBody>
+        </SheetContent>
+      </Sheet>
+    </>
+  )
+}

--- a/src/components/header/menus.tsx
+++ b/src/components/header/menus.tsx
@@ -13,7 +13,7 @@ import type { MenuRouteKey } from '@/components/header/nav-config'
 export const NavMenuCloseContext = createContext<() => void>(() => {})
 
 const MENU_ITEM_CLASSES =
-  'flex items-center gap-2 px-3 py-2 text-sm no-underline text-inherit ' +
+  'flex items-center gap-2 min-h-11 px-3 py-2 text-sm no-underline text-inherit ' +
   'hover:bg-accent transition-colors'
 
 export function SettingsMenuContent() {

--- a/src/components/ui/__tests__/sheet.test.tsx
+++ b/src/components/ui/__tests__/sheet.test.tsx
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'bun:test';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetBody,
+  SheetFooter,
+} from '@/components/ui/sheet';
+
+function Example({ side }: Readonly<{ side?: 'left' | 'right' | 'bottom' }>) {
+  return (
+    <Sheet>
+      <SheetTrigger>Open</SheetTrigger>
+      <SheetContent side={side} data-testid="content">
+        <SheetHeader data-testid="header">
+          <SheetTitle>Navigation</SheetTitle>
+          <SheetDescription>Jump to a section</SheetDescription>
+        </SheetHeader>
+        <SheetBody data-testid="body">Body content</SheetBody>
+        <SheetFooter data-testid="footer">
+          <SheetClose>Dismiss</SheetClose>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+async function openSheet(side?: 'left' | 'right' | 'bottom') {
+  render(<Example side={side} />);
+  fireEvent.click(screen.getByText('Open'));
+  await screen.findByTestId('content');
+}
+
+describe('Sheet', () => {
+  it('opens from its trigger and renders every slot', async () => {
+    render(<Example />);
+    expect(screen.queryByText('Navigation')).toBeNull();
+
+    fireEvent.click(screen.getByText('Open'));
+
+    expect(await screen.findByText('Navigation')).not.toBeNull();
+    expect(screen.getByText('Jump to a section')).not.toBeNull();
+    expect(screen.getByTestId('body').textContent).toBe('Body content');
+    expect(screen.getByTestId('footer')).not.toBeNull();
+  });
+
+  it('closes from SheetClose', async () => {
+    await openSheet();
+
+    fireEvent.click(screen.getByText('Dismiss'));
+
+    await waitFor(() => expect(screen.queryByText('Navigation')).toBeNull());
+  });
+
+  it('defaults to the left side', async () => {
+    await openSheet();
+
+    const content = screen.getByTestId('content');
+    expect(content.dataset.side).toBe('left');
+    expect(content.className).toContain('left-0');
+  });
+
+  it('anchors to the requested side', async () => {
+    await openSheet('bottom');
+
+    const content = screen.getByTestId('content');
+    expect(content.dataset.side).toBe('bottom');
+    expect(content.className).toContain('bottom-0');
+    expect(content.className).toContain('max-h-[85dvh]');
+  });
+
+  it('pads the header and footer clear of the safe area', async () => {
+    await openSheet();
+
+    expect(screen.getByTestId('header').className).toContain('env(safe-area-inset-top)');
+    expect(screen.getByTestId('footer').className).toContain('env(safe-area-inset-bottom)');
+  });
+
+  it('contains overscroll in the scrollable body', async () => {
+    await openSheet();
+
+    const body = screen.getByTestId('body');
+    expect(body.className).toContain('overflow-y-auto');
+    expect(body.className).toContain('overscroll-contain');
+  });
+
+  it('merges caller classes onto the popup', async () => {
+    render(
+      <Sheet defaultOpen>
+        <SheetContent className="w-[500px]" data-testid="content">
+          <SheetTitle>Wide</SheetTitle>
+        </SheetContent>
+      </Sheet>,
+    );
+
+    expect((await screen.findByTestId('content')).className).toContain('w-[500px]');
+  });
+});

--- a/src/components/ui/datatable/DataTable.tsx
+++ b/src/components/ui/datatable/DataTable.tsx
@@ -18,6 +18,7 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible';
 import { ArrowUp, ArrowDown } from 'lucide-react';
 import { DataTableToolbar } from '@/components/ui/datatable/DataTableToolbar';
+import { MOBILE_BREAKPOINT } from '@/lib/constants/breakpoints';
 import { useGeneralSettings } from '@/hooks/useSettings';
 
 export interface MetricGroup {
@@ -109,9 +110,6 @@ function buildGridTemplate<TRow>(
     })
     .join(' ');
 }
-
-/** Width threshold (px) below which the table is considered mobile. */
-const MOBILE_BREAKPOINT = 1024;
 
 /**
  * Generic data table component with TanStack Table v8 column management,

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,0 +1,135 @@
+import type { ComponentProps } from 'react';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils/cn';
+
+function Sheet(props: Readonly<ComponentProps<typeof DialogPrimitive.Root>>) {
+  return <DialogPrimitive.Root data-slot="sheet" {...props} />;
+}
+
+function SheetTrigger(props: Readonly<ComponentProps<typeof DialogPrimitive.Trigger>>) {
+  return <DialogPrimitive.Trigger data-slot="sheet-trigger" {...props} />;
+}
+
+function SheetClose(props: Readonly<ComponentProps<typeof DialogPrimitive.Close>>) {
+  return <DialogPrimitive.Close data-slot="sheet-close" {...props} />;
+}
+
+const sheetVariants = cva(
+  'bg-card text-card-foreground fixed z-50 flex flex-col shadow-xl outline-none transition-transform duration-200 ease-out',
+  {
+    variants: {
+      side: {
+        left: 'inset-y-0 left-0 h-full w-[min(20rem,85vw)] border-r border-border data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full',
+        right:
+          'inset-y-0 right-0 h-full w-[min(20rem,85vw)] border-l border-border data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full',
+        bottom:
+          'inset-x-0 bottom-0 max-h-[85dvh] rounded-t-2xl border-t border-border data-[starting-style]:translate-y-full data-[ending-style]:translate-y-full',
+      },
+    },
+    defaultVariants: { side: 'left' },
+  },
+);
+
+type SheetContentProps = ComponentProps<typeof DialogPrimitive.Popup> &
+  VariantProps<typeof sheetVariants>;
+
+/**
+ * Slide-in panel. `bottom` is the phone-friendly default for pickers and
+ * actions; `left`/`right` suit navigation. Height uses `dvh` so the panel does
+ * not sit under a mobile browser's retracting URL bar, and the safe-area pad
+ * keeps the last row clear of the iOS home indicator.
+ */
+function SheetContent({ className, children, side, ...props }: SheetContentProps) {
+  return (
+    <DialogPrimitive.Portal>
+      <DialogPrimitive.Backdrop
+        data-slot="sheet-backdrop"
+        className="fixed inset-0 z-50 bg-black/50 transition-opacity duration-200 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0"
+      />
+      <DialogPrimitive.Popup
+        data-slot="sheet-content"
+        data-side={side ?? 'left'}
+        className={cn(sheetVariants({ side }), className)}
+        {...props}
+      >
+        {children}
+      </DialogPrimitive.Popup>
+    </DialogPrimitive.Portal>
+  );
+}
+
+function SheetHeader({ className, ...props }: ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn(
+        'flex items-center gap-2 border-b border-border px-4 py-3 pt-[max(0.75rem,env(safe-area-inset-top))]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetTitle({ className, ...props }: ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="sheet-title"
+      className={cn('text-base font-semibold', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="sheet-description"
+      className={cn('text-muted-foreground text-sm', className)}
+      {...props}
+    />
+  );
+}
+
+function SheetBody({ className, ...props }: ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-body"
+      className={cn(
+        'themed-scrollbar min-h-0 flex-1 overflow-y-auto overscroll-contain pb-[max(1rem,env(safe-area-inset-bottom))]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+function SheetFooter({ className, ...props }: ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn(
+        'flex items-center justify-end gap-2 border-t border-border p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+  SheetDescription,
+  SheetBody,
+  SheetFooter,
+  sheetVariants,
+};

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -20,9 +20,9 @@ const sheetVariants = cva(
   {
     variants: {
       side: {
-        left: 'inset-y-0 left-0 h-full w-[min(20rem,85vw)] border-r border-border data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full',
+        left: 'inset-y-0 left-0 h-dvh w-[min(20rem,85vw)] border-r border-border data-[starting-style]:-translate-x-full data-[ending-style]:-translate-x-full',
         right:
-          'inset-y-0 right-0 h-full w-[min(20rem,85vw)] border-l border-border data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full',
+          'inset-y-0 right-0 h-dvh w-[min(20rem,85vw)] border-l border-border data-[starting-style]:translate-x-full data-[ending-style]:translate-x-full',
         bottom:
           'inset-x-0 bottom-0 max-h-[85dvh] rounded-t-2xl border-t border-border data-[starting-style]:translate-y-full data-[ending-style]:translate-y-full',
       },

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -43,9 +43,10 @@ type SheetContentProps = ComponentProps<typeof DialogPrimitive.Popup> &
 function SheetContent({ className, children, side, ...props }: SheetContentProps) {
   return (
     <DialogPrimitive.Portal>
+      {/* min-h-dvh is needed for Safari on iOS since it mispaints a fixed backdrop as the URL bar retracts */}
       <DialogPrimitive.Backdrop
         data-slot="sheet-backdrop"
-        className="fixed inset-0 z-50 bg-black/50 transition-opacity duration-200 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0"
+        className="fixed inset-0 z-50 min-h-dvh bg-black/50 transition-opacity duration-200 data-[starting-style]:opacity-0 data-[ending-style]:opacity-0 supports-[-webkit-touch-callout:none]:absolute"
       />
       <DialogPrimitive.Popup
         data-slot="sheet-content"

--- a/src/hooks/__tests__/useMediaQuery.test.ts
+++ b/src/hooks/__tests__/useMediaQuery.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it, afterEach } from 'bun:test';
+import { act, renderHook } from '@testing-library/react';
+import {
+  useIsCompactNav,
+  useIsMobile,
+  useIsTouch,
+  useMediaQuery,
+} from '@/hooks/useMediaQuery';
+
+interface MockList {
+  matches: boolean;
+  media: string;
+  listeners: Set<() => void>;
+}
+
+const originalMatchMedia = window.matchMedia;
+const lists = new Map<string, MockList>();
+
+function installMatchMedia(initial: (query: string) => boolean) {
+  lists.clear();
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => {
+      let list = lists.get(query);
+      if (!list) {
+        list = { matches: initial(query), media: query, listeners: new Set() };
+        lists.set(query, list);
+      }
+      return {
+        get matches() {
+          return list.matches;
+        },
+        media: query,
+        addEventListener: (_: string, cb: () => void) => list.listeners.add(cb),
+        removeEventListener: (_: string, cb: () => void) => list.listeners.delete(cb),
+      };
+    },
+  });
+}
+
+function emitChange(query: string, matches: boolean) {
+  const list = lists.get(query);
+  if (!list) throw new Error(`no mock media query list for ${query}`);
+  list.matches = matches;
+  act(() => {
+    for (const cb of list.listeners) cb();
+  });
+}
+
+function removeMatchMedia() {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: undefined,
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+  lists.clear();
+});
+
+describe('useMediaQuery', () => {
+  it('reports the initial match state of the query', () => {
+    installMatchMedia(() => true);
+    const { result } = renderHook(() => useMediaQuery('(max-width: 500px)'));
+    expect(result.current).toBe(true);
+  });
+
+  it('re-renders when the query starts matching', () => {
+    installMatchMedia(() => false);
+    const { result } = renderHook(() => useMediaQuery('(max-width: 500px)'));
+    expect(result.current).toBe(false);
+
+    emitChange('(max-width: 500px)', true);
+    expect(result.current).toBe(true);
+  });
+
+  it('re-renders when the query stops matching', () => {
+    installMatchMedia(() => true);
+    const { result } = renderHook(() => useMediaQuery('(max-width: 500px)'));
+
+    emitChange('(max-width: 500px)', false);
+    expect(result.current).toBe(false);
+  });
+
+  it('removes its listener on unmount', () => {
+    installMatchMedia(() => false);
+    const { unmount } = renderHook(() => useMediaQuery('(max-width: 500px)'));
+    expect(lists.get('(max-width: 500px)')!.listeners.size).toBe(1);
+
+    unmount();
+    expect(lists.get('(max-width: 500px)')!.listeners.size).toBe(0);
+  });
+
+  it('resubscribes when the query string changes', () => {
+    installMatchMedia((query) => query === '(min-width: 900px)');
+    const { result, rerender } = renderHook(({ q }) => useMediaQuery(q), {
+      initialProps: { q: '(max-width: 500px)' },
+    });
+    expect(result.current).toBe(false);
+
+    rerender({ q: '(min-width: 900px)' });
+    expect(result.current).toBe(true);
+    expect(lists.get('(max-width: 500px)')!.listeners.size).toBe(0);
+    expect(lists.get('(min-width: 900px)')!.listeners.size).toBe(1);
+  });
+
+  it('reports false when matchMedia is unavailable', () => {
+    removeMatchMedia();
+    const { result } = renderHook(() => useMediaQuery('(max-width: 500px)'));
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('breakpoint hooks', () => {
+  it('useIsMobile queries one pixel below the lg breakpoint', () => {
+    installMatchMedia(() => true);
+    const { result } = renderHook(() => useIsMobile());
+    expect(result.current).toBe(true);
+    expect([...lists.keys()]).toEqual(['(max-width: 1023px)']);
+  });
+
+  it('useIsCompactNav queries one pixel below the md breakpoint', () => {
+    installMatchMedia(() => false);
+    renderHook(() => useIsCompactNav());
+    expect([...lists.keys()]).toEqual(['(max-width: 767px)']);
+  });
+
+  it('useIsTouch queries hover and pointer capability', () => {
+    installMatchMedia(() => true);
+    const { result } = renderHook(() => useIsTouch());
+    expect(result.current).toBe(true);
+    expect([...lists.keys()]).toEqual(['(hover: none), (pointer: coarse)']);
+  });
+});

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -1,0 +1,52 @@
+import { useCallback, useSyncExternalStore } from 'react';
+import { MOBILE_BREAKPOINT, NAV_BREAKPOINT } from '@/lib/constants/breakpoints';
+
+const NOOP_UNSUBSCRIBE = () => {};
+
+/**
+ * Subscribe to a CSS media query.
+ *
+ * Window-scoped, unlike DataTable's container-scoped ResizeObserver: use this
+ * for chrome that reacts to the device (nav, dialogs, page layout) and the
+ * ResizeObserver for anything that must also react to a narrow container.
+ */
+export function useMediaQuery(query: string): boolean {
+  const subscribe = useCallback(
+    (onChange: () => void) => {
+      if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+        return NOOP_UNSUBSCRIBE;
+      }
+      const list = window.matchMedia(query);
+      list.addEventListener('change', onChange);
+      return () => list.removeEventListener('change', onChange);
+    },
+    [query],
+  );
+
+  const getSnapshot = useCallback(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+    return window.matchMedia(query).matches;
+  }, [query]);
+
+  return useSyncExternalStore(subscribe, getSnapshot, () => false);
+}
+
+/** True below the `lg` breakpoint: the viewport gets the single-column touch layout. */
+export function useIsMobile(): boolean {
+  return useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+}
+
+/** True below the `md` breakpoint: the header tab bar is collapsed into the drawer. */
+export function useIsCompactNav(): boolean {
+  return useMediaQuery(`(max-width: ${NAV_BREAKPOINT - 1}px)`);
+}
+
+/**
+ * True when the primary input is touch. Drives tap-to-open on menus that
+ * otherwise open on hover, which a touch device can never satisfy.
+ */
+export function useIsTouch(): boolean {
+  return useMediaQuery('(hover: none), (pointer: coarse)');
+}

--- a/src/lib/constants/breakpoints.ts
+++ b/src/lib/constants/breakpoints.ts
@@ -1,0 +1,23 @@
+/**
+ * Viewport widths shared between CSS (Tailwind's default `sm`/`md`/`lg` screens)
+ * and the JS that has to make the same decision. Keep these in sync with the
+ * Tailwind prefix used alongside them: a hook reporting `lg` while the markup
+ * switches at `md` produces a band where the two disagree.
+ */
+export const BREAKPOINTS = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+} as const;
+
+export type BreakpointName = keyof typeof BREAKPOINTS;
+
+/** Below this, layouts switch to their single-column touch variants (Tailwind `lg:`). */
+export const MOBILE_BREAKPOINT = BREAKPOINTS.lg;
+
+/** Below this, the header collapses its tab bar into the drawer (Tailwind `md:`). */
+export const NAV_BREAKPOINT = BREAKPOINTS.md;
+
+/** Minimum comfortable touch target, per WCAG 2.2 target-size (minimum). */
+export const TOUCH_TARGET_PX = 44;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -9,59 +9,34 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
-import { Route as ZfsRouteImport } from './routes/zfs'
-import { Route as StacksRouteImport } from './routes/stacks'
-import { Route as SettingsRouteImport } from './routes/settings'
-import { Route as ProxmoxRouteImport } from './routes/proxmox'
-import { Route as LoginRouteImport } from './routes/login'
-import { Route as DockerRouteImport } from './routes/docker'
-import { Route as DeniedRouteImport } from './routes/denied'
 import { Route as IndexRouteImport } from './routes/index'
+import { Route as DeniedRouteImport } from './routes/denied'
+import { Route as DockerRouteImport } from './routes/docker'
+import { Route as LoginRouteImport } from './routes/login'
+import { Route as ProxmoxRouteImport } from './routes/proxmox'
+import { Route as SettingsRouteImport } from './routes/settings'
+import { Route as StacksRouteImport } from './routes/stacks'
+import { Route as ZfsRouteImport } from './routes/zfs'
+import { Route as ApiDockerInventoryRouteImport } from './routes/api/docker-inventory'
+import { Route as ApiDockerStatsRouteImport } from './routes/api/docker-stats'
+import { Route as ApiHealthRouteImport } from './routes/api/health'
+import { Route as ApiProxmoxStatsRouteImport } from './routes/api/proxmox-stats'
+import { Route as ApiSettingsRouteImport } from './routes/api/settings'
+import { Route as ApiStackStatusRouteImport } from './routes/api/stack-status'
+import { Route as ApiZfsStatsRouteImport } from './routes/api/zfs-stats'
+import { Route as DockerContainerIdRouteImport } from './routes/docker.$containerId'
 import { Route as StacksIndexRouteImport } from './routes/stacks/index'
 import { Route as StacksStackNameRouteImport } from './routes/stacks/$stackName'
-import { Route as DockerContainerIdRouteImport } from './routes/docker.$containerId'
-import { Route as ApiZfsStatsRouteImport } from './routes/api/zfs-stats'
-import { Route as ApiStackStatusRouteImport } from './routes/api/stack-status'
-import { Route as ApiSettingsRouteImport } from './routes/api/settings'
-import { Route as ApiProxmoxStatsRouteImport } from './routes/api/proxmox-stats'
-import { Route as ApiHealthRouteImport } from './routes/api/health'
-import { Route as ApiDockerStatsRouteImport } from './routes/api/docker-stats'
-import { Route as ApiDockerInventoryRouteImport } from './routes/api/docker-inventory'
-import { Route as StacksHostHostNameRouteImport } from './routes/stacks/host.$hostName'
-import { Route as ApiGitSplatRouteImport } from './routes/api/git.$'
-import { Route as ApiDockerLogsContainerIdRouteImport } from './routes/api/docker-logs.$containerId'
-import { Route as ApiAuthLogoutRouteImport } from './routes/api/auth/logout'
-import { Route as ApiAuthLoginRouteImport } from './routes/api/auth/login'
 import { Route as ApiAuthCallbackRouteImport } from './routes/api/auth/callback'
+import { Route as ApiAuthLoginRouteImport } from './routes/api/auth/login'
+import { Route as ApiAuthLogoutRouteImport } from './routes/api/auth/logout'
+import { Route as ApiDockerLogsContainerIdRouteImport } from './routes/api/docker-logs.$containerId'
+import { Route as ApiGitSplatRouteImport } from './routes/api/git.$'
+import { Route as StacksHostHostNameRouteImport } from './routes/stacks/host.$hostName'
 
-const ZfsRoute = ZfsRouteImport.update({
-  id: '/zfs',
-  path: '/zfs',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const StacksRoute = StacksRouteImport.update({
-  id: '/stacks',
-  path: '/stacks',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const SettingsRoute = SettingsRouteImport.update({
-  id: '/settings',
-  path: '/settings',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ProxmoxRoute = ProxmoxRouteImport.update({
-  id: '/proxmox',
-  path: '/proxmox',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const LoginRoute = LoginRouteImport.update({
-  id: '/login',
-  path: '/login',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const DockerRoute = DockerRouteImport.update({
-  id: '/docker',
-  path: '/docker',
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
   getParentRoute: () => rootRouteImport,
 } as any)
 const DeniedRoute = DeniedRouteImport.update({
@@ -69,10 +44,75 @@ const DeniedRoute = DeniedRouteImport.update({
   path: '/denied',
   getParentRoute: () => rootRouteImport,
 } as any)
-const IndexRoute = IndexRouteImport.update({
-  id: '/',
-  path: '/',
+const DockerRoute = DockerRouteImport.update({
+  id: '/docker',
+  path: '/docker',
   getParentRoute: () => rootRouteImport,
+} as any)
+const LoginRoute = LoginRouteImport.update({
+  id: '/login',
+  path: '/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ProxmoxRoute = ProxmoxRouteImport.update({
+  id: '/proxmox',
+  path: '/proxmox',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const SettingsRoute = SettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const StacksRoute = StacksRouteImport.update({
+  id: '/stacks',
+  path: '/stacks',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ZfsRoute = ZfsRouteImport.update({
+  id: '/zfs',
+  path: '/zfs',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiDockerInventoryRoute = ApiDockerInventoryRouteImport.update({
+  id: '/api/docker-inventory',
+  path: '/api/docker-inventory',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiDockerStatsRoute = ApiDockerStatsRouteImport.update({
+  id: '/api/docker-stats',
+  path: '/api/docker-stats',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiHealthRoute = ApiHealthRouteImport.update({
+  id: '/api/health',
+  path: '/api/health',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiProxmoxStatsRoute = ApiProxmoxStatsRouteImport.update({
+  id: '/api/proxmox-stats',
+  path: '/api/proxmox-stats',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiSettingsRoute = ApiSettingsRouteImport.update({
+  id: '/api/settings',
+  path: '/api/settings',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiStackStatusRoute = ApiStackStatusRouteImport.update({
+  id: '/api/stack-status',
+  path: '/api/stack-status',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiZfsStatsRoute = ApiZfsStatsRouteImport.update({
+  id: '/api/zfs-stats',
+  path: '/api/zfs-stats',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const DockerContainerIdRoute = DockerContainerIdRouteImport.update({
+  id: '/$containerId',
+  path: '/$containerId',
+  getParentRoute: () => DockerRoute,
 } as any)
 const StacksIndexRoute = StacksIndexRouteImport.update({
   id: '/',
@@ -84,54 +124,19 @@ const StacksStackNameRoute = StacksStackNameRouteImport.update({
   path: '/$stackName',
   getParentRoute: () => StacksRoute,
 } as any)
-const DockerContainerIdRoute = DockerContainerIdRouteImport.update({
-  id: '/$containerId',
-  path: '/$containerId',
-  getParentRoute: () => DockerRoute,
-} as any)
-const ApiZfsStatsRoute = ApiZfsStatsRouteImport.update({
-  id: '/api/zfs-stats',
-  path: '/api/zfs-stats',
+const ApiAuthCallbackRoute = ApiAuthCallbackRouteImport.update({
+  id: '/api/auth/callback',
+  path: '/api/auth/callback',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiStackStatusRoute = ApiStackStatusRouteImport.update({
-  id: '/api/stack-status',
-  path: '/api/stack-status',
+const ApiAuthLoginRoute = ApiAuthLoginRouteImport.update({
+  id: '/api/auth/login',
+  path: '/api/auth/login',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiSettingsRoute = ApiSettingsRouteImport.update({
-  id: '/api/settings',
-  path: '/api/settings',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiProxmoxStatsRoute = ApiProxmoxStatsRouteImport.update({
-  id: '/api/proxmox-stats',
-  path: '/api/proxmox-stats',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiHealthRoute = ApiHealthRouteImport.update({
-  id: '/api/health',
-  path: '/api/health',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiDockerStatsRoute = ApiDockerStatsRouteImport.update({
-  id: '/api/docker-stats',
-  path: '/api/docker-stats',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiDockerInventoryRoute = ApiDockerInventoryRouteImport.update({
-  id: '/api/docker-inventory',
-  path: '/api/docker-inventory',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const StacksHostHostNameRoute = StacksHostHostNameRouteImport.update({
-  id: '/host/$hostName',
-  path: '/host/$hostName',
-  getParentRoute: () => StacksRoute,
-} as any)
-const ApiGitSplatRoute = ApiGitSplatRouteImport.update({
-  id: '/api/git/$',
-  path: '/api/git/$',
+const ApiAuthLogoutRoute = ApiAuthLogoutRouteImport.update({
+  id: '/api/auth/logout',
+  path: '/api/auth/logout',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiDockerLogsContainerIdRoute =
@@ -140,20 +145,15 @@ const ApiDockerLogsContainerIdRoute =
     path: '/api/docker-logs/$containerId',
     getParentRoute: () => rootRouteImport,
   } as any)
-const ApiAuthLogoutRoute = ApiAuthLogoutRouteImport.update({
-  id: '/api/auth/logout',
-  path: '/api/auth/logout',
+const ApiGitSplatRoute = ApiGitSplatRouteImport.update({
+  id: '/api/git/$',
+  path: '/api/git/$',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiAuthLoginRoute = ApiAuthLoginRouteImport.update({
-  id: '/api/auth/login',
-  path: '/api/auth/login',
-  getParentRoute: () => rootRouteImport,
-} as any)
-const ApiAuthCallbackRoute = ApiAuthCallbackRouteImport.update({
-  id: '/api/auth/callback',
-  path: '/api/auth/callback',
-  getParentRoute: () => rootRouteImport,
+const StacksHostHostNameRoute = StacksHostHostNameRouteImport.update({
+  id: '/host/$hostName',
+  path: '/host/$hostName',
+  getParentRoute: () => StacksRoute,
 } as any)
 
 export interface FileRoutesByFullPath {
@@ -339,46 +339,11 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    '/zfs': {
-      id: '/zfs'
-      path: '/zfs'
-      fullPath: '/zfs'
-      preLoaderRoute: typeof ZfsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/stacks': {
-      id: '/stacks'
-      path: '/stacks'
-      fullPath: '/stacks'
-      preLoaderRoute: typeof StacksRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/settings': {
-      id: '/settings'
-      path: '/settings'
-      fullPath: '/settings'
-      preLoaderRoute: typeof SettingsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/proxmox': {
-      id: '/proxmox'
-      path: '/proxmox'
-      fullPath: '/proxmox'
-      preLoaderRoute: typeof ProxmoxRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/login': {
-      id: '/login'
-      path: '/login'
-      fullPath: '/login'
-      preLoaderRoute: typeof LoginRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/docker': {
-      id: '/docker'
-      path: '/docker'
-      fullPath: '/docker'
-      preLoaderRoute: typeof DockerRouteImport
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/denied': {
@@ -388,12 +353,103 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DeniedRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexRouteImport
+    '/docker': {
+      id: '/docker'
+      path: '/docker'
+      fullPath: '/docker'
+      preLoaderRoute: typeof DockerRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/login': {
+      id: '/login'
+      path: '/login'
+      fullPath: '/login'
+      preLoaderRoute: typeof LoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/proxmox': {
+      id: '/proxmox'
+      path: '/proxmox'
+      fullPath: '/proxmox'
+      preLoaderRoute: typeof ProxmoxRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings': {
+      id: '/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof SettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/stacks': {
+      id: '/stacks'
+      path: '/stacks'
+      fullPath: '/stacks'
+      preLoaderRoute: typeof StacksRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/zfs': {
+      id: '/zfs'
+      path: '/zfs'
+      fullPath: '/zfs'
+      preLoaderRoute: typeof ZfsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/docker-inventory': {
+      id: '/api/docker-inventory'
+      path: '/api/docker-inventory'
+      fullPath: '/api/docker-inventory'
+      preLoaderRoute: typeof ApiDockerInventoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/docker-stats': {
+      id: '/api/docker-stats'
+      path: '/api/docker-stats'
+      fullPath: '/api/docker-stats'
+      preLoaderRoute: typeof ApiDockerStatsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/health': {
+      id: '/api/health'
+      path: '/api/health'
+      fullPath: '/api/health'
+      preLoaderRoute: typeof ApiHealthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/proxmox-stats': {
+      id: '/api/proxmox-stats'
+      path: '/api/proxmox-stats'
+      fullPath: '/api/proxmox-stats'
+      preLoaderRoute: typeof ApiProxmoxStatsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/settings': {
+      id: '/api/settings'
+      path: '/api/settings'
+      fullPath: '/api/settings'
+      preLoaderRoute: typeof ApiSettingsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/stack-status': {
+      id: '/api/stack-status'
+      path: '/api/stack-status'
+      fullPath: '/api/stack-status'
+      preLoaderRoute: typeof ApiStackStatusRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/zfs-stats': {
+      id: '/api/zfs-stats'
+      path: '/api/zfs-stats'
+      fullPath: '/api/zfs-stats'
+      preLoaderRoute: typeof ApiZfsStatsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/docker/$containerId': {
+      id: '/docker/$containerId'
+      path: '/$containerId'
+      fullPath: '/docker/$containerId'
+      preLoaderRoute: typeof DockerContainerIdRouteImport
+      parentRoute: typeof DockerRoute
     }
     '/stacks/': {
       id: '/stacks/'
@@ -409,88 +465,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof StacksStackNameRouteImport
       parentRoute: typeof StacksRoute
     }
-    '/docker/$containerId': {
-      id: '/docker/$containerId'
-      path: '/$containerId'
-      fullPath: '/docker/$containerId'
-      preLoaderRoute: typeof DockerContainerIdRouteImport
-      parentRoute: typeof DockerRoute
-    }
-    '/api/zfs-stats': {
-      id: '/api/zfs-stats'
-      path: '/api/zfs-stats'
-      fullPath: '/api/zfs-stats'
-      preLoaderRoute: typeof ApiZfsStatsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/stack-status': {
-      id: '/api/stack-status'
-      path: '/api/stack-status'
-      fullPath: '/api/stack-status'
-      preLoaderRoute: typeof ApiStackStatusRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/settings': {
-      id: '/api/settings'
-      path: '/api/settings'
-      fullPath: '/api/settings'
-      preLoaderRoute: typeof ApiSettingsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/proxmox-stats': {
-      id: '/api/proxmox-stats'
-      path: '/api/proxmox-stats'
-      fullPath: '/api/proxmox-stats'
-      preLoaderRoute: typeof ApiProxmoxStatsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/health': {
-      id: '/api/health'
-      path: '/api/health'
-      fullPath: '/api/health'
-      preLoaderRoute: typeof ApiHealthRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/docker-stats': {
-      id: '/api/docker-stats'
-      path: '/api/docker-stats'
-      fullPath: '/api/docker-stats'
-      preLoaderRoute: typeof ApiDockerStatsRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/docker-inventory': {
-      id: '/api/docker-inventory'
-      path: '/api/docker-inventory'
-      fullPath: '/api/docker-inventory'
-      preLoaderRoute: typeof ApiDockerInventoryRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/stacks/host/$hostName': {
-      id: '/stacks/host/$hostName'
-      path: '/host/$hostName'
-      fullPath: '/stacks/host/$hostName'
-      preLoaderRoute: typeof StacksHostHostNameRouteImport
-      parentRoute: typeof StacksRoute
-    }
-    '/api/git/$': {
-      id: '/api/git/$'
-      path: '/api/git/$'
-      fullPath: '/api/git/$'
-      preLoaderRoute: typeof ApiGitSplatRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/docker-logs/$containerId': {
-      id: '/api/docker-logs/$containerId'
-      path: '/api/docker-logs/$containerId'
-      fullPath: '/api/docker-logs/$containerId'
-      preLoaderRoute: typeof ApiDockerLogsContainerIdRouteImport
-      parentRoute: typeof rootRouteImport
-    }
-    '/api/auth/logout': {
-      id: '/api/auth/logout'
-      path: '/api/auth/logout'
-      fullPath: '/api/auth/logout'
-      preLoaderRoute: typeof ApiAuthLogoutRouteImport
+    '/api/auth/callback': {
+      id: '/api/auth/callback'
+      path: '/api/auth/callback'
+      fullPath: '/api/auth/callback'
+      preLoaderRoute: typeof ApiAuthCallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/auth/login': {
@@ -500,12 +479,33 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiAuthLoginRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/auth/callback': {
-      id: '/api/auth/callback'
-      path: '/api/auth/callback'
-      fullPath: '/api/auth/callback'
-      preLoaderRoute: typeof ApiAuthCallbackRouteImport
+    '/api/auth/logout': {
+      id: '/api/auth/logout'
+      path: '/api/auth/logout'
+      fullPath: '/api/auth/logout'
+      preLoaderRoute: typeof ApiAuthLogoutRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/api/docker-logs/$containerId': {
+      id: '/api/docker-logs/$containerId'
+      path: '/api/docker-logs/$containerId'
+      fullPath: '/api/docker-logs/$containerId'
+      preLoaderRoute: typeof ApiDockerLogsContainerIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/git/$': {
+      id: '/api/git/$'
+      path: '/api/git/$'
+      fullPath: '/api/git/$'
+      preLoaderRoute: typeof ApiGitSplatRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/stacks/host/$hostName': {
+      id: '/stacks/host/$hostName'
+      path: '/host/$hostName'
+      fullPath: '/stacks/host/$hostName'
+      preLoaderRoute: typeof StacksHostHostNameRouteImport
+      parentRoute: typeof StacksRoute
     }
   }
 }

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -39,7 +39,7 @@ export const Route = createRootRoute({
       },
       {
         name: 'viewport',
-        content: 'initial-scale=1, width=device-width',
+        content: 'initial-scale=1, width=device-width, viewport-fit=cover',
       },
       {
         title: 'Homelab Manager',


### PR DESCRIPTION
## What and why

The header rendered five hover-opened tabs at every width. Below ~768px the tab bar overflowed the viewport, and the Docker/Stacks/Settings submenus were unreachable on any touch device at any width, because a finger cannot produce the `mouseenter` they wait for.

Below the `md` breakpoint the tab bar is now a drawer: a hamburger plus the current route name, opening a left `Sheet` that lists every destination, with the former hover menus turned into tap-expandable sections. The submenu of the current route starts expanded. At `md` and up the tab bar is visually unchanged; a touch pointer now opens a tab's menu on tap, and the popover gained an `onOpenChange` so an outside press can dismiss it (previously it had no dismissal path at all on touch).

This PR is also the foundation the four route PRs stack on:

- `useMediaQuery` (matchMedia + `useSyncExternalStore`) with `useIsMobile` / `useIsCompactNav` / `useIsTouch`. Window-scoped, unlike DataTable's container-scoped `ResizeObserver` -- both are kept, for chrome and for containers respectively.
- `src/lib/constants/breakpoints.ts`, so the JS thresholds and the Tailwind prefixes cannot drift apart.
- A `Sheet` primitive on the same Base UI `Dialog` as the existing `dialog.tsx`, with `left` / `right` / `bottom` variants, `dvh` sizing, and `overscroll-contain`.
- `viewport-fit=cover` plus `env(safe-area-inset-*)` padding on the header and sheet.
- A `.tap-target` utility that lifts a control's hit area to the 44px WCAG target-size minimum without changing its painted size.
- A Playwright `mobile` project on a Pixel 7, so each route PR can assert against a real phone viewport rather than a resized desktop one.

## Flow

```
Header -> useIsCompactNav -> MobileNav -> Sheet -> NAV_ITEMS + MenuContentFor
```

Before, at every width:

```
Header -> Tabs/TabsList -> hover (mouseenter) -> useMenuController -> Popover -> MenuContentFor
```

After, at `md` and up the hover path is unchanged; a touch pointer takes the tap branch into the same `useMenuController`. Below `md` the tab bar is not rendered at all and `MobileNav` reuses `MenuContentFor` inside a `Collapsible`, so the submenu contents have exactly one implementation.

## What else this touches

- `menus.tsx`: `MENU_ITEM_CLASSES` gains `min-h-11`, so the desktop popover rows also reach 44px. Affects the settings, stacks, and docker-hosts menus equally.
- `playwright.config.ts`: the `app` project's `testIgnore` widens to `/.*\.(demo|mobile)\.e2e\.ts$/` so the new `mobile` project owns `*.mobile.e2e.ts` exclusively (per the `bun test` / Playwright collection gotcha).
- `__root.tsx`: viewport meta only. No route, loader, SSE, settings key, migration, or env var is touched.
- No changes to any DataTable, route body, or data path. The route bodies still overflow at phone widths; that is the subject of the stacked PRs.

## Verification

- `bun run typecheck:all` -- clean.
- `bunx playwright test --project=mobile` -- 4 passed (Pixel 7 viewport): drawer replaces the tab bar, drawer navigates, drawer exposes a submenu that desktop opens on hover, header fits the viewport on all five routes.
- `bunx playwright test --project=app --project=demo` -- 21 passed, no desktop regression.
- New unit tests: 10 for `MobileNav`, 3 for `Header` below `md`, 7 for `Sheet`, 9 for `useMediaQuery`. All pass.
- `bun test --isolate` (full suite) is not a usable signal in this container: it reports ~540 failures on an unmodified `main` as well. The container has Bun 1.3.11 against the pinned 1.3.14, and the failing files pass individually (e.g. `git-token-repository.test.ts`: 17/17 alone, failing in the full run), which is the documented mock-leak-under-version-drift symptom. I diffed the full-run failure list with and without this branch: identical apart from one pre-existing flake that happened to pass. Please treat CI's coverage run as the authority here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2DmUg6NUpd51qSsKyiG5R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added responsive mobile navigation using a left-side drawer with route-aware labels, expandable submenu entries, and automatic closing after navigation.
  * Added a new “Sheet” UI component suite for drawer/panel composition.
  * Improved mobile viewport behavior with `viewport-fit=cover`.

* **Bug Fixes**
  * Improved touch-device header interactions by suppressing hover/focus behavior and using tap-based menu control.
  * Prevented header/demo content from exceeding mobile viewport width.

* **Tests**
  * Added/expanded mobile, touch, and navigation-focused coverage, including header layout checks across key routes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->