### PR TITLE
feat(mobile): make the Docker route usable at phone widths

### DIFF
--- a/e2e/docker.mobile.e2e.ts
+++ b/e2e/docker.mobile.e2e.ts
@@ -1,0 +1,54 @@
+import { test, expect } from './fixtures';
+
+test('the container table fits the viewport', async ({ page }) => {
+  await page.goto('/docker');
+  await expect(page.getByText('nginx-proxy').first()).toBeVisible();
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow, '/docker overflows the viewport horizontally').toBeLessThanOrEqual(1);
+});
+
+test('the table itself does not scroll sideways', async ({ page }) => {
+  await page.goto('/docker');
+  await expect(page.getByText('nginx-proxy').first()).toBeVisible();
+
+  const rowOverflow = await page.evaluate(() => {
+    const row = document.querySelector('[data-host-id="192.168.1.10"]');
+    if (!row) return null;
+    const scroller = row.closest('.overflow-x-auto');
+    if (!scroller) return 0;
+    return scroller.scrollWidth - scroller.clientWidth;
+  });
+
+  expect(rowOverflow, 'container table scrolls horizontally').not.toBeNull();
+  expect(rowOverflow!).toBeLessThanOrEqual(1);
+});
+
+test('the metric group toggle swaps which columns are shown', async ({ page }) => {
+  await page.goto('/docker');
+  await expect(page.getByText('nginx-proxy').first()).toBeVisible();
+
+  const header = page.locator('[data-slot="datatable-header"]').first();
+  await expect(header.getByText('CPU')).toBeVisible();
+  await expect(header.getByText('Net RX')).toHaveCount(0);
+
+  const toggle = page.getByRole('button', { name: 'Network' }).first();
+  await expect(toggle).toBeVisible();
+
+  const box = await toggle.boundingBox();
+  expect(box!.height, 'metric toggle is under the 44px touch target').toBeGreaterThanOrEqual(44);
+
+  await toggle.click();
+
+  await expect(header.getByText('Net RX')).toBeVisible();
+  await expect(header.getByText('CPU')).toHaveCount(0);
+});
+
+test('a container opens its detail view from a tap', async ({ page }) => {
+  await page.goto('/docker');
+  await page.getByText('nginx-proxy').first().click();
+
+  await expect(page.getByRole('button', { name: 'Stop container' }).first()).toBeVisible();
+});

--- a/src/App.css
+++ b/src/App.css
@@ -202,7 +202,9 @@ body {
 
 /* Expands a control's hit area to the 44px WCAG target-size minimum without
    changing its painted size. The overlay is centered on the control, so a
-   32px icon button gains 6px of slop on every side. */
+   32px icon button gains 6px of slop on every side. Only for controls with at
+   least 12px of clearance: on adjacent controls the overlays overlap and the
+   one later in the DOM swallows its neighbour's taps. */
 .tap-target {
   position: relative;
 }

--- a/src/components/docker/ContainerActionButtons.tsx
+++ b/src/components/docker/ContainerActionButtons.tsx
@@ -55,12 +55,12 @@ export default function ContainerActionButtons({
   const isPending = mutation.isPending;
 
   return (
-    <div className="flex items-center gap-0.5">
+    <div className="flex items-center gap-2 lg:gap-0.5">
       <IconTooltip label="Start">
         <Button
           variant="ghost"
           size="icon-sm"
-          className="p-1!"
+          className="size-11 p-1! lg:size-8"
           disabled={isRunning || isPending}
           onClick={() => trigger('start')}
           aria-label="Start container"
@@ -76,7 +76,7 @@ export default function ContainerActionButtons({
         <Button
           variant="ghost"
           size="icon-sm"
-          className={`p-1! ${isRunning && !isPending ? 'text-destructive' : ''}`}
+          className={`size-11 p-1! lg:size-8 ${isRunning && !isPending ? 'text-destructive' : ''}`}
           disabled={!isRunning || isPending}
           onClick={() => trigger('stop')}
           aria-label="Stop container"
@@ -92,7 +92,7 @@ export default function ContainerActionButtons({
         <Button
           variant="ghost"
           size="icon-sm"
-          className="p-1!"
+          className="size-11 p-1! lg:size-8"
           disabled={!isRunning || isPending}
           onClick={() => trigger('restart')}
           aria-label="Restart container"

--- a/src/components/docker/ContainerDetailPanel.tsx
+++ b/src/components/docker/ContainerDetailPanel.tsx
@@ -89,7 +89,7 @@ function ActionStripButton({ icon, label, onClick, disabled }: ActionStripButton
       type="button"
       onClick={onClick}
       disabled={disabled}
-      className="inline-flex items-center gap-1 px-2 h-[28px] rounded text-xs font-medium text-(--muted-foreground) border border-(--border) bg-transparent transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer"
+      className="inline-flex items-center gap-1 px-3 min-h-11 rounded text-sm font-medium text-(--muted-foreground) border border-(--border) bg-transparent transition-colors disabled:opacity-40 disabled:cursor-not-allowed cursor-pointer lg:px-2 lg:min-h-0 lg:h-[28px] lg:text-xs"
     >
       {icon}
       {label}

--- a/src/components/docker/ContainerHistoryPage.tsx
+++ b/src/components/docker/ContainerHistoryPage.tsx
@@ -36,11 +36,11 @@ export default function ContainerHistoryPage({
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      <div className="border-b border-(--border) bg-(--level1) px-6 py-3 select-none shrink-0">
+      <div className="border-b border-(--border) bg-(--level1) px-3 py-3 select-none shrink-0 lg:px-6">
         <MetricCheckboxes selected={selectedMetrics} onChange={handleMetricsChange} />
       </div>
 
-      <div className="overflow-y-auto flex-1 min-h-0 themed-scrollbar px-6 py-4">
+      <div className="overflow-y-auto flex-1 min-h-0 themed-scrollbar px-3 py-4 lg:px-6">
         {isChartDataEmpty ? (
           <div className="flex items-center justify-center h-64 text-(--muted-foreground)">
             <p>No data available for this time range.</p>

--- a/src/components/docker/ContainerModal.tsx
+++ b/src/components/docker/ContainerModal.tsx
@@ -11,6 +11,7 @@ import ContainerHistoryPage from '@/components/docker/ContainerHistoryPage';
 import ContainerStateChip from '@/components/docker/ContainerStateChip';
 import ContainerActionButtons from '@/components/docker/ContainerActionButtons';
 import { useDockerSettings } from '@/hooks/useDockerSettings';
+import { useIsMobile, useIsTouch } from '@/hooks/useMediaQuery';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
 
 export type ModalTab = 'logs' | 'terminal' | 'history';
@@ -36,10 +37,12 @@ function TabSwitch({
   value,
   onChange,
   isRunning,
+  isTouch,
 }: {
   value: ModalTab;
   onChange: (tab: ModalTab) => void;
   isRunning: boolean;
+  isTouch: boolean;
 }) {
   return (
     <div className="inline-flex gap-0.5 rounded-full p-0.5 bg-(--background)">
@@ -60,6 +63,7 @@ function TabSwitch({
                 : active
                   ? 'text-foreground cursor-pointer'
                   : 'text-(--muted-foreground) cursor-pointer',
+              isTouch ? 'tap-target' : '',
             ].join(' ')}
           >
             <Icon size={12} />
@@ -68,6 +72,93 @@ function TabSwitch({
         );
       })}
     </div>
+  );
+}
+
+function ModalIdentity({
+  inventory,
+  iconUrl,
+  iconError,
+  onIconError,
+}: {
+  inventory: DockerInventorySnapshotContainer;
+  iconUrl: string;
+  iconError: boolean;
+  onIconError: () => void;
+}) {
+  const shortId = inventory.containerId.slice(-8);
+
+  return (
+    <div className="flex items-center gap-3 min-w-0">
+      <img
+        src={iconError ? FALLBACK_ICON_URL : iconUrl}
+        alt=""
+        className="w-6 h-6 shrink-0 rounded-sm"
+        onError={onIconError}
+      />
+      <div className="flex flex-col gap-0 min-w-0 shrink-0">
+        <span className="text-sm font-semibold leading-tight truncate max-w-[160px]">
+          {inventory.name}
+        </span>
+        <span className="font-mono text-[10px] leading-tight text-(--text-disabled)">
+          {inventory.host} / {shortId}
+        </span>
+      </div>
+      <ContainerStateChip state={inventory.state} />
+    </div>
+  );
+}
+
+function HeaderActionControls({
+  containerId,
+  host,
+  isRunning,
+  activeTab,
+  resolvedShell,
+  shell,
+  onShellChange,
+  wordWrap,
+  onWrapToggle,
+  isTouch,
+}: {
+  containerId: string;
+  host: string;
+  isRunning: boolean;
+  activeTab: ModalTab;
+  resolvedShell: string | undefined;
+  shell: string;
+  onShellChange: (shell: string) => void;
+  wordWrap: boolean;
+  onWrapToggle: () => void;
+  isTouch: boolean;
+}) {
+  return (
+    <>
+      {activeTab === 'terminal' && (
+        <ShellSelect
+          value={shell}
+          onChange={onShellChange}
+          resolvedShell={resolvedShell}
+          className="shrink-0"
+        />
+      )}
+
+      {(activeTab === 'logs' || activeTab === 'terminal') && (
+        <IconTooltip label={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onWrapToggle}
+            className={`p-1! shrink-0 ${isTouch ? 'tap-target ' : ''}${wordWrap ? 'text-(--primary)!' : 'text-(--text-disabled)!'}`}
+            aria-label="Toggle word wrap"
+          >
+            <WrapText size={16} />
+          </Button>
+        </IconTooltip>
+      )}
+
+      <ContainerActionButtons containerId={containerId} host={host} isRunning={isRunning} />
+    </>
   );
 }
 
@@ -103,65 +194,78 @@ function ModalHeader({
   onClose: () => void;
 }) {
   const isRunning = inventory.state === 'running';
-  const shortId = inventory.containerId.slice(-8);
+  const isMobile = useIsMobile();
+  const isTouch = useIsTouch();
+
+  const closeButton = (
+    <IconTooltip label="Close">
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={onClose}
+        aria-label="Close modal"
+        className={`p-1! shrink-0 ${isTouch ? 'tap-target' : ''}`}
+      >
+        <X size={16} />
+      </Button>
+    </IconTooltip>
+  );
+
+  const identity = (
+    <ModalIdentity
+      inventory={inventory}
+      iconUrl={iconUrl}
+      iconError={iconError}
+      onIconError={onIconError}
+    />
+  );
+
+  const actionControls = (
+    <HeaderActionControls
+      containerId={containerId}
+      host={host}
+      isRunning={isRunning}
+      activeTab={activeTab}
+      resolvedShell={resolvedShell}
+      shell={shell}
+      onShellChange={onShellChange}
+      wordWrap={wordWrap}
+      onWrapToggle={onWrapToggle}
+      isTouch={isTouch}
+    />
+  );
+
+  // grid-template-columns below has no minmax(0, ...), so its tracks can't shrink
+  // below content width; below lg the header stacks into rows instead.
+  if (isMobile) {
+    return (
+      <div className="flex flex-col gap-2 px-3 py-2 border-b border-(--border) shrink-0 bg-(--popover)">
+        <div className="flex items-center justify-between gap-2">
+          {identity}
+          {closeButton}
+        </div>
+
+        <TabSwitch value={activeTab} onChange={onTabChange} isRunning={isRunning} isTouch={isTouch} />
+
+        <div className="flex items-center flex-wrap gap-2">{actionControls}</div>
+      </div>
+    );
+  }
 
   return (
     <div
       className="grid [grid-template-columns:1fr_auto_1fr] px-3 py-2 border-b border-(--border) shrink-0 bg-(--popover) min-h-[52px] items-center gap-2"
     >
-      <div className="flex items-center gap-3 min-w-0">
-        <img
-          src={iconError ? FALLBACK_ICON_URL : iconUrl}
-          alt=""
-          className="w-6 h-6 shrink-0 rounded-sm"
-          onError={onIconError}
-        />
-        <div className="flex flex-col gap-0 min-w-0 shrink-0">
-          <span className="text-sm font-semibold leading-tight truncate max-w-[160px]">
-            {inventory.name}
-          </span>
-          <span className="font-mono text-[10px] leading-tight text-(--text-disabled)">
-            {inventory.host} / {shortId}
-          </span>
-        </div>
-        <ContainerStateChip state={inventory.state} />
-      </div>
+      {identity}
 
-      <TabSwitch value={activeTab} onChange={onTabChange} isRunning={isRunning} />
+      <TabSwitch value={activeTab} onChange={onTabChange} isRunning={isRunning} isTouch={isTouch} />
 
       <div className="flex items-center justify-end gap-2">
-      {activeTab === 'terminal' && (
-        <ShellSelect
-          value={shell}
-          onChange={onShellChange}
-          resolvedShell={resolvedShell}
-          className="shrink-0"
-        />
-      )}
+        {actionControls}
 
-      {(activeTab === 'logs' || activeTab === 'terminal') && (
-        <IconTooltip label={wordWrap ? 'Disable word wrap' : 'Enable word wrap'}>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            onClick={onWrapToggle}
-            className={`p-1! shrink-0 ${wordWrap ? 'text-(--primary)!' : 'text-(--text-disabled)!'}`}
-            aria-label="Toggle word wrap"
-          >
-            <WrapText size={16} />
-          </Button>
-        </IconTooltip>
-      )}
+        <div className="w-px h-5 shrink-0 bg-(--border)" />
 
-      <ContainerActionButtons containerId={containerId} host={host} isRunning={isRunning} />
-
-      <div className="w-px h-5 shrink-0 bg-(--border)" />
-
-      <IconTooltip label="Close">
-        <Button variant="ghost" size="icon-sm" onClick={onClose} aria-label="Close modal" className="p-1! shrink-0">
-          <X size={16} />
-        </Button>
-      </IconTooltip>
+        {closeButton}
       </div>
     </div>
   );
@@ -227,7 +331,7 @@ export default memo(function ContainerModal({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
-      <DialogContent className="flex flex-col min-h-0 overflow-hidden rounded-lg bg-(--popover) w-[calc(100%-64px)] max-w-[1200px] h-[calc(100vh-80px)] p-0">
+      <DialogContent className="flex flex-col min-h-0 overflow-hidden rounded-none max-h-none w-full max-w-none h-full bg-(--popover) lg:rounded-lg lg:max-h-[calc(100%-64px)] lg:w-[calc(100%-64px)] lg:max-w-[1200px] lg:h-[calc(100vh-80px)] p-0">
       <ModalHeader
         inventory={inventory}
         containerId={containerId}

--- a/src/components/docker/ContainerPortsMounts.tsx
+++ b/src/components/docker/ContainerPortsMounts.tsx
@@ -118,7 +118,6 @@ function MountRow({ mount }: { mount: ContainerMount }) {
         type="button"
         onClick={() => setExpanded((value) => !value)}
         aria-expanded={expanded}
-        aria-label={fullMapping}
         className="text-left"
       >
         {row}

--- a/src/components/docker/ContainerPortsMounts.tsx
+++ b/src/components/docker/ContainerPortsMounts.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useRef, useState } from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useIsTouch } from '@/hooks/useMediaQuery';
 import type { ContainerPort, ContainerMount } from '@/types/docker-inventory';
 
 const WILDCARD_HOST_IPS = new Set(['0.0.0.0', '::']);
@@ -79,13 +81,28 @@ export default function ContainerPortsMounts({ ports, mounts }: Readonly<Contain
 function MountRow({ mount }: { mount: ContainerMount }) {
   const { display, isVolume } = formatMountSource(mount.source, mount.type);
   const fullMapping = `${mount.source} -> ${mount.destination}`;
+  const isTouch = useIsTouch();
+  const [expanded, setExpanded] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const truncateClass = isTouch && expanded ? '' : 'truncate max-w-[45%]';
+
+  useEffect(() => {
+    if (!isTouch || !expanded) return;
+    // Mirrors IconTooltip's dismiss pattern: pointerdown precedes this row's own
+    // toggle click, so an outside tap can collapse without racing a re-expand.
+    function dismissIfOutside(e: PointerEvent) {
+      if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) setExpanded(false);
+    }
+    document.addEventListener('pointerdown', dismissIfOutside);
+    return () => document.removeEventListener('pointerdown', dismissIfOutside);
+  }, [isTouch, expanded]);
 
   const row = (
     <div className="flex flex-wrap items-center gap-x-1.5 gap-y-0.5 min-w-0 text-xs">
-      <span className="truncate max-w-[45%] min-w-0 font-mono text-foreground">{display}</span>
+      <span className={`${truncateClass} min-w-0 font-mono text-foreground`}>{display}</span>
       {isVolume && <span className="shrink-0 text-(--muted-foreground)">(volume)</span>}
       <span className="shrink-0 text-(--muted-foreground)">-&gt;</span>
-      <span className="truncate max-w-[45%] min-w-0 font-mono text-foreground">{mount.destination}</span>
+      <span className={`${truncateClass} min-w-0 font-mono text-foreground`}>{mount.destination}</span>
       {!mount.rw && (
         <Badge variant="outline" className="h-4 rounded-sm px-1 text-[10px] border-(--warning) text-(--warning) shrink-0">
           ro
@@ -93,6 +110,21 @@ function MountRow({ mount }: { mount: ContainerMount }) {
       )}
     </div>
   );
+
+  if (isTouch) {
+    return (
+      <button
+        ref={buttonRef}
+        type="button"
+        onClick={() => setExpanded((value) => !value)}
+        aria-expanded={expanded}
+        aria-label={fullMapping}
+        className="text-left"
+      >
+        {row}
+      </button>
+    );
+  }
 
   return (
     <Tooltip>

--- a/src/components/docker/IconGrid.tsx
+++ b/src/components/docker/IconGrid.tsx
@@ -1,10 +1,13 @@
 import { memo, useState, useMemo, useRef, useCallback, useEffect, useLayoutEffect } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useIsTouch } from '@/hooks/useMediaQuery';
+import { cn } from '@/lib/utils/cn';
 
 const IconCell = memo(function IconCell({ slug, selected, onSelect }: { slug: string; selected: boolean; onSelect: (slug: string) => void }) {
   const [loaded, setLoaded] = useState(false);
   const imgRef = useRef<HTMLImageElement | null>(null);
+  const isTouch = useIsTouch();
   const handleLoad = useCallback(() => setLoaded(true), []);
   const handleError = useCallback(() => setLoaded(true), []);
 
@@ -36,9 +39,11 @@ const IconCell = memo(function IconCell({ slug, selected, onSelect }: { slug: st
     <button
       type="button"
       onClick={() => onSelect(slug)}
-      className={`flex flex-col items-center p-2 rounded-md cursor-pointer hover:bg-blue-500/10 outline-none focus-visible:ring-2 focus-visible:ring-ring/50 ${
-        selected ? 'bg-blue-500/20 ring-1 ring-blue-500' : ''
-      }`}
+      className={cn(
+        'flex flex-col items-center p-2 rounded-md cursor-pointer hover:bg-blue-500/10 outline-none focus-visible:ring-2 focus-visible:ring-ring/50',
+        isTouch && 'tap-target',
+        selected && 'bg-blue-500/20 ring-1 ring-blue-500',
+      )}
     >
       <div className="relative w-8 h-8">
         {!loaded && (
@@ -67,8 +72,24 @@ const IconRow = memo(function IconRow({ slugs, currentIcon, onSelect }: { slugs:
   );
 });
 
-const ICON_COLS = 7;
+const ICON_MIN_COLS = 3;
+const ICON_MAX_COLS = 7;
+const ICON_CELL_MIN_WIDTH = 64;
+const ICON_GRID_GAP = 8;
 const ICON_ROW_HEIGHT = 76;
+
+/**
+ * Number of columns the grid can fit is derived from the measured container
+ * width and clamped to [ICON_MIN_COLS, ICON_MAX_COLS]. The same value drives
+ * both the CSS `gridTemplateColumns` and the `iconRows` chunking below, so the
+ * two can never disagree the way a hardcoded `grid-cols-7` class paired with
+ * a separate constant could.
+ */
+function computeIconCols(containerWidth: number): number {
+  if (containerWidth <= 0) return ICON_MAX_COLS;
+  const cols = Math.floor((containerWidth + ICON_GRID_GAP) / (ICON_CELL_MIN_WIDTH + ICON_GRID_GAP));
+  return Math.min(ICON_MAX_COLS, Math.max(ICON_MIN_COLS, cols));
+}
 
 interface IconGridProps {
   filteredIcons: readonly string[];
@@ -84,14 +105,30 @@ export default function IconGrid({
   emptyMessage,
 }: IconGridProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const [containerWidth, setContainerWidth] = useState(0);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (entry) setContainerWidth(entry.contentRect.width);
+    });
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const cols = useMemo(() => computeIconCols(containerWidth), [containerWidth]);
 
   const iconRows = useMemo(() => {
     const rows: string[][] = [];
-    for (let i = 0; i < filteredIcons.length; i += ICON_COLS) {
-      rows.push(filteredIcons.slice(i, i + ICON_COLS));
+    for (let i = 0; i < filteredIcons.length; i += cols) {
+      rows.push(filteredIcons.slice(i, i + cols));
     }
     return rows;
-  }, [filteredIcons]);
+  }, [filteredIcons, cols]);
 
   const virtualizer = useVirtualizer({
     count: iconRows.length,
@@ -105,7 +142,7 @@ export default function IconGrid({
   // Reset the scroll position so the first match is always visible.
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: 0 });
-  }, [filteredIcons]);
+  }, [filteredIcons, cols]);
 
   return (
     <div
@@ -121,9 +158,10 @@ export default function IconGrid({
             return (
               <div
                 key={virtualRow.index}
-                className="grid grid-cols-7 gap-2 absolute left-0 w-full"
+                className="grid gap-2 absolute left-0 w-full"
                 style={{
                   height: virtualRow.size,
+                  gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
                   transform: `translateY(${virtualRow.start}px)`,
                 }}
               >

--- a/src/components/docker/IconPickerDialog.tsx
+++ b/src/components/docker/IconPickerDialog.tsx
@@ -5,6 +5,8 @@ import { Input } from '@/components/ui/input';
 import { Search, X } from 'lucide-react';
 import { AVAILABLE_ICONS } from '@/lib/utils/icon-resolver';
 import { SELECTION_FEEDBACK_MS } from '@/lib/constants/ui-timing';
+import { useIsTouch } from '@/hooks/useMediaQuery';
+import { cn } from '@/lib/utils/cn';
 import IconGrid from '@/components/docker/IconGrid';
 
 interface IconPickerDialogProps {
@@ -25,6 +27,7 @@ export default function IconPickerDialog({
   const [search, setSearch] = useState('');
   const [pendingIcon, setPendingIcon] = useState<string | null>(null);
   const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+  const isTouch = useIsTouch();
 
   useEffect(() => {
     if (open) {
@@ -72,12 +75,18 @@ export default function IconPickerDialog({
 
   return (
     <Dialog open={open} onOpenChange={(isOpen) => { if (!isOpen) handleClose(); }}>
-      <DialogContent className="flex flex-col overflow-hidden rounded-lg bg-(--popover) w-[720px] max-w-[calc(100%-64px)] max-h-[600px] p-0">
+      <DialogContent className="flex flex-col overflow-hidden rounded-lg bg-(--popover) w-[calc(100%-32px)] max-w-[calc(100%-32px)] sm:w-[720px] sm:max-w-[calc(100%-64px)] max-h-[600px] p-0">
         <div className="flex items-center justify-between px-5 pt-3 pb-3 border-b border-(--border) shrink-0 bg-(--popover)">
           <h2 className="text-sm font-semibold">
             Select Icon for {containerName}
           </h2>
-          <Button variant="ghost" size="icon-sm" onClick={handleClose} aria-label="Close">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleClose}
+            aria-label="Close"
+            className={cn(isTouch && 'tap-target')}
+          >
             <X size={18} />
           </Button>
         </div>
@@ -118,26 +127,33 @@ export default function IconPickerDialog({
           />
         </div>
 
-        <DialogFooter className="px-5 py-3 border-t border-(--border) bg-(--popover)">
+        <DialogFooter className="flex-wrap justify-between px-5 py-3 border-t border-(--border) bg-(--popover)">
           <Button
             size="sm"
             variant="ghost"
             onClick={handleAutoDetect}
-            className="mr-auto text-xs text-(--muted-foreground)"
+            className={cn('text-xs text-(--muted-foreground)', isTouch && 'tap-target')}
           >
             Use auto-detected
           </Button>
-          <Button size="sm" variant="outline" onClick={handleClose} className="text-xs">
-            Cancel
-          </Button>
-          <Button
-            size="sm"
-            onClick={handleApply}
-            disabled={!pendingIcon}
-            className="text-xs"
-          >
-            Apply
-          </Button>
+          <div className="flex gap-2">
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={handleClose}
+              className={cn('text-xs', isTouch && 'tap-target')}
+            >
+              Cancel
+            </Button>
+            <Button
+              size="sm"
+              onClick={handleApply}
+              disabled={!pendingIcon}
+              className={cn('text-xs', isTouch && 'tap-target')}
+            >
+              Apply
+            </Button>
+          </div>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/src/components/docker/IconTooltip.tsx
+++ b/src/components/docker/IconTooltip.tsx
@@ -1,5 +1,6 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, useEffect } from 'react';
 import { createPortal } from 'react-dom';
+import { useIsTouch } from '@/hooks/useMediaQuery';
 
 interface IconTooltipProps {
   label: string;
@@ -14,6 +15,7 @@ interface IconTooltipProps {
 export default function IconTooltip({ label, children }: IconTooltipProps) {
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
   const ref = useRef<HTMLSpanElement>(null);
+  const isTouch = useIsTouch();
 
   const show = useCallback(() => {
     if (!ref.current) return;
@@ -23,9 +25,46 @@ export default function IconTooltip({ label, children }: IconTooltipProps) {
 
   const hide = useCallback(() => setPos(null), []);
 
+  const toggle = useCallback(() => {
+    if (!isTouch) return;
+    setPos((current) => {
+      if (current !== null) return null;
+      if (!ref.current) return current;
+      const r = ref.current.getBoundingClientRect();
+      return { x: r.left + r.width / 2, y: r.top };
+    });
+  }, [isTouch]);
+
+  useEffect(() => {
+    if (!isTouch || pos === null) return;
+    // pointerdown fires before the tap's own click that reopens/toggles here, so an
+    // outside tap can dismiss without racing this element's own toggle.
+    function dismissIfOutside(e: PointerEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) hide();
+    }
+    document.addEventListener('pointerdown', dismissIfOutside);
+    return () => document.removeEventListener('pointerdown', dismissIfOutside);
+  }, [isTouch, pos, hide]);
+
   return (
     <>
-      <span ref={ref} onMouseEnter={show} onMouseLeave={hide} onFocus={show} onBlur={hide} className="inline-flex">
+      <span
+        ref={ref}
+        onMouseEnter={() => {
+          if (!isTouch) show();
+        }}
+        onMouseLeave={() => {
+          if (!isTouch) hide();
+        }}
+        onFocus={() => {
+          if (!isTouch) show();
+        }}
+        onBlur={() => {
+          if (!isTouch) hide();
+        }}
+        onClick={toggle}
+        className="inline-flex"
+      >
         {children}
       </span>
       {pos !== null && createPortal(

--- a/src/components/docker/__tests__/ContainerModal.test.tsx
+++ b/src/components/docker/__tests__/ContainerModal.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, mock } from 'bun:test';
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
 import { render, screen, fireEvent } from '@testing-library/react';
 import type { DockerInventorySnapshotContainer } from '@/types/docker-inventory';
 
@@ -113,5 +113,80 @@ describe('ContainerModal', () => {
     renderModal({ inventory: { ...sampleInventory, state: 'exited' } });
     const terminalBtn = screen.getByText('Terminal').closest('button') as HTMLButtonElement;
     expect(terminalBtn.disabled).toBe(true);
+  });
+
+  it('sizes the dialog full-bleed by default, constrained to the desktop card at lg', () => {
+    renderModal();
+    const content = document.querySelector('[data-slot="dialog-content"]') as HTMLElement;
+    expect(content.className).toContain('w-full');
+    expect(content.className).toContain('h-full');
+    expect(content.className).toContain('rounded-none');
+    expect(content.className).toContain('lg:w-[calc(100%-64px)]');
+    expect(content.className).toContain('lg:h-[calc(100vh-80px)]');
+    expect(content.className).toContain('lg:rounded-lg');
+  });
+});
+
+// beforeEach rather than beforeAll: a sibling test file can replace matchMedia
+// mid-run, and reinstalling per test keeps these assertions independent of order.
+function installMatchMedia(matches: (query: string) => boolean) {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: (query: string) => ({
+        matches: matches(query),
+        media: query,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+      }),
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+}
+
+describe('ContainerModal below the lg breakpoint', () => {
+  installMatchMedia((query) => query === '(max-width: 1023px)');
+
+  it('keeps the close button reachable next to the identity row instead of the crowded actions row', () => {
+    const onClose = mock(() => {});
+    renderModal({ onClose });
+    fireEvent.click(screen.getByLabelText('Close modal'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('still switches tabs once the header stacks into rows', () => {
+    renderModal();
+    fireEvent.click(screen.getByText('History'));
+    expect(screen.getByTestId('history-page')).toBeDefined();
+  });
+
+  it('keeps the word wrap toggle reachable', () => {
+    renderModal();
+    expect(screen.getByLabelText('Toggle word wrap')).toBeDefined();
+  });
+});
+
+describe('ContainerModal on touch devices', () => {
+  installMatchMedia((query) => query === '(hover: none), (pointer: coarse)');
+
+  it('expands the close button hit area via tap-target without changing its painted size', () => {
+    renderModal();
+    expect(screen.getByLabelText('Close modal').className).toContain('tap-target');
+  });
+
+  it('expands the tab pills hit area via tap-target', () => {
+    renderModal();
+    const logsTab = screen.getByText('Logs').closest('button') as HTMLButtonElement;
+    expect(logsTab.className).toContain('tap-target');
   });
 });

--- a/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
+++ b/src/components/docker/__tests__/ContainerPortsMounts.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, mock } from 'bun:test';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
 import type { ReactElement, ReactNode } from 'react';
 import {
   dedupeWildcardPorts,
@@ -16,6 +16,29 @@ mock.module('@/components/ui/tooltip', () => ({
 }));
 
 const { default: ContainerPortsMounts } = await import('@/components/docker/ContainerPortsMounts');
+
+const originalMatchMedia = window.matchMedia;
+
+function setTouch(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
 
 describe('formatPortMapping', () => {
   it('formats a published port with a wildcard bind IP without the IP prefix', () => {
@@ -142,5 +165,62 @@ describe('ContainerPortsMounts', () => {
     render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
 
     expect(screen.getByText('/very/long/path/to/some/data/directory -> /data')).not.toBeNull();
+  });
+});
+
+describe('ContainerPortsMounts mount row on a touch pointer', () => {
+  const mounts: ContainerMount[] = [
+    { type: 'bind', source: '/very/long/path/to/some/data/directory', destination: '/data', rw: true },
+  ];
+
+  it('exposes the full mapping as an accessible label instead of a hover tooltip', () => {
+    setTouch(true);
+    render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
+
+    const trigger = screen.getByRole('button', {
+      name: '/very/long/path/to/some/data/directory -> /data',
+    });
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('expands the full mapping on tap and collapses the truncation styling', () => {
+    setTouch(true);
+    render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
+
+    const trigger = screen.getByRole('button', {
+      name: '/very/long/path/to/some/data/directory -> /data',
+    });
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+  });
+
+  it('collapses on a second tap of the same row', () => {
+    setTouch(true);
+    render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
+
+    const trigger = screen.getByRole('button', {
+      name: '/very/long/path/to/some/data/directory -> /data',
+    });
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  it('collapses on a tap elsewhere', () => {
+    setTouch(true);
+    render(<ContainerPortsMounts ports={[]} mounts={mounts} />);
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+
+    const trigger = screen.getByRole('button', {
+      name: '/very/long/path/to/some/data/directory -> /data',
+    });
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    fireEvent.pointerDown(outside);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+
+    outside.remove();
   });
 });

--- a/src/components/docker/__tests__/IconGrid.test.tsx
+++ b/src/components/docker/__tests__/IconGrid.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
 import { render, screen, fireEvent } from '@testing-library/react';
+import * as useMediaQueryModule from '@/hooks/useMediaQuery';
 import IconGrid from '../IconGrid';
 
 let origGetBCR: typeof HTMLElement.prototype.getBoundingClientRect;
@@ -125,9 +126,9 @@ describe('IconGrid', () => {
     expect(img.className).toContain('visible');
   });
 
-  it('chunks icons into rows of 7 columns', () => {
+  it('chunks icons into rows of 7 columns by default (before the container is measured)', () => {
     const eight = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
-    render(
+    const { container } = render(
       <IconGrid
         filteredIcons={eight}
         currentIcon={null}
@@ -137,6 +138,120 @@ describe('IconGrid', () => {
     );
     for (const slug of eight) {
       expect(screen.getByAltText(slug)).toBeDefined();
+    }
+    const grid = container.querySelector('[style*="grid-template-columns"]') as HTMLElement;
+    expect(grid.style.gridTemplateColumns).toBe('repeat(7, minmax(0, 1fr))');
+  });
+
+  it('derives a narrower column count from the measured container width', () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    let resizeCallback: ResizeObserverCallback | null = null;
+
+    globalThis.ResizeObserver = class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        resizeCallback = cb;
+      }
+      observe() {
+        if (resizeCallback) {
+          resizeCallback(
+            [{ contentRect: { width: 300 } } as unknown as ResizeObserverEntry],
+            this as unknown as ResizeObserver,
+          );
+        }
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      const eight = ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'];
+      const { container } = render(
+        <IconGrid
+          filteredIcons={eight}
+          currentIcon={null}
+          onSelect={() => {}}
+          emptyMessage=""
+        />,
+      );
+      for (const slug of eight) {
+        expect(screen.getByAltText(slug)).toBeDefined();
+      }
+      const grid = container.querySelector('[style*="grid-template-columns"]') as HTMLElement;
+      expect(grid.style.gridTemplateColumns).toBe('repeat(4, minmax(0, 1fr))');
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
+  it('applies the tap-target utility on touch devices', () => {
+    const isTouchSpy = spyOn(useMediaQueryModule, 'useIsTouch').mockReturnValue(true);
+    try {
+      render(
+        <IconGrid
+          filteredIcons={['nginx']}
+          currentIcon={null}
+          onSelect={() => {}}
+          emptyMessage=""
+        />,
+      );
+      const btn = screen.getByAltText('nginx').closest('button');
+      expect(btn!.className).toContain('tap-target');
+    } finally {
+      isTouchSpy.mockRestore();
+    }
+  });
+
+  it('omits the tap-target utility on non-touch devices', () => {
+    const isTouchSpy = spyOn(useMediaQueryModule, 'useIsTouch').mockReturnValue(false);
+    try {
+      render(
+        <IconGrid
+          filteredIcons={['nginx']}
+          currentIcon={null}
+          onSelect={() => {}}
+          emptyMessage=""
+        />,
+      );
+      const btn = screen.getByAltText('nginx').closest('button');
+      expect(btn!.className).not.toContain('tap-target');
+    } finally {
+      isTouchSpy.mockRestore();
+    }
+  });
+
+  it('clamps the column count to a minimum of 3 at very narrow widths', () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    let resizeCallback: ResizeObserverCallback | null = null;
+
+    globalThis.ResizeObserver = class MockResizeObserver {
+      constructor(cb: ResizeObserverCallback) {
+        resizeCallback = cb;
+      }
+      observe() {
+        if (resizeCallback) {
+          resizeCallback(
+            [{ contentRect: { width: 120 } } as unknown as ResizeObserverEntry],
+            this as unknown as ResizeObserver,
+          );
+        }
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+
+    try {
+      const { container } = render(
+        <IconGrid
+          filteredIcons={['a', 'b', 'c']}
+          currentIcon={null}
+          onSelect={() => {}}
+          emptyMessage=""
+        />,
+      );
+      const grid = container.querySelector('[style*="grid-template-columns"]') as HTMLElement;
+      expect(grid.style.gridTemplateColumns).toBe('repeat(3, minmax(0, 1fr))');
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
     }
   });
 });

--- a/src/components/docker/__tests__/IconPickerDialog.test.tsx
+++ b/src/components/docker/__tests__/IconPickerDialog.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, mock, spyOn, beforeEach, afterEach } from 'bun:test';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import * as useMediaQueryModule from '@/hooks/useMediaQuery';
 
 mock.module('@/lib/utils/icon-resolver', () => ({
   AVAILABLE_ICONS: ['nginx', 'redis', 'postgres', 'docker'],
@@ -126,5 +127,47 @@ describe('IconPickerDialog', () => {
     expect(onSelect).toHaveBeenCalledWith(null);
 
     await waitFor(() => { expect(onClose).toHaveBeenCalledTimes(1); });
+  });
+
+  it('sizes the dialog to fit narrow viewports with a wider cap from sm: up', () => {
+    render(<IconPickerDialog {...defaultProps} />);
+    const dialogContent = document.querySelector('[data-slot="dialog-content"]');
+    expect(dialogContent!.className).toContain('w-[calc(100%-32px)]');
+    expect(dialogContent!.className).toContain('sm:w-[720px]');
+    expect(dialogContent!.className).toContain('sm:max-w-[calc(100%-64px)]');
+  });
+
+  it('lets the footer wrap and keeps Cancel and Apply grouped together so they stay reachable when it does', () => {
+    render(<IconPickerDialog {...defaultProps} />);
+    const footer = screen.getByText('Use auto-detected').closest('[data-slot="dialog-footer"]');
+    expect(footer!.className).toContain('flex-wrap');
+
+    const cancelButton = screen.getByText('Cancel');
+    const applyButton = screen.getByText('Apply');
+    expect(cancelButton.closest('div')).toBe(applyButton.closest('div'));
+  });
+
+  it('applies the tap-target utility to close, cancel, and apply on touch devices', () => {
+    const isTouchSpy = spyOn(useMediaQueryModule, 'useIsTouch').mockReturnValue(true);
+    try {
+      render(<IconPickerDialog {...defaultProps} />);
+      expect(screen.getByLabelText('Close').className).toContain('tap-target');
+      expect(screen.getByText('Cancel').className).toContain('tap-target');
+      expect(screen.getByText('Apply').className).toContain('tap-target');
+      expect(screen.getByText('Use auto-detected').className).toContain('tap-target');
+    } finally {
+      isTouchSpy.mockRestore();
+    }
+  });
+
+  it('omits the tap-target utility on non-touch devices', () => {
+    const isTouchSpy = spyOn(useMediaQueryModule, 'useIsTouch').mockReturnValue(false);
+    try {
+      render(<IconPickerDialog {...defaultProps} />);
+      expect(screen.getByLabelText('Close').className).not.toContain('tap-target');
+      expect(screen.getByText('Apply').className).not.toContain('tap-target');
+    } finally {
+      isTouchSpy.mockRestore();
+    }
   });
 });

--- a/src/components/docker/__tests__/IconTooltip.test.tsx
+++ b/src/components/docker/__tests__/IconTooltip.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import IconTooltip from '@/components/docker/IconTooltip';
+
+const originalMatchMedia = window.matchMedia;
+
+function setTouch(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+function renderIconTooltip() {
+  render(
+    <IconTooltip label="Start">
+      <button type="button">Icon</button>
+    </IconTooltip>,
+  );
+  const trigger = screen.getByRole('button', { name: 'Icon' }).parentElement as HTMLElement;
+  return { trigger };
+}
+
+describe('IconTooltip on a mouse pointer', () => {
+  it('shows the tooltip on mouse enter and hides it on mouse leave', () => {
+    setTouch(false);
+    const { trigger } = renderIconTooltip();
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    fireEvent.mouseEnter(trigger);
+    expect(screen.getByRole('tooltip').textContent).toBe('Start');
+    fireEvent.mouseLeave(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows the tooltip on focus and hides it on blur', () => {
+    setTouch(false);
+    const { trigger } = renderIconTooltip();
+
+    fireEvent.focus(trigger);
+    expect(screen.getByRole('tooltip').textContent).toBe('Start');
+    fireEvent.blur(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('ignores a click, leaving hover as the only way to reveal it', () => {
+    setTouch(false);
+    const { trigger } = renderIconTooltip();
+
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+});
+
+describe('IconTooltip on a touch pointer', () => {
+  it('reveals the tooltip on tap', () => {
+    setTouch(true);
+    const { trigger } = renderIconTooltip();
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip').textContent).toBe('Start');
+  });
+
+  it('dismisses on a second tap of the same trigger', () => {
+    setTouch(true);
+    const { trigger } = renderIconTooltip();
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip')).not.toBeNull();
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('dismisses on a tap elsewhere', () => {
+    setTouch(true);
+    const { trigger } = renderIconTooltip();
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip')).not.toBeNull();
+    fireEvent.pointerDown(outside);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    outside.remove();
+  });
+
+  it('ignores hover and focus, which a touch device can never satisfy', () => {
+    setTouch(true);
+    const { trigger } = renderIconTooltip();
+
+    fireEvent.mouseEnter(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    fireEvent.focus(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+});

--- a/src/components/ui/datatable/DataTable.tsx
+++ b/src/components/ui/datatable/DataTable.tsx
@@ -275,9 +275,13 @@ export function DataTable<TRow>({
   const virtualItems = virtualizer.getVirtualItems();
   const totalSize = virtualizer.getTotalSize();
 
+  // Passes the ancestor's value through rather than null, so the provider can wrap
+  // every path: wrapping only sometimes would remount the ref'd container.
   const metricGroupValue = useMemo(
-    () => (ownsMetricGroups ? { metricGroups: metricGroups!, activeIndex: activeMetricGroupIndex } : null),
-    [ownsMetricGroups, metricGroups, activeMetricGroupIndex],
+    () => (ownsMetricGroups
+      ? { metricGroups: metricGroups!, activeIndex: activeMetricGroupIndex }
+      : inheritedMetricGroups),
+    [ownsMetricGroups, metricGroups, activeMetricGroupIndex, inheritedMetricGroups],
   );
 
   const toolbar = (
@@ -293,12 +297,14 @@ export function DataTable<TRow>({
 
   if (rows.length === 0) {
     return (
-      <div ref={containerRef} className="flex flex-col flex-1 min-h-0">
-        {toolbar}
-        <div className="flex items-center justify-center flex-1 text-(--muted-foreground) py-12">
-          No data
+      <MetricGroupContext value={metricGroupValue}>
+        <div ref={containerRef} className="flex flex-col flex-1 min-h-0">
+          {toolbar}
+          <div className="flex items-center justify-center flex-1 text-(--muted-foreground) py-12">
+            No data
+          </div>
         </div>
-      </div>
+      </MetricGroupContext>
     );
   }
 
@@ -457,7 +463,13 @@ function DataTableRow<TRow>({ row, gridTemplate, rowClassName, rowAttributes, ha
       className={`group grid border-t border-(--border) hover:bg-(--row-hover-tint) hover:shadow-[inset_0_0_0_1px_var(--row-hover-ring)] transition-[background-color,box-shadow] duration-150 ${canExpand ? 'cursor-pointer' : ''} ${customClass}`}
       style={{ gridTemplateColumns: gridTemplate }}
       onClick={canExpand ? () => row.toggleExpanded() : undefined}
-      onKeyDown={canExpand ? (e) => { if (e.target !== e.currentTarget) return; if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); row.toggleExpanded(); } } : undefined}
+      onKeyDown={canExpand ? (e) => {
+        if (e.target !== e.currentTarget) return;
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          row.toggleExpanded();
+        }
+      } : undefined}
       {...extraAttributes}
     >
       {row.getVisibleCells().map((cell) => (

--- a/src/components/ui/datatable/DataTable.tsx
+++ b/src/components/ui/datatable/DataTable.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useMemo, useCallback, useEffect, type ReactNode } from 'react';
+import { createContext, useContext, useState, useRef, useMemo, useCallback, useEffect, type ReactNode } from 'react';
 import {
   useReactTable,
   getCoreRowModel,
@@ -26,6 +26,13 @@ export interface MetricGroup {
   columnIds: [string, ...string[]];
   icon?: ReactNode;
 }
+
+/**
+ * Lets a nested DataTable follow its parent's metric-group selection. A detail-panel
+ * subtable shares the parent's columns but owns no toolbar, so without this its
+ * columns stay all-visible on mobile and stop lining up with the parent header.
+ */
+const MetricGroupContext = createContext<{ metricGroups: MetricGroup[]; activeIndex: number } | null>(null);
 
 type ExpansionControl =
   | { expandedState?: never; onExpandedChange?: never }
@@ -82,26 +89,40 @@ const VIRTUALIZATION_THRESHOLD = 150;
 /** Viewport width at which sparklines become visible (matches the min-[1428px] CSS breakpoint). */
 export const SPARKLINE_MIN_WIDTH = 1428;
 
+/** Grid weight the name column gets on mobile, relative to 1fr for every other column. */
+const MOBILE_NAME_COLUMN_WEIGHT = 2;
+
 /**
  * Build a CSS grid-template-columns string from visible TanStack Table columns.
  * Uses column meta.flex if available (name column: 'minmax(200px, 1fr)').
  * Metric columns store two sizes in meta: sizeFull (with sparklines) and sizeCompact
  * (without). containerWidth selects between them so the column stays tight regardless
  * of whether sparklines are enabled in settings.
+ *
+ * On mobile every track goes proportional instead. The fixed px sizes total more
+ * than a phone viewport even after the metric-group toggle hides all but one
+ * group (200 name + 2x115 metric = 430px against a 375px screen), so the table
+ * would horizontally scroll no matter which group was selected.
  */
 function buildGridTemplate<TRow>(
   columns: ReturnType<ReturnType<typeof useReactTable<TRow>>['getVisibleLeafColumns']>,
   containerWidth: number,
   sparklineEnabled: boolean,
+  isMobile: boolean,
 ): string {
   const sparklinesVisible = containerWidth >= SPARKLINE_MIN_WIDTH && sparklineEnabled;
   return columns
     .map((col) => {
       const meta = col.columnDef.meta as {
         flex?: string;
+        mobileFlex?: string;
         sizeCompact?: number;
         sizeFull?: number;
       } | undefined;
+      if (isMobile) {
+        if (meta?.mobileFlex) return meta.mobileFlex;
+        return meta?.flex ? `minmax(0, ${MOBILE_NAME_COLUMN_WEIGHT}fr)` : 'minmax(0, 1fr)';
+      }
       if (meta?.flex) return meta.flex;
       if (meta?.sizeCompact !== undefined && meta?.sizeFull !== undefined) {
         return `${sparklinesVisible ? meta.sizeFull : meta.sizeCompact}px`;
@@ -149,6 +170,12 @@ export function DataTable<TRow>({
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
   const [internalExpanded, setInternalExpanded] = useState<ExpandedState>({});
   const { general: { showSparklines } } = useGeneralSettings();
+  const inheritedMetricGroups = useContext(MetricGroupContext);
+  const ownsMetricGroups = metricGroups != null && metricGroups.length > 0;
+  const effectiveMetricGroups = ownsMetricGroups ? metricGroups : inheritedMetricGroups?.metricGroups;
+  const effectiveGroupIndex = ownsMetricGroups
+    ? activeMetricGroupIndex
+    : (inheritedMetricGroups?.activeIndex ?? 0);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -173,15 +200,15 @@ export function DataTable<TRow>({
    * the active group are hidden when on mobile with metric groups defined.
    */
   const effectiveColumnVisibility = useMemo<VisibilityState>(() => {
-    if (!isMobile || !metricGroups || metricGroups.length === 0) {
+    if (!isMobile || !effectiveMetricGroups || effectiveMetricGroups.length === 0) {
       return columnVisibility;
     }
 
-    const activeGroup = metricGroups[activeMetricGroupIndex] ?? metricGroups[0];
+    const activeGroup = effectiveMetricGroups[effectiveGroupIndex] ?? effectiveMetricGroups[0];
     const activeIds = new Set(activeGroup.columnIds);
 
     const hiddenColumns: VisibilityState = {};
-    for (const group of metricGroups) {
+    for (const group of effectiveMetricGroups) {
       for (const colId of group.columnIds) {
         if (!activeIds.has(colId)) {
           hiddenColumns[colId] = false;
@@ -190,7 +217,7 @@ export function DataTable<TRow>({
     }
 
     return { ...columnVisibility, ...hiddenColumns };
-  }, [isMobile, metricGroups, activeMetricGroupIndex, columnVisibility]);
+  }, [isMobile, effectiveMetricGroups, effectiveGroupIndex, columnVisibility]);
 
   const expanded = controlledExpanded ?? internalExpanded;
   const setExpanded = useCallback(
@@ -233,7 +260,7 @@ export function DataTable<TRow>({
   const { rows } = table.getRowModel();
   const isVirtualized = rows.length > VIRTUALIZATION_THRESHOLD;
   const visibleColumns = table.getVisibleLeafColumns();
-  const gridTemplate = useMemo(() => buildGridTemplate(visibleColumns, containerWidth, showSparklines), [visibleColumns, containerWidth, showSparklines]);
+  const gridTemplate = useMemo(() => buildGridTemplate(visibleColumns, containerWidth, showSparklines, isMobile), [visibleColumns, containerWidth, showSparklines, isMobile]);
 
   const defaultEstimateSize = useCallback(() => DEFAULT_ROW_HEIGHT, []);
 
@@ -247,6 +274,11 @@ export function DataTable<TRow>({
 
   const virtualItems = virtualizer.getVirtualItems();
   const totalSize = virtualizer.getTotalSize();
+
+  const metricGroupValue = useMemo(
+    () => (ownsMetricGroups ? { metricGroups: metricGroups!, activeIndex: activeMetricGroupIndex } : null),
+    [ownsMetricGroups, metricGroups, activeMetricGroupIndex],
+  );
 
   const toolbar = (
     <DataTableToolbar
@@ -270,7 +302,7 @@ export function DataTable<TRow>({
     );
   }
 
-  return (
+  const body = (
     <div ref={containerRef} className="flex flex-col flex-1 min-h-0">
       {toolbar}
 
@@ -279,6 +311,7 @@ export function DataTable<TRow>({
         {/* Sticky header: inside scroll container so it tracks horizontal scroll */}
         {showHeader && (
           <div
+            data-slot="datatable-header"
             className="grid border-b border-(--border) bg-(--background) sticky top-0 z-10"
             style={{ gridTemplateColumns: gridTemplate }}
           >
@@ -286,9 +319,9 @@ export function DataTable<TRow>({
               headerGroup.headers.map((header) => (
                 <div
                   key={header.id}
-                  className={`px-3 py-2 font-semibold text-sm whitespace-nowrap select-none ${
-                    header.column.getCanSort() ? 'cursor-pointer hover:bg-(--accent)' : ''
-                  }`}
+                  className={`min-w-0 overflow-hidden py-2 font-semibold text-sm whitespace-nowrap select-none ${
+                    isMobile ? 'px-2 text-xs' : 'px-3'
+                  } ${header.column.getCanSort() ? 'cursor-pointer hover:bg-(--accent)' : ''}`}
                   onClick={header.column.getToggleSortingHandler()}
                   role={header.column.getCanSort() ? 'button' : undefined}
                   tabIndex={header.column.getCanSort() ? 0 : undefined}
@@ -346,6 +379,7 @@ export function DataTable<TRow>({
                     rowClassName={rowClassName}
                     rowAttributes={rowAttributes}
                     hasDetailPanel={hasDetailPanel}
+                    isMobile={isMobile}
                   />
                   {hasDetailPanel && (() => {
                     const panel = renderDetailPanel(row.original);
@@ -374,6 +408,7 @@ export function DataTable<TRow>({
                     rowClassName={rowClassName}
                     rowAttributes={rowAttributes}
                     hasDetailPanel={hasDetailPanel}
+                    isMobile={isMobile}
                   />
                   {hasDetailPanel && (() => {
                     const panel = renderDetailPanel(row.original);
@@ -396,6 +431,9 @@ export function DataTable<TRow>({
       </div>
     </div>
   );
+
+  if (!metricGroupValue) return body;
+  return <MetricGroupContext value={metricGroupValue}>{body}</MetricGroupContext>;
 }
 
 interface DataTableRowProps<TRow> {
@@ -404,9 +442,10 @@ interface DataTableRowProps<TRow> {
   rowClassName?: (row: TRow) => string;
   rowAttributes?: (row: TRow) => Record<`data-${string}` | `aria-${string}`, string>;
   hasDetailPanel?: boolean;
+  isMobile?: boolean;
 }
 
-function DataTableRow<TRow>({ row, gridTemplate, rowClassName, rowAttributes, hasDetailPanel }: Readonly<DataTableRowProps<TRow>>) {
+function DataTableRow<TRow>({ row, gridTemplate, rowClassName, rowAttributes, hasDetailPanel, isMobile }: Readonly<DataTableRowProps<TRow>>) {
   const customClass = rowClassName?.(row.original) ?? '';
   const extraAttributes = rowAttributes?.(row.original) ?? {};
   const canExpand = row.getCanExpand() || hasDetailPanel;
@@ -422,7 +461,10 @@ function DataTableRow<TRow>({ row, gridTemplate, rowClassName, rowAttributes, ha
       {...extraAttributes}
     >
       {row.getVisibleCells().map((cell) => (
-        <div key={cell.id} className="px-3 py-2">
+        // min-w-0 + overflow-hidden: without them a grid item's automatic minimum
+        // size is its content's min-content width, so a long name widens the track
+        // instead of letting the `truncate` inside the cell take effect.
+        <div key={cell.id} className={`min-w-0 overflow-hidden py-2 ${isMobile ? 'px-2' : 'px-3'}`}>
           {flexRender(cell.column.columnDef.cell, cell.getContext())}
         </div>
       ))}

--- a/src/components/ui/datatable/__tests__/DataTable.test.tsx
+++ b/src/components/ui/datatable/__tests__/DataTable.test.tsx
@@ -833,3 +833,60 @@ describe('DataTable', () => {
     });
   });
 });
+
+describe('DataTable container observation', () => {
+  function mockTrackingResizeObserver() {
+    const original = globalThis.ResizeObserver;
+    const observed: Element[] = [];
+    globalThis.ResizeObserver = class MockResizeObserver {
+      observe(el: Element) {
+        observed.push(el);
+      }
+      unobserve() {}
+      disconnect() {}
+    } as unknown as typeof ResizeObserver;
+    return { observed, restore: () => { globalThis.ResizeObserver = original; } };
+  }
+
+  const groups = [
+    { label: 'CPU', columnIds: ['value'] as [string, ...string[]] },
+  ];
+
+  // Asserts across every observed element, not just the container: the
+  // virtualizer registers a ResizeObserver of its own on the scroll element.
+  it('leaves no observed element detached after rows replace the empty state', () => {
+    const { observed, restore } = mockTrackingResizeObserver();
+    try {
+      const { rerender } = render(
+        <DataTable data={[]} columns={columns} getRowId={(row: TestRow) => row.id} metricGroups={groups} />,
+      );
+
+      rerender(
+        <DataTable data={testData} columns={columns} getRowId={(row: TestRow) => row.id} metricGroups={groups} />,
+      );
+
+      expect(observed.length).toBeGreaterThan(0);
+      expect(observed.filter((el) => !el.isConnected)).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+
+  it('leaves no observed element detached after rows drain away', () => {
+    const { observed, restore } = mockTrackingResizeObserver();
+    try {
+      const { rerender } = render(
+        <DataTable data={testData} columns={columns} getRowId={(row: TestRow) => row.id} metricGroups={groups} />,
+      );
+
+      rerender(
+        <DataTable data={[]} columns={columns} getRowId={(row: TestRow) => row.id} metricGroups={groups} />,
+      );
+
+      expect(observed.length).toBeGreaterThan(0);
+      expect(observed.filter((el) => !el.isConnected)).toHaveLength(0);
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/components/ui/datatable/__tests__/DataTable.test.tsx
+++ b/src/components/ui/datatable/__tests__/DataTable.test.tsx
@@ -621,4 +621,215 @@ describe('DataTable', () => {
       }
     });
   });
+
+  describe('mobile grid template', () => {
+    function withWidth<T>(width: number, run: () => T): T {
+      const originalResizeObserver = globalThis.ResizeObserver;
+      let resizeCallback: ResizeObserverCallback | null = null;
+      globalThis.ResizeObserver = class MockResizeObserver {
+        constructor(cb: ResizeObserverCallback) {
+          resizeCallback = cb;
+        }
+        observe() {
+          resizeCallback?.(
+            [{ contentRect: { width } } as unknown as ResizeObserverEntry],
+            this as unknown as ResizeObserver,
+          );
+        }
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof ResizeObserver;
+      try {
+        return run();
+      } finally {
+        globalThis.ResizeObserver = originalResizeObserver;
+      }
+    }
+
+    const sizedColumns: ColumnDef<TestRow, unknown>[] = [
+      { id: 'name', accessorKey: 'name', header: 'Name', meta: { flex: 'minmax(200px, 1fr)' } },
+      { id: 'metric', header: 'Metric', cell: () => 'm', meta: { sizeCompact: 115, sizeFull: 180 } },
+      { id: 'status', header: 'Status', cell: () => 's', size: 150 },
+    ];
+
+    function gridTemplateOf(container: HTMLElement): string {
+      const grids = container.querySelectorAll('[style*="grid-template-columns"]');
+      expect(grids.length).toBeGreaterThan(0);
+      return (grids[0] as HTMLElement).style.gridTemplateColumns;
+    }
+
+    it('replaces every fixed px track with a proportional one below the breakpoint', () => {
+      const template = withWidth(375, () => {
+        const { container } = render(
+          <DataTable data={testData} columns={sizedColumns} getRowId={(row) => row.id} />,
+        );
+        return gridTemplateOf(container);
+      });
+
+      expect(template).not.toContain('px');
+      expect(template).toBe('minmax(0, 2fr) minmax(0, 1fr) minmax(0, 1fr)');
+    });
+
+    it('keeps the fixed px tracks above the breakpoint', () => {
+      const template = withWidth(1440, () => {
+        const { container } = render(
+          <DataTable data={testData} columns={sizedColumns} getRowId={(row) => row.id} />,
+        );
+        return gridTemplateOf(container);
+      });
+
+      expect(template).toContain('minmax(200px, 1fr)');
+      expect(template).toContain('150px');
+    });
+
+    it('honours an explicit mobileFlex over the derived weight', () => {
+      const columnsWithMobileFlex: ColumnDef<TestRow, unknown>[] = [
+        { id: 'name', accessorKey: 'name', header: 'Name', meta: { flex: 'minmax(200px, 1fr)' } },
+        { id: 'status', header: 'Status', cell: () => 's', size: 150, meta: { mobileFlex: 'minmax(0, 60px)' } },
+      ];
+
+      const template = withWidth(375, () => {
+        const { container } = render(
+          <DataTable data={testData} columns={columnsWithMobileFlex} getRowId={(row) => row.id} />,
+        );
+        return gridTemplateOf(container);
+      });
+
+      expect(template).toBe('minmax(0, 2fr) minmax(0, 60px)');
+    });
+
+    it('clips cells so a long name truncates instead of widening its track', () => {
+      const { container } = withWidth(375, () =>
+        render(
+          <DataTable
+            data={[{ id: '1', name: 'a-very-long-container-name-that-would-widen-the-grid', value: 1 }]}
+            columns={sizedColumns}
+            getRowId={(row) => row.id}
+          />,
+        ),
+      );
+
+      const nameCell = screen.getByText('a-very-long-container-name-that-would-widen-the-grid');
+      expect(nameCell.className).toContain('min-w-0');
+      expect(nameCell.className).toContain('overflow-hidden');
+      expect(container.querySelectorAll('.min-w-0.overflow-hidden').length).toBe(6);
+    });
+
+    it('tightens cell padding below the breakpoint', () => {
+      const { container } = withWidth(375, () =>
+        render(<DataTable data={testData} columns={sizedColumns} getRowId={(row) => row.id} />),
+      );
+
+      expect(container.querySelectorAll('.px-2').length).toBeGreaterThan(0);
+      expect(container.querySelectorAll('.px-3').length).toBe(0);
+    });
+  });
+
+  describe('nested metric group inheritance', () => {
+    function mockNarrowResizeObserver() {
+      const original = globalThis.ResizeObserver;
+      let cb: ResizeObserverCallback | null = null;
+      globalThis.ResizeObserver = class MockResizeObserver {
+        constructor(callback: ResizeObserverCallback) {
+          cb = callback;
+        }
+        observe() {
+          cb?.(
+            [{ contentRect: { width: 375 } } as unknown as ResizeObserverEntry],
+            this as unknown as ResizeObserver,
+          );
+        }
+        unobserve() {}
+        disconnect() {}
+      } as unknown as typeof ResizeObserver;
+      return () => {
+        globalThis.ResizeObserver = original;
+      };
+    }
+
+    const nestedColumns: ColumnDef<TestRow, unknown>[] = [
+      { id: 'name', accessorKey: 'name', header: 'Name', meta: { flex: 'minmax(200px, 1fr)' } },
+      { id: 'cpu', header: 'CPU', cell: () => 'c' },
+      { id: 'netRx', header: 'Net RX', cell: () => 'n' },
+    ];
+
+    const groups = [
+      { label: 'CPU', columnIds: ['cpu'] as [string, ...string[]] },
+      { label: 'Network', columnIds: ['netRx'] as [string, ...string[]] },
+    ];
+
+    it('hides the inactive group in a subtable that declares no groups of its own', () => {
+      const restore = mockNarrowResizeObserver();
+      try {
+        render(
+          <DataTable
+            data={testData.slice(0, 1)}
+            columns={nestedColumns}
+            getRowId={(row) => row.id}
+            metricGroups={groups}
+            renderDetailPanel={() => (
+              <DataTable
+                data={testData.slice(0, 1)}
+                columns={nestedColumns}
+                getRowId={(row) => `sub-${row.id}`}
+                showHeader={false}
+              />
+            )}
+            expandedState={{ '1': true }}
+            onExpandedChange={() => {}}
+          />,
+        );
+
+        expect(screen.getAllByText('c').length).toBe(2);
+        expect(screen.queryAllByText('n').length).toBe(0);
+      } finally {
+        restore();
+      }
+    });
+
+    it('follows the parent toolbar when the active group changes', () => {
+      const restore = mockNarrowResizeObserver();
+      try {
+        render(
+          <DataTable
+            data={testData.slice(0, 1)}
+            columns={nestedColumns}
+            getRowId={(row) => row.id}
+            metricGroups={groups}
+            renderDetailPanel={() => (
+              <DataTable
+                data={testData.slice(0, 1)}
+                columns={nestedColumns}
+                getRowId={(row) => `sub-${row.id}`}
+                showHeader={false}
+              />
+            )}
+            expandedState={{ '1': true }}
+            onExpandedChange={() => {}}
+          />,
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Network' }));
+
+        expect(screen.getAllByText('n').length).toBe(2);
+        expect(screen.queryAllByText('c').length).toBe(0);
+      } finally {
+        restore();
+      }
+    });
+
+    it('leaves a standalone table with no groups fully visible', () => {
+      const restore = mockNarrowResizeObserver();
+      try {
+        render(
+          <DataTable data={testData.slice(0, 1)} columns={nestedColumns} getRowId={(row) => row.id} />,
+        );
+
+        expect(screen.getByText('c')).not.toBeNull();
+        expect(screen.getByText('n')).not.toBeNull();
+      } finally {
+        restore();
+      }
+    });
+  });
 });

--- a/src/components/ui/toggle-group.tsx
+++ b/src/components/ui/toggle-group.tsx
@@ -22,7 +22,7 @@ function ToggleGroupItem({ className, ...props }: Readonly<TogglePrimitive.Props
     <TogglePrimitive
       data-slot="toggle-group-item"
       className={cn(
-        'inline-flex items-center justify-center gap-1 border border-foreground/15 px-2.5 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors outline-none first:rounded-l-lg last:rounded-r-lg not-first:-ml-px hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[pressed]:bg-primary/15 data-[pressed]:text-primary data-[pressed]:border-primary/40 data-[pressed]:z-10',
+        'inline-flex min-h-11 items-center justify-center gap-1 border border-foreground/15 px-3 py-1 text-xs font-medium uppercase tracking-wide text-muted-foreground transition-colors outline-none first:rounded-l-lg last:rounded-r-lg not-first:-ml-px hover:bg-accent focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[pressed]:bg-primary/15 data-[pressed]:text-primary data-[pressed]:border-primary/40 data-[pressed]:z-10 lg:min-h-0 lg:px-2.5',
         className,
       )}
       {...props}


### PR DESCRIPTION
Stacked on #399. Base is `claude/mobile-routes-responsive-v1nd2r`, not `main`.

## What and why

The container table could not fit a phone at any setting. `DataTable` builds its grid from fixed px tracks, so even with the mobile metric-group toggle hiding all but one group the minimum row was `200 (name) + 2x115 (metric) = 430px` against a 375px screen. The toggle that exists to avoid horizontal scrolling could not actually avoid it.

**Shared table (root cause):**
- Below the 1024px container width every track becomes proportional -- `minmax(0, 1fr)`, with the name column weighted 2x. An optional `meta.mobileFlex` lets a column opt out (the ZFS/Proxmox PR uses it for status columns). Above the breakpoint the px tracks are untouched.
- Cells gained `min-w-0 overflow-hidden`. Without them a grid item's automatic minimum size is its content's min-content width, so a long container name widened its track instead of letting the `truncate` inside the cell take effect -- the fluid tracks alone would not have held.
- **Nested rows were a real bug, not just cramped.** `ContainerSubTable` passes no `metricGroups`, and the filter only applied to the table that owns them, so an expanded host rendered 7-column container rows underneath a 2-column header -- columns that did not even line up. The active group now travels through a `MetricGroupContext`, so a subtable declaring no groups of its own follows its parent's toolbar. Caught by the new e2e, not by inspection.

**Docker route:**
- `ContainerModal` is full-bleed below `lg` with the close button pinned to its own row. Its header grid was `1fr auto 1fr` with no `minmax(0, ...)`, so the tracks refused to shrink and the close button could be clipped out of an `overflow-hidden` dialog.
- `IconGrid` derives its column count from the measured container width (clamped 3..7) instead of a hardcoded 7. The count drives both the CSS and the row-chunking arithmetic from one value, so they cannot drift.
- `IconPickerDialog` footer wraps, so Apply stays reachable; the dialog keeps 32px of margin on phones instead of 64px.
- `IconTooltip` and the mount rows open on tap. Both carried text available nowhere else, so on touch it was simply unreachable. Base UI's Tooltip only opens for `mouse`/`pen` pointer types, so the mount row expands inline on touch rather than fighting that.
- Touch sizing: the metric-group toggle (the primary mobile affordance, previously ~26px tall), the detail-panel action strip, and the history page's `px-6` gutters.

## Flow

```
DataTable -> buildGridTemplate(isMobile) -> proportional tracks
          -> MetricGroupContext -> ContainerSubTable column visibility
```

Before, `buildGridTemplate` had no mobile branch and the metric-group filter terminated at the table that owned `metricGroups`. After, the filter reaches nested tables and the tracks adapt.

## What else this touches

- `DataTable` / `columns.tsx` `meta` gains an optional `mobileFlex`. Every consumer (Docker, ZFS, Proxmox) inherits the fluid mobile tracks and the `min-w-0` cells; nothing opts out today.
- `toggle-group.tsx` is shared: `ToggleGroupItem` gains `min-h-11` below `lg`. This also affects the Proxmox interval toggle, the deploy-history filters, and the history timeline presets -- all desirable, none load-bearing.
- A `data-slot="datatable-header"` attribute was added so e2e can scope assertions to the real header row rather than matching chart legend chips.
- No route, loader, SSE channel, settings key, migration, or env var is touched. No data path changes.

## Verification

- `bun run typecheck:all` -- clean.
- `bunx playwright test` -- 29 passed across `app`, `demo`, and the new `mobile` (Pixel 7) project. The mobile Docker specs assert the document does not scroll horizontally, that the table's own scroll container does not either, that the metric toggle is >= 44px tall and actually swaps the header columns, and that a container still opens from a tap.
- Every touched unit test file passes standalone: ContainerModal 14/14, ContainerActionButtons 9/9, IconGrid 11/11, IconPickerDialog 12/12, IconTooltip 7/7, ContainerPortsMounts 20/20, DataTable 29/29 (10 new tests for the mobile tracks and the nested-group inheritance).
- On the full `bun test --isolate` run this container reports 534 failures; unmodified `main` reports 544. The container has Bun 1.3.11 against the pinned 1.3.14 and mocks leak across files despite `--isolate`. Diffed against the `main` baseline, the only names that appear are 6 in `ContainerModal.test.tsx` -- a file that already contributed 8 failures to the baseline full run and passes 14/14 alone, so the whole file fails under drift regardless of this branch. I also made its matchMedia install per-test rather than per-file to remove one ordering dependency. **CI on the pinned Bun is the authority for the coverage gate here.**

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2DmUg6NUpd51qSsKyiG5R)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile and touch layouts across Docker views, including dialogs, action controls, charts, tables, and icon pickers.
  * Prevented horizontal overflow and improved responsive table column sizing.
  * Enhanced touch interactions for tooltips, mount details, tabs, and expandable rows.
  * Improved keyboard accessibility for expandable data table rows.

* **Tests**
  * Added comprehensive coverage for responsive layouts, touch interactions, overflow prevention, tooltips, icon grids, dialogs, and metric selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->