### PR TITLE
feat(mobile): make the Settings route usable at phone widths

### DIFF
--- a/e2e/settings.mobile.e2e.ts
+++ b/e2e/settings.mobile.e2e.ts
@@ -1,0 +1,55 @@
+import { test, expect, overrideServerFn } from './fixtures';
+
+test('the settings page does not scroll the document horizontally', async ({ page }) => {
+  await page.goto('/settings');
+  await expect(page.getByText('Something went wrong')).toHaveCount(0);
+
+  const scrollWidths = await page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+  expect(scrollWidths.scrollWidth).toBeLessThanOrEqual(scrollWidths.clientWidth);
+});
+
+test('a slider thumb meets the 44px touch target', async ({ page }) => {
+  await page.goto('/settings');
+
+  const thumb = page.locator('[data-slot="slider-thumb"]').first();
+  await expect(thumb).toBeVisible();
+
+  // `.tap-target` expands the hit area via a pseudo-element rather than the
+  // painted thumb itself, so the touch target lives in ::after, not the
+  // element's own bounding box.
+  const hitArea = await thumb.evaluate((el) => {
+    const after = getComputedStyle(el, '::after');
+    return { width: parseFloat(after.width), height: parseFloat(after.height) };
+  });
+  expect(hitArea.width).toBeGreaterThanOrEqual(44);
+  expect(hitArea.height).toBeGreaterThanOrEqual(44);
+});
+
+test('an admin sees the auth management tables rendered as cards, not a wide table', async ({ page }) => {
+  await overrideServerFn(page, 'getSession', {
+    id: 7,
+    email: 'admin@example.com',
+    name: 'Admin',
+    role: 'admin',
+  });
+  await overrideServerFn(page, 'listUsers', [
+    {
+      id: 1,
+      oidcSubject: 'sub1',
+      email: 'alice@example.com',
+      name: 'Alice',
+      role: 'admin',
+      oidcGroups: ['homelab-admins'],
+      lastLogin: new Date().toISOString(),
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    },
+  ]);
+
+  await page.goto('/settings');
+  await expect(page.getByText('alice@example.com')).toBeVisible();
+  await expect(page.locator('table', { hasText: 'alice@example.com' })).toHaveCount(0);
+});

--- a/src/components/settings/AuthManagementCard.tsx
+++ b/src/components/settings/AuthManagementCard.tsx
@@ -18,6 +18,17 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { listUsers, listSessions, revokeSession, revokeAllUserSessions, getRoleMapping } from '@/data/auth.functions'
 import { listGitTokens, createGitToken, revokeGitToken } from '@/data/git-tokens.functions'
 import { Spinner } from '@/components/ui/spinner';
+import { useIsMobile } from '@/hooks/useMediaQuery'
+import type { ReactNode } from 'react'
+
+function MobileField({ label, value }: { label: string; value: ReactNode }) {
+  return (
+    <div className="flex justify-between gap-3 text-xs">
+      <span className="text-muted-foreground shrink-0">{label}</span>
+      <span className="text-right break-words">{value}</span>
+    </div>
+  )
+}
 
 function RoleMappingPanel() {
   const { data: roleMapping } = useQuery({
@@ -74,6 +85,7 @@ function RoleMappingPanel() {
 }
 
 function UsersTable() {
+  const isMobile = useIsMobile()
   const { data: users = [], isLoading, isError, error } = useQuery({
     queryKey: ['auth-users'],
     queryFn: () => listUsers(),
@@ -92,6 +104,21 @@ function UsersTable() {
           <Spinner className="size-4" />
           <p className="text-sm text-muted-foreground">Loading users…</p>
         </div>
+      ) : isMobile ? (
+        users.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No users found.</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {users.map((user) => (
+              <div key={user.id} className="rounded-lg border border-border p-3 flex flex-col gap-1.5">
+                <p className="text-sm font-semibold truncate">{user.name ?? '—'}</p>
+                <p className="text-xs text-muted-foreground break-all">{user.email}</p>
+                <MobileField label="Role" value={user.role} />
+                <MobileField label="Last Login" value={formatDate(user.lastLogin)} />
+              </div>
+            ))}
+          </div>
+        )
       ) : (
         <Table>
           <TableHeader>
@@ -128,6 +155,7 @@ function UsersTable() {
 
 function SessionsTable() {
   const queryClient = useQueryClient()
+  const isMobile = useIsMobile()
 
   const { data: sessions = [], isLoading, isError, error } = useQuery({
     queryKey: ['auth-sessions'],
@@ -175,12 +203,12 @@ function SessionsTable() {
 
           return (
             <div key={userId} className="mb-4">
-              <div className="flex items-center justify-between mb-1">
-                <p className="text-sm font-semibold">{displayName}</p>
+              <div className="flex items-center justify-between gap-2 mb-1">
+                <p className="text-sm font-semibold truncate min-w-0">{displayName}</p>
                 <Button
                   size="sm"
                   variant="outline"
-                  className="text-destructive border-destructive/50 hover:border-destructive hover:bg-destructive/5"
+                  className="text-destructive border-destructive/50 hover:border-destructive hover:bg-destructive/5 shrink-0"
                   disabled={revokeAllMutation.isPending}
                   onClick={() => revokeAllMutation.mutate(userId)}
                   aria-label={`Revoke all sessions for ${displayName}`}
@@ -188,56 +216,88 @@ function SessionsTable() {
                   Revoke All Sessions
                 </Button>
               </div>
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>User</TableHead>
-                    <TableHead>IP Address</TableHead>
-                    <TableHead>User Agent</TableHead>
-                    <TableHead>Created</TableHead>
-                    <TableHead>Expires</TableHead>
-                    <TableHead />
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
+              {isMobile ? (
+                <div className="flex flex-col gap-2">
                   {userSessions.map((session) => (
-                    <TableRow key={session.id}>
-                      <TableCell>
-                        <div>{session.userName ?? '—'}</div>
-                        <div className="text-xs text-muted-foreground">{session.userEmail}</div>
-                      </TableCell>
-                      <TableCell>{session.ipAddress ?? '—'}</TableCell>
-                      <TableCell>
-                        <Tooltip>
-                          <TooltipTrigger render={<span />}>{truncate(session.userAgent ?? '', 50)}</TooltipTrigger>
-                          <TooltipContent>{session.userAgent ?? ''}</TooltipContent>
-                        </Tooltip>
-                      </TableCell>
-                      <TableCell>{formatDate(session.createdAt)}</TableCell>
-                      <TableCell>{formatDate(session.expiresAt)}</TableCell>
-                      <TableCell>
-                        <Tooltip>
-                          <TooltipTrigger
-                            render={
-                              <Button
-                                variant="ghost"
-                                size="icon-sm"
-                                className="text-destructive"
-                                disabled={revokeMutation.isPending}
-                                onClick={() => revokeMutation.mutate(session.id)}
-                                aria-label="Revoke session"
-                              />
-                            }
-                          >
-                            <Trash2 size={14} />
-                          </TooltipTrigger>
-                          <TooltipContent>Revoke session</TooltipContent>
-                        </Tooltip>
-                      </TableCell>
-                    </TableRow>
+                    <div key={session.id} className="rounded-lg border border-border p-3 flex flex-col gap-1.5">
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0">
+                          <p className="text-sm truncate">{session.userName ?? '—'}</p>
+                          <p className="text-xs text-muted-foreground truncate">{session.userEmail}</p>
+                        </div>
+                        <Button
+                          variant="ghost"
+                          size="icon-sm"
+                          className="text-destructive shrink-0"
+                          disabled={revokeMutation.isPending}
+                          onClick={() => revokeMutation.mutate(session.id)}
+                          aria-label="Revoke session"
+                        >
+                          <Trash2 size={14} />
+                        </Button>
+                      </div>
+                      <MobileField label="IP Address" value={session.ipAddress ?? '—'} />
+                      <div className="text-xs">
+                        <span className="text-muted-foreground">User Agent</span>
+                        <p className="break-words mt-0.5">{session.userAgent ?? '—'}</p>
+                      </div>
+                      <MobileField label="Created" value={formatDate(session.createdAt)} />
+                      <MobileField label="Expires" value={formatDate(session.expiresAt)} />
+                    </div>
                   ))}
-                </TableBody>
-              </Table>
+                </div>
+              ) : (
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>User</TableHead>
+                      <TableHead>IP Address</TableHead>
+                      <TableHead>User Agent</TableHead>
+                      <TableHead>Created</TableHead>
+                      <TableHead>Expires</TableHead>
+                      <TableHead />
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {userSessions.map((session) => (
+                      <TableRow key={session.id}>
+                        <TableCell>
+                          <div>{session.userName ?? '—'}</div>
+                          <div className="text-xs text-muted-foreground">{session.userEmail}</div>
+                        </TableCell>
+                        <TableCell>{session.ipAddress ?? '—'}</TableCell>
+                        <TableCell>
+                          <Tooltip>
+                            <TooltipTrigger render={<span />}>{truncate(session.userAgent ?? '', 50)}</TooltipTrigger>
+                            <TooltipContent>{session.userAgent ?? ''}</TooltipContent>
+                          </Tooltip>
+                        </TableCell>
+                        <TableCell>{formatDate(session.createdAt)}</TableCell>
+                        <TableCell>{formatDate(session.expiresAt)}</TableCell>
+                        <TableCell>
+                          <Tooltip>
+                            <TooltipTrigger
+                              render={
+                                <Button
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  className="text-destructive"
+                                  disabled={revokeMutation.isPending}
+                                  onClick={() => revokeMutation.mutate(session.id)}
+                                  aria-label="Revoke session"
+                                />
+                              }
+                            >
+                              <Trash2 size={14} />
+                            </TooltipTrigger>
+                            <TooltipContent>Revoke session</TooltipContent>
+                          </Tooltip>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              )}
             </div>
           )
         })
@@ -316,6 +376,7 @@ function GenerateTokenDialog({ open, onClose, onGenerate, isGenerating, newToken
 
 function GitTokensTable() {
   const queryClient = useQueryClient()
+  const isMobile = useIsMobile()
   const [generateDialogOpen, setGenerateDialogOpen] = useState(false)
   const [newToken, setNewToken] = useState<string | null>(null)
 
@@ -360,6 +421,35 @@ function GitTokensTable() {
           <Spinner className="size-4" />
           <p className="text-sm text-muted-foreground">Loading tokens…</p>
         </div>
+      ) : isMobile ? (
+        tokens.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No tokens.</p>
+        ) : (
+          <div className="flex flex-col gap-2">
+            {tokens.map((token) => (
+              <div key={token.id} className="rounded-lg border border-border p-3 flex flex-col gap-1.5">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="min-w-0">
+                    <p className="text-sm font-semibold truncate">{token.label}</p>
+                    <p className="text-xs text-muted-foreground truncate">{token.userName ?? token.userEmail}</p>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    className="text-destructive shrink-0"
+                    disabled={revokeMutation.isPending}
+                    onClick={() => revokeMutation.mutate(token.id)}
+                    aria-label="Revoke token"
+                  >
+                    <Trash2 size={14} />
+                  </Button>
+                </div>
+                <MobileField label="Last Used" value={token.lastUsedAt ? formatDate(token.lastUsedAt) : '—'} />
+                <MobileField label="Created" value={formatDate(token.createdAt)} />
+              </div>
+            ))}
+          </div>
+        )
       ) : (
         <Table>
           <TableHeader>

--- a/src/components/settings/HostRow.tsx
+++ b/src/components/settings/HostRow.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import type { HostListItem } from '@/lib/hosts/host-utils'
 import { Spinner } from '@/components/ui/spinner';
+import { cn } from '@/lib/utils/cn'
 
 function StatusDot({ status }: { status: HostListItem['status'] }) {
   if (status === 'healthy') {
@@ -44,7 +45,7 @@ function HostAction({ label, ariaLabel, disabled, onClick, className, children }
           <Button
             variant="ghost"
             size="icon-sm"
-            className={className ?? 'text-foreground'}
+            className={cn('size-11 lg:size-8', className ?? 'text-foreground')}
             onClick={onClick}
             disabled={disabled}
             aria-label={ariaLabel}
@@ -85,7 +86,7 @@ export default function HostRow({ host, isChecking, isRemoving, onHealthCheck, o
           </div>
         </div>
       </div>
-      <div className="flex items-center gap-1 shrink-0">
+      <div className="flex items-center gap-2 lg:gap-1 shrink-0">
         <HostAction label="Check health" ariaLabel="check health" disabled={busy} onClick={onHealthCheck}>
           {isChecking ? <Spinner className="size-3.5" /> : <RefreshCw size={14} />}
         </HostAction>

--- a/src/components/settings/__tests__/AuthManagementCard.test.tsx
+++ b/src/components/settings/__tests__/AuthManagementCard.test.tsx
@@ -384,4 +384,70 @@ describe('AuthManagementCard', () => {
       })
     })
   })
+
+  describe('below the lg breakpoint', () => {
+    const originalMatchMedia = window.matchMedia
+
+    beforeEach(() => {
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: (query: string) => ({
+          matches: query === '(max-width: 1023px)',
+          media: query,
+          addEventListener: () => {},
+          removeEventListener: () => {},
+        }),
+      })
+    })
+
+    afterEach(() => {
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        writable: true,
+        value: originalMatchMedia,
+      })
+    })
+
+    it('renders users as stacked cards instead of a table', async () => {
+      const authFns = require('@/data/auth.functions') as { listUsers: ReturnType<typeof mock> }
+      authFns.listUsers.mockImplementation(() => Promise.resolve(mockUsers))
+
+      renderCard()
+      await waitFor(() => expect(screen.getByText('alice@example.com')).toBeDefined())
+      expect(!!screen.getByText('alice@example.com').closest('table')).toBe(false)
+    })
+
+    it('shows the full user agent inline instead of behind a hover tooltip', async () => {
+      const authFns = require('@/data/auth.functions') as { listSessions: ReturnType<typeof mock> }
+      authFns.listSessions.mockImplementation(() => Promise.resolve(mockSessions))
+
+      renderCard()
+      await waitFor(() => {
+        expect(screen.getByText(mockSessions[0]!.userAgent!)).toBeDefined()
+      })
+    })
+
+    it('renders git tokens as stacked cards instead of a table', async () => {
+      const gitFns = require('@/data/git-tokens.functions') as { listGitTokens: ReturnType<typeof mock> }
+      gitFns.listGitTokens.mockImplementation(() => Promise.resolve(mockTokens))
+
+      renderCard()
+      await waitFor(() => expect(screen.getByText('CI deploy key')).toBeDefined())
+      expect(!!screen.getByText('CI deploy key').closest('table')).toBe(false)
+    })
+
+    it('truncates a long display name in the Revoke All Sessions header row', async () => {
+      const authFns = require('@/data/auth.functions') as { listSessions: ReturnType<typeof mock> }
+      authFns.listSessions.mockImplementation(() =>
+        Promise.resolve([{ ...mockSessions[0]!, userName: 'A'.repeat(200) }]),
+      )
+
+      renderCard()
+      await waitFor(() => {
+        const headerName = screen.getAllByText('A'.repeat(200)).find((el) => el.classList.contains('font-semibold'))
+        expect(headerName?.classList.contains('truncate')).toBe(true)
+      })
+    })
+  })
 })

--- a/src/components/settings/__tests__/HostRow.test.tsx
+++ b/src/components/settings/__tests__/HostRow.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, mock } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+import HostRow from '@/components/settings/HostRow'
+import type { HostListItem } from '@/lib/hosts/host-utils'
+
+const makeHost = (overrides?: Partial<HostListItem>): HostListItem => ({
+  id: 1,
+  name: 'server1',
+  agentUrl: 'http://192.168.1.10:9090',
+  capabilities: { docker: true, zfs: false },
+  agentVersion: '1.2.3',
+  status: 'healthy',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+  ...overrides,
+})
+
+function renderRow(overrides?: Partial<HostListItem>) {
+  return render(
+    <HostRow
+      host={makeHost(overrides)}
+      isChecking={false}
+      isRemoving={false}
+      onHealthCheck={mock(() => {})}
+      onEdit={mock(() => {})}
+      onRemove={mock(() => {})}
+    />,
+  )
+}
+
+describe('HostRow action buttons', () => {
+  it('grows to the touch target size below the lg breakpoint and shrinks back above it', () => {
+    renderRow()
+    for (const label of ['check health', 'edit host', 'remove host']) {
+      const button = screen.getByLabelText(label)
+      expect(button.classList.contains('size-11')).toBe(true)
+      expect(button.classList.contains('lg:size-8')).toBe(true)
+    }
+  })
+})

--- a/src/components/settings/wizard-steps/CapabilitiesStep.tsx
+++ b/src/components/settings/wizard-steps/CapabilitiesStep.tsx
@@ -11,6 +11,25 @@ interface CapabilitiesStepProps {
   onZfsChange: (value: boolean) => void
 }
 
+interface CapabilityRowProps {
+  id: string
+  checked: boolean
+  onChange: (value: boolean) => void
+  label: string
+  ariaLabel: string
+}
+
+function CapabilityRow({ id, checked, onChange, label, ariaLabel }: CapabilityRowProps) {
+  return (
+    <div className="flex items-center gap-2 min-h-11">
+      <Checkbox id={id} checked={checked} onCheckedChange={onChange} aria-label={ariaLabel} />
+      <Label htmlFor={id} className="flex-1 self-stretch flex items-center cursor-pointer">
+        {label}
+      </Label>
+    </div>
+  )
+}
+
 export default function CapabilitiesStep({ name, docker, zfs, onNameChange, onDockerChange, onZfsChange }: CapabilitiesStepProps) {
   return (
     <div className="flex flex-col gap-3" data-testid="step-capabilities">
@@ -30,24 +49,8 @@ export default function CapabilitiesStep({ name, docker, zfs, onNameChange, onDo
       <p className="text-sm text-muted-foreground">
         Select the capabilities this host will provide:
       </p>
-      <div className="flex items-center gap-2">
-        <Checkbox
-          id="capability-docker"
-          checked={docker}
-          onCheckedChange={(checked) => onDockerChange(checked)}
-          aria-label="Docker capability"
-        />
-        <Label htmlFor="capability-docker" className="cursor-pointer">Docker</Label>
-      </div>
-      <div className="flex items-center gap-2">
-        <Checkbox
-          id="capability-zfs"
-          checked={zfs}
-          onCheckedChange={(checked) => onZfsChange(checked)}
-          aria-label="ZFS capability"
-        />
-        <Label htmlFor="capability-zfs" className="cursor-pointer">ZFS</Label>
-      </div>
+      <CapabilityRow id="capability-docker" checked={docker} onChange={onDockerChange} label="Docker" ariaLabel="Docker capability" />
+      <CapabilityRow id="capability-zfs" checked={zfs} onChange={onZfsChange} label="ZFS" ariaLabel="ZFS capability" />
     </div>
   )
 }

--- a/src/components/settings/wizard-steps/ZfsSetupStep.tsx
+++ b/src/components/settings/wizard-steps/ZfsSetupStep.tsx
@@ -35,13 +35,14 @@ export default function ZfsSetupStep({
       <p className="text-sm text-muted-foreground">
         Run these commands on the target host to create the ZFS user:
       </p>
-      <div className="relative">
+      <div>
+        <div className="flex items-center justify-between mb-1">
+          <span className="text-xs font-semibold">Setup commands</span>
+          <CopyButton text={ZFS_SETUP_COMMANDS} label="ZFS setup commands" />
+        </div>
         <pre className="p-3 rounded text-xs overflow-x-auto bg-(--level1) text-foreground">
           {ZFS_SETUP_COMMANDS}
         </pre>
-        <div className="absolute top-1 right-1">
-          <CopyButton text={ZFS_SETUP_COMMANDS} label="ZFS setup commands" />
-        </div>
       </div>
       <p className="text-sm text-muted-foreground mt-2">
         From the output above: copy the number after <code>uid=</code> into HLM_ZFS_UID, and the number after{' '}

--- a/src/components/settings/wizard-steps/__tests__/CapabilitiesStep.test.tsx
+++ b/src/components/settings/wizard-steps/__tests__/CapabilitiesStep.test.tsx
@@ -1,0 +1,35 @@
+import { describe, it, expect, mock } from 'bun:test'
+import { render, screen, fireEvent } from '@testing-library/react'
+import CapabilitiesStep from '@/components/settings/wizard-steps/CapabilitiesStep'
+
+function renderStep(overrides?: Partial<{ docker: boolean; zfs: boolean }>) {
+  const onDockerChange = mock((_value: boolean) => {})
+  const onZfsChange = mock((_value: boolean) => {})
+  render(
+    <CapabilitiesStep
+      name=""
+      docker={overrides?.docker ?? true}
+      zfs={overrides?.zfs ?? false}
+      onNameChange={mock(() => {})}
+      onDockerChange={onDockerChange}
+      onZfsChange={onZfsChange}
+    />,
+  )
+  return { onDockerChange, onZfsChange }
+}
+
+describe('CapabilitiesStep checkbox rows', () => {
+  it('toggles Docker once when the label text is clicked, not the checkbox itself', () => {
+    const { onDockerChange } = renderStep({ docker: true })
+    fireEvent.click(screen.getByText('Docker'))
+    expect(onDockerChange).toHaveBeenCalledTimes(1)
+    expect(onDockerChange.mock.calls[0]?.[0]).toBe(false)
+  })
+
+  it('toggles ZFS once when the checkbox itself is clicked', () => {
+    const { onZfsChange } = renderStep({ zfs: false })
+    fireEvent.click(screen.getByLabelText('ZFS capability'))
+    expect(onZfsChange).toHaveBeenCalledTimes(1)
+    expect(onZfsChange.mock.calls[0]?.[0]).toBe(true)
+  })
+})

--- a/src/components/settings/wizard-steps/__tests__/ZfsSetupStep.test.tsx
+++ b/src/components/settings/wizard-steps/__tests__/ZfsSetupStep.test.tsx
@@ -1,0 +1,28 @@
+import { describe, it, expect, mock } from 'bun:test'
+import { render, screen } from '@testing-library/react'
+import ZfsSetupStep from '@/components/settings/wizard-steps/ZfsSetupStep'
+
+function renderStep() {
+  return render(
+    <ZfsSetupStep
+      docker={true}
+      hlmZfsUid=""
+      hlmZfsGid=""
+      dockerGid=""
+      onHlmZfsUidChange={mock(() => {})}
+      onHlmZfsGidChange={mock(() => {})}
+      onDockerGidChange={mock(() => {})}
+    />,
+  )
+}
+
+describe('ZfsSetupStep copy button placement', () => {
+  it('renders the copy button in a header row above the pre block, not overlapping it', () => {
+    renderStep()
+    const copyButton = screen.getByLabelText('Copy ZFS setup commands')
+    const pre = screen.getByText(/useradd/).closest('pre')
+    expect(pre).not.toBeNull()
+    expect(copyButton.closest('.absolute')).toBeNull()
+    expect(pre?.contains(copyButton)).toBe(false)
+  })
+})

--- a/src/components/ui/__tests__/slider.test.tsx
+++ b/src/components/ui/__tests__/slider.test.tsx
@@ -46,4 +46,10 @@ describe('Slider', () => {
     fireEvent.keyDown(screen.getByRole('slider'), { key: 'ArrowRight' });
     expect(onValueChange).toHaveBeenCalledWith(11);
   });
+
+  it('expands the thumb hit area to the touch target minimum', () => {
+    render(<Slider value={500} onValueChange={() => {}} min={100} max={60000} aria-label="interval" />);
+    const thumb = document.querySelector('[data-slot="slider-thumb"]');
+    expect(thumb?.classList.contains('tap-target')).toBe(true);
+  });
 });

--- a/src/components/ui/__tests__/stepper.test.tsx
+++ b/src/components/ui/__tests__/stepper.test.tsx
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { Stepper } from '@/components/ui/stepper';
+
+const STEPS = ['Capabilities', 'ZFS Setup', 'Compose File'] as const;
+
+function installMatchMedia(matchesMobile: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches: matchesMobile && query === '(max-width: 1023px)',
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+describe('Stepper above the lg breakpoint', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    installMatchMedia(false);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it('renders every step label', () => {
+    render(<Stepper steps={STEPS} activeStep={1} />);
+    for (const step of STEPS) {
+      expect(screen.getByText(step)).not.toBeNull();
+    }
+  });
+
+  it('does not render a separate active-step label', () => {
+    render(<Stepper steps={STEPS} activeStep={1} />);
+    expect(document.querySelector('[data-slot="stepper-active-label"]')).toBeNull();
+  });
+});
+
+describe('Stepper below the lg breakpoint', () => {
+  const originalMatchMedia = window.matchMedia;
+
+  beforeEach(() => {
+    installMatchMedia(true);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+  });
+
+  it('hides the per-step labels', () => {
+    render(<Stepper steps={STEPS} activeStep={1} />);
+    expect(document.querySelectorAll('[data-slot="stepper-label"]').length).toBe(0);
+  });
+
+  it('shows the active step name once, below the dots', () => {
+    render(<Stepper steps={STEPS} activeStep={1} />);
+    expect(screen.getByText('ZFS Setup')).not.toBeNull();
+  });
+
+  it('still renders one indicator dot per step', () => {
+    render(<Stepper steps={STEPS} activeStep={1} />);
+    const indicators = document.querySelectorAll('[data-slot="stepper-indicator"]');
+    expect(indicators.length).toBe(STEPS.length);
+  });
+});

--- a/src/components/ui/slider.tsx
+++ b/src/components/ui/slider.tsx
@@ -49,7 +49,7 @@ function Slider({ value, onValueChange, min, max, marks, disabled, className, ..
           <SliderPrimitive.Indicator className="bg-primary rounded-full select-none" />
           <SliderPrimitive.Thumb
             data-slot="slider-thumb"
-            className="bg-primary size-5 rounded-full shadow outline-none transition-shadow select-none focus-visible:ring-4 focus-visible:ring-primary/30 hover:ring-4 hover:ring-primary/15"
+            className="tap-target bg-primary size-5 rounded-full shadow outline-none transition-shadow select-none focus-visible:ring-4 focus-visible:ring-primary/30 hover:ring-4 hover:ring-primary/15"
           />
         </SliderPrimitive.Track>
       </SliderPrimitive.Control>

--- a/src/components/ui/stepper.tsx
+++ b/src/components/ui/stepper.tsx
@@ -1,5 +1,6 @@
 import { Check } from 'lucide-react';
 import { cn } from '@/lib/utils/cn';
+import { useIsMobile } from '@/hooks/useMediaQuery';
 
 interface StepperProps {
   steps: readonly string[];
@@ -13,42 +14,53 @@ interface StepperProps {
  * presentational; step state lives in the caller.
  */
 function Stepper({ steps, activeStep, className }: Readonly<StepperProps>) {
+  const isMobile = useIsMobile();
+
   return (
-    <div data-slot="stepper" className={cn('flex w-full', className)}>
-      {steps.map((label, index) => {
-        const isCompleted = index < activeStep;
-        const isActive = index === activeStep;
-        return (
-          <div key={label} className="relative flex flex-1 flex-col items-center gap-2 px-2">
-            {index > 0 && (
-              <div
-                aria-hidden
-                className="absolute top-3 right-1/2 left-[calc(-50%+20px)] mr-5 h-px bg-border"
-              />
-            )}
-            <span
-              data-slot="stepper-indicator"
-              className={cn(
-                'z-10 flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-medium',
-                isActive || isCompleted
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-foreground/30 text-background',
+    <div data-slot="stepper" className={cn('flex flex-col gap-2 w-full', className)}>
+      <div className="flex w-full">
+        {steps.map((label, index) => {
+          const isCompleted = index < activeStep;
+          const isActive = index === activeStep;
+          return (
+            <div key={label} className="relative flex flex-1 flex-col items-center gap-2 px-2">
+              {index > 0 && (
+                <div
+                  aria-hidden
+                  className="absolute top-3 right-1/2 left-[calc(-50%+20px)] mr-5 h-px bg-border"
+                />
               )}
-            >
-              {isCompleted ? <Check className="size-3.5" strokeWidth={3} /> : index + 1}
-            </span>
-            <span
-              data-slot="stepper-label"
-              className={cn(
-                'text-center text-sm',
-                isActive ? 'font-medium text-foreground' : 'text-muted-foreground',
+              <span
+                data-slot="stepper-indicator"
+                className={cn(
+                  'z-10 flex size-6 shrink-0 items-center justify-center rounded-full text-xs font-medium',
+                  isActive || isCompleted
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-foreground/30 text-background',
+                )}
+              >
+                {isCompleted ? <Check className="size-3.5" strokeWidth={3} /> : index + 1}
+              </span>
+              {!isMobile && (
+                <span
+                  data-slot="stepper-label"
+                  className={cn(
+                    'text-center text-sm',
+                    isActive ? 'font-medium text-foreground' : 'text-muted-foreground',
+                  )}
+                >
+                  {label}
+                </span>
               )}
-            >
-              {label}
-            </span>
-          </div>
-        );
-      })}
+            </div>
+          );
+        })}
+      </div>
+      {isMobile && (
+        <span data-slot="stepper-active-label" className="text-center text-sm font-medium text-foreground">
+          {steps[activeStep]}
+        </span>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Stacked on #399. Base is `claude/mobile-routes-responsive-v1nd2r`, not `main`. Independent of #400 and #401 (no file overlap).

## What and why

`settings.tsx` is already a single stacked column with no split panes and needed no restructuring. The problems were in its controls and its admin tables.

- **The three auth tables** (users, sessions, git tokens) only survived a phone by falling back to the shared `<Table>` wrapper's horizontal scroll. Six columns behind a sideways drag is a bad way to read admin data on touch. Below `lg` they render as stacked label/value cards. The sessions card also shows the **full user agent inline**: it was truncated to 50 characters with the remainder behind a hover `Tooltip`, and Base UI only opens tooltips for `mouse`/`pen` pointer types, so that value was unreachable on exactly the devices where the truncation bites. `RoleMappingPanel` (2 columns) is left alone.
- **The slider thumb** was `size-5` (20px), well under a usable drag target, and four settings use one. It keeps its painted size and gains the `.tap-target` hit area. Worth noting for review: Base UI positions the thumb with an inline `position: absolute`, which wins over the utility's `position: relative`, so the rule does not disturb it. I verified this in a real browser rather than assuming -- computed position stays `absolute`, painted box stays 20px, and the `::after` hit area measures 44x44.
- **The wizard stepper** crowded up to five text labels into ~70px columns at 375px, wrapping them into the `absolute`-positioned connector lines. Below `lg` it renders dots plus the active step's name.

Smaller items: host row actions are `size-11 lg:size-8` rather than `.tap-target` overlays (a 4px gap would let the overlays swallow each other); capability rows are a full 44px; and `ZfsSetupStep`'s copy button moved out of the scrollable `<pre>`'s corner into a header row, matching `ComposeFileStep`/`ConfigurationStep`.

## Flow

```
AuthManagementCard -> useIsMobile -> stacked cards (mobile) | <Table> (desktop)
Stepper            -> useIsMobile -> dots + active label    | per-step labels
Slider thumb       -> .tap-target -> 20px painted, 44px hit area
```

Above `lg` all three render what they rendered before.

## What else this touches

- `src/components/ui/slider.tsx` and `src/components/ui/stepper.tsx` are shared primitives. Slider is used only by Settings; Stepper only by `AddHostWizard`. Desktop e2e re-run to confirm no regression.
- No route loader, SSE channel, settings key, migration, or env var. Nothing changes what any setting does or how it persists -- only how the controls are laid out and sized.

## Review note

The capability rows initially landed with an `onClick` on a plain `<div>` and no `htmlFor`, which trades a real accessibility affordance for a bigger tap target. I reworked it: the `Checkbox` keeps its `id`, the `Label` keeps `htmlFor` and stretches to fill a 44px row, so the whole row is tappable through native label semantics with no JS handler and no non-interactive element carrying a click. The existing test (label click and checkbox click each fire exactly once) passes against this version, which is the behavior that actually matters -- nesting the checkbox inside the label double-fires for checkboxes specifically.

## Verification

- `bun run typecheck` -- clean.
- `bunx playwright test` -- 28 passed across `app`, `demo`, and `mobile` (Pixel 7). The 3 new settings specs assert no horizontal document scroll, the slider thumb's 44px hit area (measured via `::after`, since `boundingBox()` only sees the painted box), and that the auth tables render as cards rather than a table.
- Per-file unit tests green standalone: AuthManagementCard 33, AddHostWizard 34, HostRow 1, slider 6, stepper 5, CapabilitiesStep 2, ZfsSetupStep 1. All 8 settings test files together: 148 pass.
- The full `bun test --isolate` run is not a usable signal in this container (~530 failures on unmodified `main` too; Bun 1.3.11 vs the pinned 1.3.14 leaks module mocks across files). CI on the pinned Bun is the authority for the coverage gate.

One note for anyone writing tests here later: `expect(mock).toHaveBeenCalledWith(true)` against a Base UI `onCheckedChange` hangs and consumes gigabytes, because Bun's arg-count-mismatch diffing tries to serialize the second `details` argument, which wraps a circular native event. Assert on `mock.calls[0]?.[0]` instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2DmUg6NUpd51qSsKyiG5R)_