### PR TITLE
feat(mobile): make the Stacks routes usable at phone widths

### DIFF
--- a/e2e/stacks.mobile.e2e.ts
+++ b/e2e/stacks.mobile.e2e.ts
@@ -1,0 +1,65 @@
+import type { Page } from '@playwright/test';
+import { test, expect } from './fixtures';
+
+async function expectNoHorizontalScroll(page: Page, label: string) {
+  const overflow = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  // 1px of slack for sub-pixel rounding on the device scale factor.
+  expect(overflow.scrollWidth, `${label} scrolls horizontally`).toBeLessThanOrEqual(
+    overflow.clientWidth + 1,
+  );
+}
+
+test('the stacks overview fits the viewport', async ({ page }) => {
+  await page.goto('/stacks');
+  await expect(page.getByText('Stacks Overview')).toBeVisible();
+  await expectNoHorizontalScroll(page, '/stacks');
+});
+
+test('a stack detail view fits the viewport on every tab', async ({ page }) => {
+  await page.goto('/stacks/traefik');
+  await expect(page.getByRole('heading', { name: 'traefik' })).toBeVisible();
+  await expectNoHorizontalScroll(page, '/stacks/traefik');
+
+  for (const tab of ['Secrets', 'Containers', 'Deploys']) {
+    await page.getByRole('tab', { name: tab }).click();
+    await expect(page.getByText('Something went wrong')).toHaveCount(0);
+    await expectNoHorizontalScroll(page, `/stacks/traefik (${tab})`);
+  }
+});
+
+test('the last tab is reachable rather than clipped', async ({ page }) => {
+  await page.goto('/stacks/traefik');
+  const deploysTab = page.getByRole('tab', { name: 'Deploys' });
+  await deploysTab.scrollIntoViewIfNeeded();
+  await deploysTab.click();
+  await expect(deploysTab).toHaveAttribute('aria-selected', 'true');
+  await expectNoHorizontalScroll(page, 'the tab bar');
+});
+
+test('deploy stays inline and the destructive actions live in a sheet', async ({ page }) => {
+  await page.goto('/stacks/traefik');
+
+  const deploy = page.getByRole('button', { name: 'Deploy' });
+  await expect(deploy).toBeInViewport();
+  const deployBox = await deploy.boundingBox();
+  const viewport = page.viewportSize();
+  expect(deployBox!.x + deployBox!.width).toBeLessThanOrEqual(viewport!.width);
+  expect(deployBox!.height).toBeGreaterThanOrEqual(44);
+
+  const overflow = page.getByRole('button', { name: 'More stack actions' });
+  await expect(overflow).toBeInViewport();
+  await expect(page.getByRole('button', { name: 'Delete Stack' })).toHaveCount(0);
+
+  await overflow.click();
+  const deleteButton = page.getByRole('button', { name: 'Delete Stack' });
+  await expect(deleteButton).toBeInViewport();
+  const deleteBox = await deleteButton.boundingBox();
+  expect(deleteBox!.x + deleteBox!.width).toBeLessThanOrEqual(viewport!.width);
+  expect(deleteBox!.height).toBeGreaterThanOrEqual(44);
+
+  await expect(page.getByRole('button', { name: 'Teardown' })).toBeInViewport();
+  await expect(page.getByRole('button', { name: 'Update images' })).toBeInViewport();
+});

--- a/src/components/stacks/DeployHistoryRow.tsx
+++ b/src/components/stacks/DeployHistoryRow.tsx
@@ -44,6 +44,8 @@ function getActionLabel(record: StackDeployRecord): string {
 
 const ROLLBACK_ELIGIBLE: Set<DeployStatus> = new Set(['succeeded', 'no_change']);
 
+const ROW_ACTION_CLASS = 'text-xs h-11 px-4 lg:h-6 lg:px-2';
+
 interface DeployHistoryRowProps {
   record: StackDeployRecord;
   stackName?: string;
@@ -86,7 +88,7 @@ export default function DeployHistoryRow({ record, stackName, host, onRollbackCo
           tabIndex={record.logs ? 0 : undefined}
           onClick={() => record.logs && setExpanded(!expanded)}
           onKeyDown={record.logs ? (e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); setExpanded(!expanded); } } : undefined}
-          className={`flex items-center gap-3 px-3 py-2 text-sm ${record.logs ? 'cursor-pointer hover:bg-accent' : ''}`}
+          className={`flex flex-wrap items-center gap-x-3 gap-y-1.5 px-3 py-2 text-sm ${record.logs ? 'cursor-pointer hover:bg-accent' : ''}`}
         >
           {record.logs && (
             <ChevronRight
@@ -119,49 +121,53 @@ export default function DeployHistoryRow({ record, stackName, host, onRollbackCo
             {timestamp.toLocaleDateString()} {timestamp.toLocaleTimeString()}
           </span>
 
-          {showApprovalActions && onApprove !== undefined && (
-            <Button
-              size="sm"
-              className="text-xs h-6 px-2 ml-1"
-              onClick={(e) => {
-                e.stopPropagation();
-                onApprove(record.id);
-              }}
-              onKeyDown={(e) => e.stopPropagation()}
-              disabled={isApproving || isRejecting}
-            >
-              Approve
-            </Button>
-          )}
-          {showApprovalActions && onReject !== undefined && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="text-xs h-6 px-2 ml-1 text-destructive border-destructive/50 hover:border-destructive hover:bg-destructive/5"
-              onClick={(e) => {
-                e.stopPropagation();
-                onReject(record.id);
-              }}
-              onKeyDown={(e) => e.stopPropagation()}
-              disabled={isApproving || isRejecting}
-            >
-              Reject
-            </Button>
-          )}
+          {(showApprovalActions || canRollback) && (
+            <div className="ml-auto flex items-center gap-2 lg:gap-1">
+              {showApprovalActions && onApprove !== undefined && (
+                <Button
+                  size="sm"
+                  className={ROW_ACTION_CLASS}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onApprove(record.id);
+                  }}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  disabled={isApproving || isRejecting}
+                >
+                  Approve
+                </Button>
+              )}
+              {showApprovalActions && onReject !== undefined && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className={`${ROW_ACTION_CLASS} text-destructive border-destructive/50 hover:border-destructive hover:bg-destructive/5`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onReject(record.id);
+                  }}
+                  onKeyDown={(e) => e.stopPropagation()}
+                  disabled={isApproving || isRejecting}
+                >
+                  Reject
+                </Button>
+              )}
 
-          {canRollback && (
-            <Button
-              size="sm"
-              variant="outline"
-              className="text-xs h-6 px-2 ml-1 border-destructive text-destructive hover:bg-destructive/10"
-              onClick={(e) => {
-                e.stopPropagation();
-                setRollbackOpen(true);
-              }}
-              disabled={rollbackMutation.isPending}
-            >
-              Rollback
-            </Button>
+              {canRollback && (
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className={`${ROW_ACTION_CLASS} border-destructive text-destructive hover:bg-destructive/10`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setRollbackOpen(true);
+                  }}
+                  disabled={rollbackMutation.isPending}
+                >
+                  Rollback
+                </Button>
+              )}
+            </div>
           )}
         </div>
 

--- a/src/components/stacks/StackActionBar.tsx
+++ b/src/components/stacks/StackActionBar.tsx
@@ -1,7 +1,22 @@
-import { Play, RefreshCw, Square, Trash2 } from 'lucide-react';
+import { useState } from 'react';
+import { MoreHorizontal, Play, RefreshCw, Square, Trash2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetBody,
+  SheetContent,
+  SheetHeader,
+  SheetTitle,
+} from '@/components/ui/sheet';
 import { Spinner } from '@/components/ui/spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useIsMobile } from '@/hooks/useMediaQuery';
+
+const UPDATE_IMAGES_HINT =
+  'Pulls newer images for every service and recreates containers whose image changed. Also applies any undeployed compose changes.';
+
+const DESTRUCTIVE_CLASSES =
+  'text-destructive border-destructive/50 hover:border-destructive hover:bg-destructive/5';
 
 interface StackActionBarProps {
   onDeploy: () => void;
@@ -18,6 +33,78 @@ export default function StackActionBar({
   onDelete,
   isDeploying,
 }: StackActionBarProps) {
+  const isMobile = useIsMobile();
+  const [sheetOpen, setSheetOpen] = useState(false);
+
+  function runFromSheet(action: () => void) {
+    setSheetOpen(false);
+    action();
+  }
+
+  if (isMobile) {
+    return (
+      <div className="flex items-center gap-2">
+        <Button className="h-11 flex-1" disabled={isDeploying} onClick={onDeploy}>
+          {isDeploying ? <Spinner className="size-4 text-inherit" /> : <Play size={16} />}
+          Deploy
+        </Button>
+
+        <Button
+          variant="outline"
+          size="icon"
+          className="size-11 shrink-0"
+          aria-label="More stack actions"
+          aria-expanded={sheetOpen}
+          onClick={() => setSheetOpen(true)}
+        >
+          <MoreHorizontal size={18} />
+        </Button>
+
+        <Sheet open={sheetOpen} onOpenChange={setSheetOpen}>
+          <SheetContent side="bottom">
+            <SheetHeader>
+              <SheetTitle>Stack actions</SheetTitle>
+            </SheetHeader>
+            <SheetBody className="flex flex-col gap-4 p-4">
+              <div className="flex flex-col gap-1.5">
+                <Button
+                  variant="secondary"
+                  className="h-11 w-full justify-start"
+                  disabled={isDeploying}
+                  onClick={() => runFromSheet(onUpdate)}
+                >
+                  <RefreshCw size={16} />
+                  Update images
+                </Button>
+                <p className="text-xs text-muted-foreground">{UPDATE_IMAGES_HINT}</p>
+              </div>
+
+              <Button
+                variant="outline"
+                className={`h-11 w-full justify-start ${DESTRUCTIVE_CLASSES}`}
+                disabled={isDeploying}
+                onClick={() => runFromSheet(onTeardown)}
+              >
+                <Square size={16} />
+                Teardown
+              </Button>
+
+              <Button
+                variant="outline"
+                className={`h-11 w-full justify-start ${DESTRUCTIVE_CLASSES}`}
+                disabled={isDeploying}
+                onClick={() => runFromSheet(onDelete)}
+              >
+                <Trash2 size={16} />
+                Delete Stack
+              </Button>
+            </SheetBody>
+          </SheetContent>
+        </Sheet>
+      </div>
+    );
+  }
+
   return (
     <div className="flex items-center gap-2">
       <Button size="sm" disabled={isDeploying} onClick={onDeploy}>
@@ -39,10 +126,7 @@ export default function StackActionBar({
           <RefreshCw size={14} />
           Update images
         </TooltipTrigger>
-        <TooltipContent className="max-w-xs">
-          Pulls newer images for every service and recreates containers whose image changed.
-          Also applies any undeployed compose changes.
-        </TooltipContent>
+        <TooltipContent className="max-w-xs">{UPDATE_IMAGES_HINT}</TooltipContent>
       </Tooltip>
 
       <Button
@@ -50,7 +134,7 @@ export default function StackActionBar({
         size="sm"
         disabled={isDeploying}
         onClick={onTeardown}
-        className="text-destructive border-destructive/50 hover:border-destructive hover:bg-destructive/5"
+        className={DESTRUCTIVE_CLASSES}
       >
         <Square size={14} />
         Teardown
@@ -62,7 +146,7 @@ export default function StackActionBar({
           size="sm"
           disabled={isDeploying}
           onClick={onDelete}
-          className="text-destructive border-destructive/50 hover:border-destructive hover:bg-destructive/5"
+          className={DESTRUCTIVE_CLASSES}
         >
           <Trash2 size={14} />
           Delete Stack

--- a/src/components/stacks/StackContainersPanel.tsx
+++ b/src/components/stacks/StackContainersPanel.tsx
@@ -15,6 +15,7 @@ import ContainerTerminal from '@/components/docker/ContainerTerminal';
 import ShellSelect from '@/components/docker/ShellSelect';
 import UnsavedChangesDialog from '@/components/stacks/UnsavedChangesDialog';
 import { useDockerSettings } from '@/hooks/useDockerSettings';
+import { useIsMobile } from '@/hooks/useMediaQuery';
 
 interface StackContainersPanelProps {
   containers: StackContainer[];
@@ -37,6 +38,7 @@ export default function StackContainersPanel({ containers, stackName, host, onRe
   const [modalState, setModalState] = useState<{ container: StackContainer; view: ModalView } | null>(null);
   const [activeKey, setActiveKey] = useState<ActiveKey | null>(null);
   const [recreateConfirmOpen, setRecreateConfirmOpen] = useState(false);
+  const isMobile = useIsMobile();
 
   const controlMutation = useMutation({
     mutationFn: ({ action, target }: { action: ControlAction; target: ControlTarget }) => {
@@ -66,11 +68,12 @@ export default function StackContainersPanel({ containers, stackName, host, onRe
 
   return (
     <div className="flex flex-col gap-4 py-4">
-      <div className="flex items-center gap-2">
+      <div className="flex flex-wrap items-center gap-2">
         <span className="text-xs opacity-50 mr-1">Stack</span>
         <Button
           size="sm"
           variant="outline"
+          className={STACK_CONTROL_CLASS}
           disabled={controlMutation.isPending || isDeploying || containers.length === 0}
           onClick={() => trigger('start', { scope: 'stack' })}
           aria-label="Start"
@@ -81,6 +84,7 @@ export default function StackContainersPanel({ containers, stackName, host, onRe
         <Button
           size="sm"
           variant="outline"
+          className={STACK_CONTROL_CLASS}
           disabled={controlMutation.isPending || isDeploying || containers.length === 0}
           onClick={() => trigger('stop', { scope: 'stack' })}
           aria-label="Stop"
@@ -91,6 +95,7 @@ export default function StackContainersPanel({ containers, stackName, host, onRe
         <Button
           size="sm"
           variant="outline"
+          className={STACK_CONTROL_CLASS}
           disabled={controlMutation.isPending || isDeploying || containers.length === 0}
           onClick={() => trigger('restart', { scope: 'stack' })}
           aria-label="Restart"
@@ -101,6 +106,7 @@ export default function StackContainersPanel({ containers, stackName, host, onRe
         <Button
           size="sm"
           variant="outline"
+          className={STACK_CONTROL_CLASS}
           disabled={controlMutation.isPending || isDeploying}
           onClick={() => setRecreateConfirmOpen(true)}
           aria-label="Recreate"
@@ -119,7 +125,7 @@ export default function StackContainersPanel({ containers, stackName, host, onRe
           {containers.map((container) => (
             <div
               key={container.id}
-              className="flex items-center gap-2 py-1.5 px-2 rounded hover:bg-(--accent) group"
+              className="flex flex-wrap items-center gap-x-2 gap-y-1 py-1.5 px-2 rounded hover:bg-(--accent) group"
             >
               <span
                 className={`w-2 h-2 rounded-full flex-shrink-0 ${container.status === 'running' ? 'bg-green-500' : 'bg-red-500'}`}
@@ -145,16 +151,16 @@ export default function StackContainersPanel({ containers, stackName, host, onRe
       )}
 
       <Dialog open={modalState !== null} onOpenChange={(o) => { if (!o) setModalState(null); }}>
-        <DialogContent className="w-[calc(100%-64px)] max-w-[1200px] h-[70vh] flex flex-col min-h-0 p-2">
+        <DialogContent className="w-[calc(100%-16px)] max-w-[1200px] max-h-none h-[calc(100dvh-16px)] lg:w-[calc(100%-64px)] lg:max-h-[calc(100%-64px)] lg:h-[70vh] flex flex-col min-h-0 p-2">
           <DialogTitle className="flex items-center justify-between px-1 py-2 text-sm font-medium">
-            <span>{modalState?.container.name}</span>
-            <Button variant="ghost" size="icon-sm" onClick={() => setModalState(null)} aria-label="Close">
+            <span className="truncate">{modalState?.container.name}</span>
+            <Button variant="ghost" size="icon-sm" className="size-11 shrink-0 lg:size-8" onClick={() => setModalState(null)} aria-label="Close">
               <X size={16} />
             </Button>
           </DialogTitle>
           <div className="flex flex-col min-h-0 flex-1">
             {modalState?.view === 'logs' && (
-              <ContainerLogViewer containerId={modalState.container.id} host={host} wordWrap={false} />
+              <ContainerLogViewer containerId={modalState.container.id} host={host} wordWrap={isMobile} />
             )}
             {modalState?.view === 'terminal' && (
               <TerminalDialogContent container={modalState.container} host={host} />
@@ -186,6 +192,9 @@ const ACTION_PAST: Record<ControlAction, string> = {
 };
 
 const MAX_VISIBLE_PORT_CHIPS = 4;
+
+const STACK_CONTROL_CLASS = 'h-11 lg:h-8';
+const SERVICE_CONTROL_CLASS = 'size-11 lg:size-8';
 
 function portKey(port: ContainerPort, idx: number): string {
   return `${port.containerPort}/${port.protocol}/${port.hostIp ?? ''}/${port.hostPort ?? ''}/${idx}`;
@@ -282,13 +291,14 @@ function ServiceControls({
 }) {
   return (
     <TooltipProvider>
-      <div className="ml-auto flex items-center gap-0.5">
+      <div className="ml-auto flex items-center gap-1 lg:gap-0.5">
         <Tooltip>
           <TooltipTrigger
             render={
               <Button
                 variant="ghost"
                 size="icon-sm"
+                className={SERVICE_CONTROL_CLASS}
                 disabled={isPending}
                 onClick={() => trigger('start', { scope: 'service', service })}
                 aria-label={`Start ${service}`}
@@ -305,6 +315,7 @@ function ServiceControls({
               <Button
                 variant="ghost"
                 size="icon-sm"
+                className={SERVICE_CONTROL_CLASS}
                 disabled={isPending}
                 onClick={() => trigger('stop', { scope: 'service', service })}
                 aria-label={`Stop ${service}`}
@@ -321,6 +332,7 @@ function ServiceControls({
               <Button
                 variant="ghost"
                 size="icon-sm"
+                className={SERVICE_CONTROL_CLASS}
                 disabled={isPending}
                 onClick={() => trigger('restart', { scope: 'service', service })}
                 aria-label={`Restart ${service}`}
@@ -333,7 +345,7 @@ function ServiceControls({
         </Tooltip>
         <Tooltip>
           <TooltipTrigger
-            render={<Button variant="ghost" size="icon-sm" onClick={onOpenLogs} aria-label="Logs" />}
+            render={<Button variant="ghost" size="icon-sm" className={SERVICE_CONTROL_CLASS} onClick={onOpenLogs} aria-label="Logs" />}
           >
             <ScrollText size={13} />
           </TooltipTrigger>
@@ -341,7 +353,7 @@ function ServiceControls({
         </Tooltip>
         <Tooltip>
           <TooltipTrigger
-            render={<Button variant="ghost" size="icon-sm" onClick={onOpenTerminal} aria-label="Terminal" />}
+            render={<Button variant="ghost" size="icon-sm" className={SERVICE_CONTROL_CLASS} onClick={onOpenTerminal} aria-label="Terminal" />}
           >
             <Terminal size={13} />
           </TooltipTrigger>
@@ -354,6 +366,7 @@ function ServiceControls({
 
 function TerminalDialogContent({ container, host }: { container: StackContainer; host: string }) {
   const { getContainerShell, setContainerShell } = useDockerSettings();
+  const isMobile = useIsMobile();
   const [resolvedShell, setResolvedShell] = useState<string | undefined>(undefined);
   const shellKey = `${host}/${container.name}`;
   const savedShell = getContainerShell(shellKey);
@@ -383,7 +396,7 @@ function TerminalDialogContent({ container, host }: { container: StackContainer;
           host={host}
           shell={effectiveShell}
           frozen={frozen}
-          wordWrap={false}
+          wordWrap={isMobile}
           onShellResolved={handleShellResolved}
         />
       </div>

--- a/src/components/stacks/StackEditorForm.tsx
+++ b/src/components/stacks/StackEditorForm.tsx
@@ -20,6 +20,7 @@ import {
   rejectDeploy,
   scanDrift,
 } from '@/data/stacks/functions'
+import HorizontalScrollRow from '@/components/shared/HorizontalScrollRow'
 import ComposeEditorLoader from '@/components/stacks/ComposeEditorLoader'
 import VariablesPanel from '@/components/stacks/VariablesPanel'
 import DeployHistoryList from '@/components/stacks/DeployHistoryList'
@@ -34,6 +35,8 @@ import type { StackDetail } from '@/types/stacks'
 import type { StackFormValues } from '@/components/stacks/stack-form'
 
 type Panel = 'compose' | 'secrets' | 'containers' | 'deploys'
+
+const TAB_TRIGGER_CLASS = 'py-3 lg:py-2'
 
 type ConfirmableDeployAction = { action: 'deploy' | 'update'; forceRecreate?: boolean }
 type DeployMutationParams = { action: 'deploy' | 'teardown' | 'update'; forceRecreate?: boolean }
@@ -313,9 +316,9 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
     <FormProvider {...form}>
       <div className="flex flex-col h-full">
         {/* Header */}
-        <div className="flex items-center justify-between pb-3">
-          <div className="flex items-center gap-3">
-            <h2 className="text-xl">{stackName}</h2>
+        <div className="flex items-start justify-between gap-2 pb-3">
+          <div className="flex flex-wrap items-baseline gap-x-3 gap-y-0.5 min-w-0">
+            <h2 className="text-xl truncate max-w-full">{stackName}</h2>
             <span className="text-xs opacity-50">{detail.host}</span>
             <span className="text-xs opacity-50">&middot;</span>
             <span className="text-xs opacity-50">
@@ -328,7 +331,7 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
                 <Button
                   variant="ghost"
                   size="icon-sm"
-                  className="text-foreground"
+                  className="text-foreground shrink-0 size-11 lg:size-8"
                   onClick={() => setSettingsDialogOpen(true)}
                   aria-label="stack settings"
                 />
@@ -347,19 +350,25 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
         )}
 
         {/* Tab bar */}
-        <div className="flex items-center gap-3 border-b border-border">
-          <Tabs value={panel} onValueChange={(value) => setPanel(value as Panel)}>
-            <TabsList>
-              <TabsTrigger value="compose" className="py-2">
-                Compose{composeDirty && <TabDirtyDot />}
-              </TabsTrigger>
-              <TabsTrigger value="secrets" className="py-2">
-                Secrets{secretsDirty && <TabDirtyDot />}
-              </TabsTrigger>
-              <TabsTrigger value="containers" className="py-2">Containers</TabsTrigger>
-              <TabsTrigger value="deploys" className="py-2">Deploys</TabsTrigger>
-            </TabsList>
-          </Tabs>
+        <div className="border-b border-border">
+          <HorizontalScrollRow
+            bgVar="--background"
+            innerClassName="flex flex-nowrap min-w-max"
+            scrollClassName="flex flex-nowrap overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+          >
+            <Tabs value={panel} onValueChange={(value) => setPanel(value as Panel)}>
+              <TabsList>
+                <TabsTrigger value="compose" className={TAB_TRIGGER_CLASS}>
+                  Compose{composeDirty && <TabDirtyDot />}
+                </TabsTrigger>
+                <TabsTrigger value="secrets" className={TAB_TRIGGER_CLASS}>
+                  Secrets{secretsDirty && <TabDirtyDot />}
+                </TabsTrigger>
+                <TabsTrigger value="containers" className={TAB_TRIGGER_CLASS}>Containers</TabsTrigger>
+                <TabsTrigger value="deploys" className={TAB_TRIGGER_CLASS}>Deploys</TabsTrigger>
+              </TabsList>
+            </Tabs>
+          </HorizontalScrollRow>
         </div>
 
         {/* Tab content, scrollable */}

--- a/src/components/stacks/VariableRow.tsx
+++ b/src/components/stacks/VariableRow.tsx
@@ -11,7 +11,6 @@ import {
   DialogFooter,
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Trash2 } from 'lucide-react';
 import { useMutation } from '@tanstack/react-query';
 import { deleteVariable } from '@/data/stacks/functions';
@@ -51,39 +50,39 @@ export default function VariableRow({ stackName, varName, isReferenced, revealed
 
   return (
     <>
-      <div className="flex items-center gap-2">
-        <code className="text-xs font-mono min-w-[100px] opacity-80 truncate">
-          {varName}
-        </code>
-        <div className="relative flex-1 min-w-0">
-          <Input
-            type={revealed ? 'text' : 'password'}
-            autoComplete="off"
-            placeholder="No value set"
-            className="h-9 pr-10 text-xs"
-            aria-label={`${varName} value`}
-            {...register(secretFieldName(varName))}
-          />
-          <div className="absolute inset-y-0 right-1 flex items-center">
-            <Tooltip disabled={!isReferenced}>
-              <TooltipTrigger
-                render={
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    className="text-foreground"
-                    onClick={() => { setDeleteError(null); setDeleteOpen(true); }}
-                    aria-label="Delete variable"
-                    disabled={isReferenced || deleteMutation.isPending}
-                  />
-                }
+      <div className="flex flex-col gap-0.5">
+        <div className="flex items-center gap-2">
+          <code className="text-xs font-mono min-w-[100px] opacity-80 truncate">
+            {varName}
+          </code>
+          <div className="relative flex-1 min-w-0">
+            <Input
+              type={revealed ? 'text' : 'password'}
+              autoComplete="off"
+              placeholder="No value set"
+              className="h-11 pr-12 text-xs lg:h-9 lg:pr-10"
+              aria-label={`${varName} value`}
+              {...register(secretFieldName(varName))}
+            />
+            <div className="absolute inset-y-0 right-1 flex items-center">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="text-foreground size-9 lg:size-8"
+                onClick={() => { setDeleteError(null); setDeleteOpen(true); }}
+                aria-label="Delete variable"
+                disabled={isReferenced || deleteMutation.isPending}
               >
                 <Trash2 size={14} />
-              </TooltipTrigger>
-              <TooltipContent>Variable still referenced in compose file</TooltipContent>
-            </Tooltip>
+              </Button>
+            </div>
           </div>
         </div>
+        {isReferenced && (
+          <p className="text-[11px] text-muted-foreground">
+            Still referenced in the compose file, so it cannot be deleted.
+          </p>
+        )}
       </div>
 
       <Dialog open={deleteOpen} onOpenChange={(isOpen) => { if (!isOpen) setDeleteOpen(false); }}>

--- a/src/components/stacks/__tests__/DeployHistoryList.test.tsx
+++ b/src/components/stacks/__tests__/DeployHistoryList.test.tsx
@@ -471,4 +471,68 @@ describe('DeployHistoryList', () => {
     });
   });
 
+  describe('narrow-viewport layout', () => {
+    const awaitingApproval: StackDeployRecord = {
+      id: 78,
+      stack: 'plex',
+      host: 'homeserver',
+      commitSha: 'pending98765',
+      envHash: 'envhash',
+      status: 'pending',
+      trigger: 'git_push',
+      action: 'deploy',
+      forceRecreate: false,
+      logs: null,
+      createdAt: new Date().toISOString(),
+    };
+
+    it('wraps the row instead of pushing the actions off-screen', () => {
+      render(
+        <DeployHistoryList records={mockRecords} isLoading={false} stackName="plex" host="homeserver" />,
+        { wrapper: createWrapper() },
+      );
+      const row = screen.getByText('Rollback').closest('.flex-wrap');
+      expect(row).not.toBeNull();
+      expect(row?.textContent).toContain('a1b2c3d');
+    });
+
+    it('groups the row actions so they stay right-aligned on their own line', () => {
+      render(
+        <DeployHistoryList records={mockRecords} isLoading={false} stackName="plex" host="homeserver" />,
+        { wrapper: createWrapper() },
+      );
+      const group = screen.getByText('Rollback').closest('button')?.parentElement;
+      expect(group?.className).toContain('ml-auto');
+    });
+
+    it('gives the row actions a touch height below lg', () => {
+      const onApprove = mock(() => {});
+      const onReject = mock(() => {});
+      render(
+        <DeployHistoryList
+          records={[awaitingApproval]}
+          isLoading={false}
+          stackName="plex"
+          host="homeserver"
+          onApprove={onApprove}
+          onReject={onReject}
+        />,
+        { wrapper: createWrapper() },
+      );
+      for (const label of ['Approve', 'Reject']) {
+        const button = screen.getByText(label).closest('button');
+        expect(button?.className).toContain('h-11');
+        expect(button?.className).toContain('lg:h-6');
+      }
+    });
+
+    it('renders no action group at all when a row has neither approval nor rollback', () => {
+      render(<DeployHistoryList records={[mockRecords[1]]} isLoading={false} />, {
+        wrapper: createWrapper(),
+      });
+      expect(screen.queryByText('Rollback')).toBeNull();
+      expect(screen.queryByText('Approve')).toBeNull();
+    });
+  });
+
 });

--- a/src/components/stacks/__tests__/StackActionBar.mobile.test.tsx
+++ b/src/components/stacks/__tests__/StackActionBar.mobile.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MOBILE_BREAKPOINT } from '@/lib/constants/breakpoints';
+import StackActionBar from '../StackActionBar';
+
+const originalMatchMedia = window.matchMedia;
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query === `(max-width: ${MOBILE_BREAKPOINT - 1}px)`,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+function renderBar(overrides: Partial<Parameters<typeof StackActionBar>[0]> = {}) {
+  const props = {
+    onDeploy: mock(() => {}),
+    onUpdate: mock(() => {}),
+    onTeardown: mock(() => {}),
+    onDelete: mock(() => {}),
+    isDeploying: false,
+    ...overrides,
+  };
+  render(<StackActionBar {...props} />);
+  return props;
+}
+
+function openSheet() {
+  fireEvent.click(screen.getByRole('button', { name: 'More stack actions' }));
+}
+
+describe('StackActionBar below the lg breakpoint', () => {
+  it('keeps Deploy inline and moves the remaining actions behind an overflow trigger', () => {
+    renderBar();
+    expect(screen.getByRole('button', { name: /deploy/i })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'More stack actions' })).toBeDefined();
+    expect(screen.queryByText('Delete Stack')).toBeNull();
+    expect(screen.queryByText('Teardown')).toBeNull();
+    expect(screen.queryByText('Update images')).toBeNull();
+  });
+
+  it('exposes the three overflow actions once the sheet is opened', () => {
+    renderBar();
+    openSheet();
+    expect(screen.getByText('Update images')).toBeDefined();
+    expect(screen.getByText('Teardown')).toBeDefined();
+    expect(screen.getByText('Delete Stack')).toBeDefined();
+  });
+
+  it('states the update-images behavior inline, since a tooltip never opens on touch', () => {
+    renderBar();
+    openSheet();
+    expect(screen.getByText(/pulls newer images for every service/i)).toBeDefined();
+  });
+
+  it('fires onDelete and closes the sheet when Delete Stack is tapped', () => {
+    const { onDelete } = renderBar();
+    openSheet();
+    fireEvent.click(screen.getByText('Delete Stack'));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Teardown')).toBeNull();
+  });
+
+  it('fires onTeardown when Teardown is tapped', () => {
+    const { onTeardown } = renderBar();
+    openSheet();
+    fireEvent.click(screen.getByText('Teardown'));
+    expect(onTeardown).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onUpdate when Update images is tapped', () => {
+    const { onUpdate } = renderBar();
+    openSheet();
+    fireEvent.click(screen.getByText('Update images'));
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onDeploy from the inline Deploy button', () => {
+    const { onDeploy } = renderBar();
+    fireEvent.click(screen.getByRole('button', { name: /deploy/i }));
+    expect(onDeploy).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the inline Deploy button and every sheet action while deploying', () => {
+    renderBar({ isDeploying: true });
+    expect(screen.getByRole('button', { name: /deploy/i })).toHaveProperty('disabled', true);
+    openSheet();
+    for (const label of ['Update images', 'Teardown', 'Delete Stack']) {
+      expect(screen.getByText(label).closest('button')).toHaveProperty('disabled', true);
+    }
+  });
+
+  it('gives the inline controls a 44px touch height', () => {
+    renderBar();
+    expect(screen.getByRole('button', { name: /deploy/i }).className).toContain('h-11');
+    expect(screen.getByRole('button', { name: 'More stack actions' }).className).toContain('size-11');
+  });
+});

--- a/src/components/stacks/__tests__/StackContainersPanel.mobile.test.tsx
+++ b/src/components/stacks/__tests__/StackContainersPanel.mobile.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement, ReactNode } from 'react';
+import type { StackContainer } from '@/types/stacks';
+import { MOBILE_BREAKPOINT } from '@/lib/constants/breakpoints';
+
+mock.module('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipTrigger: ({ render: el }: { render: ReactElement }) => el,
+  TooltipContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  TooltipProvider: ({ children }: { children: ReactNode }) => children,
+}));
+
+mock.module('sonner', () => ({
+  toast: { success: () => {}, error: () => {} },
+}));
+
+mock.module('@/data/stacks/functions', () => ({
+  controlStack: mock(async () => {}),
+}));
+
+mock.module('@/components/docker/ContainerLogViewer', () => ({
+  default: ({ wordWrap }: { wordWrap: boolean }) => (
+    <div data-testid="log-viewer" data-wordwrap={String(wordWrap)} />
+  ),
+}));
+
+mock.module('@/components/docker/ContainerTerminal', () => ({
+  default: ({ wordWrap }: { wordWrap: boolean }) => (
+    <div data-testid="terminal-viewer" data-wordwrap={String(wordWrap)} />
+  ),
+}));
+
+mock.module('@/hooks/useDockerSettings', () => ({
+  useDockerSettings: () => ({
+    getContainerShell: () => undefined,
+    setContainerShell: () => {},
+  }),
+}));
+
+mock.module('@/lib/constants/demo', () => ({ IS_DEMO_MODE: false }));
+
+const { default: StackContainersPanel } = await import('@/components/stacks/StackContainersPanel');
+
+const containers: StackContainer[] = [
+  { id: 'abc123', name: 'plex-web-1', status: 'running', image: 'plexinc/pms-docker', service: 'web', ports: [], mounts: [] },
+];
+
+const originalMatchMedia = window.matchMedia;
+
+beforeEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: query === `(max-width: ${MOBILE_BREAKPOINT - 1}px)`,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+function renderPanel() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <StackContainersPanel
+        containers={containers}
+        stackName="plex"
+        host="server1"
+        onRecreate={() => {}}
+        isDeploying={false}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('StackContainersPanel below the lg breakpoint', () => {
+  it('wraps log output instead of scrolling it sideways in a phone-width dialog', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Logs' }));
+    expect(screen.getByTestId('log-viewer').getAttribute('data-wordwrap')).toBe('true');
+  });
+
+  it('wraps terminal output too', () => {
+    renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Terminal' }));
+    expect(screen.getByTestId('terminal-viewer').getAttribute('data-wordwrap')).toBe('true');
+  });
+
+  it('lets the log dialog fill the viewport', () => {
+    const { baseElement } = renderPanel();
+    fireEvent.click(screen.getByRole('button', { name: 'Logs' }));
+    const popup = baseElement.querySelector('[data-slot="dialog-content"]');
+    expect(popup?.className).toContain('h-[calc(100dvh-16px)]');
+    expect(popup?.className).toContain('lg:h-[70vh]');
+  });
+});

--- a/src/components/stacks/__tests__/StackContainersPanel.test.tsx
+++ b/src/components/stacks/__tests__/StackContainersPanel.test.tsx
@@ -410,4 +410,26 @@ describe('StackContainersPanel', () => {
     renderPanel();
     expect(screen.queryByLabelText(/mounts/i)).toBeNull();
   });
+
+  it('lets the stack control row wrap and gives each button a touch height below lg', () => {
+    renderPanel();
+    const startButton = screen.getByRole('button', { name: 'Start' });
+    expect(startButton.parentElement?.className).toContain('flex-wrap');
+    expect(startButton.className).toContain('h-11');
+    expect(startButton.className).toContain('lg:h-8');
+  });
+
+  it('lets a container row wrap its actions onto a second line', () => {
+    renderPanel();
+    const row = screen.getByRole('button', { name: 'Start web' }).closest('.flex-wrap');
+    expect(row).not.toBeNull();
+    expect(row?.textContent).toContain('plex-web-1');
+  });
+
+  it('sizes the per-service icon buttons for touch below lg', () => {
+    renderPanel();
+    const serviceStart = screen.getByRole('button', { name: 'Start web' });
+    expect(serviceStart.className).toContain('size-11');
+    expect(serviceStart.className).toContain('lg:size-8');
+  });
 });

--- a/src/components/stacks/__tests__/StackEditorForm.test.tsx
+++ b/src/components/stacks/__tests__/StackEditorForm.test.tsx
@@ -496,4 +496,28 @@ describe('StackEditorForm', () => {
     await waitFor(() => expect(mockDeleteStack).toHaveBeenCalledTimes(1));
     expect(mockShowToast).not.toHaveBeenCalled();
   });
+
+  describe('narrow-viewport layout', () => {
+    it('puts the tab bar in a horizontal scroller so it cannot widen the page', async () => {
+      await renderForm();
+      const composeTab = await screen.findByRole('tab', { name: /compose/i });
+      expect(composeTab.closest('.overflow-x-auto')).not.toBeNull();
+    });
+
+    it('keeps every tab on one line at a touch height', async () => {
+      await renderForm();
+      const composeTab = await screen.findByRole('tab', { name: /compose/i });
+      expect(composeTab.className).toContain('whitespace-nowrap');
+      expect(composeTab.className).toContain('shrink-0');
+      expect(composeTab.className).toContain('py-3');
+      expect(composeTab.className).toContain('lg:py-2');
+    });
+
+    it('truncates the stack name so the settings control stays on screen', async () => {
+      await renderForm();
+      const heading = await screen.findByRole('heading', { name: 'web' });
+      expect(heading.className).toContain('truncate');
+      expect(screen.getByRole('button', { name: 'stack settings' }).className).toContain('shrink-0');
+    });
+  });
 });

--- a/src/components/stacks/__tests__/VariablesPanel.test.tsx
+++ b/src/components/stacks/__tests__/VariablesPanel.test.tsx
@@ -196,22 +196,24 @@ describe('VariablesPanel', () => {
     await waitFor(() => expect(mockShowToast).toHaveBeenCalledWith('Secrets saved', 'success'));
   });
 
-  it('delete button is disabled with tooltip when variable is referenced in compose', async () => {
+  it('disables delete and states the reason inline when the variable is referenced in compose', async () => {
     mockGetValues.mockImplementation(() => Promise.resolve({ DB_URL: '' }));
     await renderPanel('mystack', ['DB_URL']);
     await waitFor(() => expect(screen.getByText('DB_URL')).toBeDefined());
 
     const deleteBtn = screen.getByLabelText('Delete variable');
     expect((deleteBtn as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText(/still referenced in the compose file/i)).toBeDefined();
   });
 
-  it('delete button is enabled when variable is not referenced in compose', async () => {
+  it('enables delete and shows no reason when the variable is not referenced in compose', async () => {
     mockGetValues.mockImplementation(() => Promise.resolve({ ORPHAN_VAR: '' }));
     await renderPanel('mystack', []);
     await waitFor(() => expect(screen.getByText('ORPHAN_VAR')).toBeDefined());
 
     const deleteBtn = screen.getByLabelText('Delete variable');
     expect((deleteBtn as HTMLButtonElement).disabled).toBe(false);
+    expect(screen.queryByText(/still referenced in the compose file/i)).toBeNull();
   });
 
   it('opens delete confirmation dialog when delete is clicked', async () => {

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ function TabsTrigger({ className, ...props }: ComponentProps<typeof TabsPrimitiv
     <TabsPrimitive.Tab
       data-slot="tabs-trigger"
       className={cn(
-        'inline-flex items-center justify-center px-4 py-3 text-sm font-medium tracking-[0.02857em] text-muted-foreground transition-colors outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[selected]:text-primary',
+        'inline-flex shrink-0 items-center justify-center whitespace-nowrap px-4 py-3 text-sm font-medium tracking-[0.02857em] text-muted-foreground transition-colors outline-none hover:text-foreground focus-visible:ring-2 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[selected]:text-primary',
         className,
       )}
       {...props}

--- a/src/routes/stacks.tsx
+++ b/src/routes/stacks.tsx
@@ -60,7 +60,7 @@ function StacksLayout() {
   return (
     <StackListContext value={{ stacks: stacks ?? [], hosts: hosts ?? [], isLoading }}>
       <StackStatusContext value={{ statusMap, deployVersion }}>
-        <div className="flex-1 min-h-0 flex flex-col p-6">
+        <div className="flex-1 min-h-0 flex flex-col p-3 lg:p-6">
           <Outlet />
         </div>
       </StackStatusContext>


### PR DESCRIPTION
Stacked on #399. Base is `claude/mobile-routes-responsive-v1nd2r`, not `main`. Independent of #400 (no file overlap).

## What and why

Five rows on this route packed labelled controls into a single nowrap flex line. At 375px the last item in each was clipped, with no scroll affordance and nothing upstream setting `overflow-x-hidden`, so they could also drive page-wide horizontal scroll. The two that actually lost function were `StackActionBar` (Delete Stack could vanish entirely) and `DeployHistoryRow` (overflowed whenever a row carried both badges and action buttons).

**`StackActionBar` is the one place that branches on viewport rather than reflowing.** Four labelled lifecycle buttons cannot fit a phone at any sensible size, and shrinking them to icons would leave Teardown and Delete Stack as unlabelled destructive actions. Below `lg`: Deploy stays inline as the primary, and Update images / Teardown / Delete Stack move into a bottom `Sheet` as full-width 44px rows. Its desktop tooltip copy is shared with the sheet's inline hint via one constant, since a Base UI tooltip never opens on touch and the text would otherwise be lost. Putting the destructive pair one deliberate tap away is also a smaller mis-tap surface than a cramped row.

**Everything else reflows, no JS branch:**
- The stack tab bar goes through `HorizontalScrollRow`, the existing edge-fade + nudge-chevron component already used by the history timeline and metrics chart. It wraps `TabsList` rather than putting an overflow rule on it, so the Base UI selection indicator can still measure `--active-tab-width`/`--active-tab-left`. `TabsTrigger` gained `shrink-0 whitespace-nowrap` in the primitive.
- Container rows, the stack control row, and deploy history rows wrap, with their action clusters dropping to a right-aligned second line.
- `StackEditorForm`'s header truncates the stack name so it can't push the settings gear off-screen.
- Route padding `p-6` -> `p-3 lg:p-6`.

**Touch sizing uses real dimensions, not `.tap-target` overlays.** The five service controls sit 2px apart and deploy history rows 4px apart; an expanded 44px overlay there would reach into the neighbouring control (or the next row's Rollback) and swallow its taps. Those got `size-11 lg:size-8` instead. The overlay utility is only appropriate where there is real clearance.

**Two information-loss fixes:** `VariableRow`'s delete-disabled reason moves from a hover tooltip to an inline line (unconditional -- one behavior, and it replaces rather than duplicates the tooltip), and the log/terminal dialog is full-bleed below `lg` with word wrap on, since xterm at ~400px without wrapping is unreadable.

## Flow

```
StackEditorForm -> HorizontalScrollRow -> TabsList (indicator still measures itself)
StackActionBar  -> useIsMobile -> Deploy inline + Sheet(Update/Teardown/Delete)
```

Above `lg` both paths render what they rendered before.

## What else this touches

- `src/components/ui/tabs.tsx` is shared: `TabsTrigger` gains `shrink-0 whitespace-nowrap`. Other consumers are the app header and `ContainerLogsTerminalPanel`; both re-verified green.
- No route loader, SSE channel, settings key, migration, or env var. The deploy/teardown/delete handlers are passed through untouched -- only where their buttons live changed.
- Deliberately **not** changed: `ComposeEditor`. Monaco is already width-responsive (`automaticLayout`, minimap off) and the audit found no defect there. A read-only mobile view, a plain-textarea swap, or a tap-to-edit gate are all product decisions that would drop YAML validation or folding, so they belong in a follow-up rather than here. Monaco's own touch handling (selection handles, no autocomplete accessory) is the real gap.

## Verification

- `bun run typecheck` -- clean.
- `bunx playwright test` -- 29 passed across `app`, `demo`, and `mobile` (Pixel 7). The 4 new mobile stacks specs assert the overview and every detail tab fit the viewport, that the last tab is reachable rather than clipped, and that Deploy stays inline while the destructive actions live in the sheet.
- Per-file unit tests, all green standalone: StackActionBar 9, StackActionBar.mobile 9, StackContainersPanel 32, StackContainersPanel.mobile 3, DeployHistoryList 28, StackEditorForm 35, StackEditorForm-deploy-guard 4, VariablesPanel 20, plus the shared-primitive consumers Header 8 / Header.mobile 3 / ContainerLogsTerminalPanel 10.
- The full `bun test --isolate` run is not a usable signal in this container (~530 failures on unmodified `main` too; Bun 1.3.11 vs the pinned 1.3.14 leaks module mocks across files). Per-file green is the standard used here; CI on the pinned Bun is the authority for the coverage gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2DmUg6NUpd51qSsKyiG5R)_