### PR TITLE
feat(mobile): make the ZFS and Proxmox routes usable at phone widths

### DIFF
--- a/e2e/navigation.mobile.e2e.ts
+++ b/e2e/navigation.mobile.e2e.ts
@@ -11,7 +11,8 @@ test('the drawer navigates between sections', async ({ page }) => {
   await page.goto('/docker');
 
   await page.getByRole('button', { name: 'Open navigation menu' }).click();
-  await page.getByRole('link', { name: 'Stacks' }).click();
+  await page.getByRole('button', { name: 'Stacks' }).click();
+  await page.getByRole('menuitem', { name: 'All stacks' }).click();
 
   await expect(page).toHaveURL(/\/stacks$/);
   await expect(page.getByText('Stacks Overview')).toBeVisible();
@@ -22,7 +23,7 @@ test('the drawer exposes submenus that desktop opens on hover', async ({ page })
   await page.goto('/stacks');
 
   await page.getByRole('button', { name: 'Open navigation menu' }).click();
-  await page.getByRole('button', { name: /expand settings menu/i }).click();
+  await page.getByRole('button', { name: 'Settings' }).click();
 
   await expect(page.getByRole('menuitem', { name: 'Managed Hosts' })).toBeVisible();
 });

--- a/e2e/navigation.mobile.e2e.ts
+++ b/e2e/navigation.mobile.e2e.ts
@@ -27,8 +27,6 @@ test('the drawer exposes submenus that desktop opens on hover', async ({ page })
   await expect(page.getByRole('menuitem', { name: 'Managed Hosts' })).toBeVisible();
 });
 
-// Route bodies are widened by their tables and are covered by the per-route
-// mobile specs; this only pins the shell chrome, which every route inherits.
 test('the header fits the viewport on every route', async ({ page }) => {
   for (const path of ['/docker', '/stacks', '/zfs', '/proxmox', '/settings']) {
     await page.goto(path);

--- a/e2e/zfs-proxmox.mobile.e2e.ts
+++ b/e2e/zfs-proxmox.mobile.e2e.ts
@@ -1,0 +1,69 @@
+import { test, expect } from './fixtures';
+
+test('the ZFS pool table does not scroll the document horizontally', async ({ page }) => {
+  await page.goto('/zfs');
+  await expect(page.getByText('nas01').first()).toBeVisible();
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow, '/zfs overflows the viewport horizontally').toBeLessThanOrEqual(1);
+});
+
+test('the ZFS pool table itself does not scroll sideways', async ({ page }) => {
+  await page.goto('/zfs');
+  await expect(page.getByText('nas01').first()).toBeVisible();
+
+  const header = page.locator('[data-slot="datatable-header"]').first();
+  const headerOverflow = await header.evaluate((el) => {
+    const scroller = el.closest('.overflow-x-auto');
+    if (!scroller) return 0;
+    return scroller.scrollWidth - scroller.clientWidth;
+  });
+  expect(headerOverflow).toBeLessThanOrEqual(1);
+});
+
+test('tapping the single-disk badge reveals the disk name that only exists in its tooltip', async ({ page }) => {
+  await page.goto('/zfs');
+  await expect(page.getByText('nas01').first()).toBeVisible();
+
+  const badge = page.getByText('single disk').first();
+  await expect(badge).toBeVisible();
+  expect(await badge.boundingBox()).not.toBeNull();
+
+  await badge.tap();
+  await expect(page.getByRole('tooltip')).toBeVisible();
+});
+
+test('the Proxmox host/guest tables do not scroll the document horizontally', async ({ page }) => {
+  await page.goto('/proxmox');
+  await expect(page.getByText('pve1').first()).toBeVisible();
+
+  const overflow = await page.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  expect(overflow, '/proxmox overflows the viewport horizontally').toBeLessThanOrEqual(1);
+});
+
+test('a Proxmox node accordion row wraps its metrics instead of forcing horizontal scroll', async ({ page }) => {
+  await page.goto('/proxmox');
+  const row = page.getByRole('button', { name: /pve1/ }).first();
+  await expect(row).toBeVisible();
+
+  const rowOverflow = await row.evaluate((el) => el.scrollWidth - el.clientWidth);
+  expect(rowOverflow).toBeLessThanOrEqual(1);
+});
+
+test('tapping the interval toggle reveals its tooltip instead of staying hidden behind hover', async ({ page }) => {
+  await page.goto('/proxmox');
+  await expect(page.getByText('pve1').first()).toBeVisible();
+
+  const relaxedButton = page.getByRole('button', { name: '10 seconds (relaxed)' });
+  await expect(relaxedButton).toBeVisible();
+
+  const box = await relaxedButton.boundingBox();
+  expect(box!.height, 'interval toggle is under the 44px touch target').toBeGreaterThanOrEqual(44);
+
+  await relaxedButton.tap();
+  await expect(page.getByText('Relaxed updates (10 seconds)')).toBeVisible();
+});

--- a/src/App.css
+++ b/src/App.css
@@ -200,11 +200,9 @@ body {
   display: none !important;
 }
 
-/* Expands a control's hit area to the 44px WCAG target-size minimum without
-   changing its painted size. The overlay is centered on the control, so a
-   32px icon button gains 6px of slop on every side. Only for controls with at
-   least 12px of clearance: on adjacent controls the overlays overlap and the
-   one later in the DOM swallows its neighbour's taps. */
+/* Only for controls with at least 12px of clearance: the 44px overlay is centered
+   on the control, so on adjacent controls the overlays overlap and the one later
+   in the DOM swallows its neighbour's taps. */
 .tap-target {
   position: relative;
 }

--- a/src/components/PageStatusBar.tsx
+++ b/src/components/PageStatusBar.tsx
@@ -9,11 +9,11 @@ export default function PageStatusBar({ left, right }: Readonly<PageStatusBarPro
   if (!left && !right) return null;
 
   return (
-    <div className="py-2 px-4 flex items-center justify-between shrink-0 border-b border-(--border)/30">
-      <div className="flex items-center gap-3 text-sm text-(--muted-foreground)">
+    <div className="py-2 px-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 shrink-0 border-b border-(--border)/30">
+      <div className="flex flex-wrap items-center gap-3 text-sm text-(--muted-foreground)">
         {left}
       </div>
-      <div className="flex items-center gap-3">
+      <div className="flex flex-wrap items-center gap-3">
         {right}
       </div>
     </div>

--- a/src/components/__tests__/PageStatusBar.test.tsx
+++ b/src/components/__tests__/PageStatusBar.test.tsx
@@ -46,4 +46,12 @@ describe('PageStatusBar', () => {
     expect(outer.className).toContain('items-center');
     expect(outer.className).toContain('justify-between');
   });
+
+  it('allows both slots to wrap onto their own line on a narrow viewport', () => {
+    const { container } = render(
+      <PageStatusBar left={<span>left content</span>} right={<span>right content</span>} />,
+    );
+    const outer = container.firstChild as HTMLElement;
+    expect(outer.className).toContain('flex-wrap');
+  });
 });

--- a/src/components/__tests__/header/Header.test.tsx
+++ b/src/components/__tests__/header/Header.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test'
 import { render, screen, fireEvent, act } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MANAGED_HOST_NAMES_QUERY_KEY, STACKS_QUERY_KEY } from '@/lib/constants/stacks-keys'
 
 mock.module('@tanstack/react-router', () => ({
   Link: ({ children, to, hash, onClick, ...rest }: {
@@ -54,13 +55,23 @@ mock.module('@/lib/constants/demo', () => ({ IS_DEMO_MODE: false }))
 
 const Header = (await import('@/components/header/Header')).default
 
-function createWrapper() {
+// Hosts seeded by default: a route with nothing to list gets no dropdown, so
+// without the seed no tab here would open a menu at all.
+function createWrapper(hosts: string[] = ['tank', 'nas']) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   })
+  qc.setQueryData(MANAGED_HOST_NAMES_QUERY_KEY, hosts)
+  qc.setQueryData(STACKS_QUERY_KEY, [])
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return <QueryClientProvider client={qc}>{children}</QueryClientProvider>
   }
+}
+
+function findDockerTab() {
+  const tab = screen.getAllByRole('tab').find((t) => t.textContent?.includes('Docker'))
+  expect(tab).not.toBeUndefined()
+  return tab!
 }
 
 describe('Header', () => {
@@ -77,10 +88,8 @@ describe('Header', () => {
     render(<Header />, { wrapper: createWrapper() })
     // MUI Tabs sets aria-selected="true" on the currently selected Tab button.
     // The Docker tab text is inside a span inside the button; query by role.
-    const tabs = screen.getAllByRole('tab')
-    const dockerTab = tabs.find((t) => t.textContent?.includes('Docker'))
-    expect(dockerTab).not.toBeNull()
-    expect(dockerTab?.getAttribute('aria-selected')).toBe('true')
+    const dockerTab = findDockerTab()
+    expect(dockerTab.getAttribute('aria-selected')).toBe('true')
   })
 
   it('does not render the demo banner when IS_DEMO_MODE is false', () => {
@@ -96,16 +105,29 @@ describe('Header', () => {
     expect(screen.getByRole('button', { name: 'Account menu' })).not.toBeNull()
   })
 
+  it('advertises a dropdown on a tab with something to list', () => {
+    render(<Header />, { wrapper: createWrapper(['tank']) })
+    expect(findDockerTab().getAttribute('aria-haspopup')).toBe('menu')
+  })
+
+  it('leaves a tab with nothing to list a plain link', () => {
+    render(<Header />, { wrapper: createWrapper([]) })
+    const dockerTab = findDockerTab()
+    expect(dockerTab.getAttribute('aria-haspopup')).toBeNull()
+
+    fireEvent.mouseEnter(dockerTab)
+
+    expect(screen.queryByRole('menu')).toBeNull()
+  })
+
   it('closes the open menu when Escape is pressed on a menu tab', () => {
     render(<Header />, { wrapper: createWrapper() })
-    const tabs = screen.getAllByRole('tab')
-    const dockerTab = tabs.find((t) => t.textContent?.includes('Docker'))
-    expect(dockerTab).not.toBeNull()
-    fireEvent.mouseEnter(dockerTab!)
+    const dockerTab = findDockerTab()
+    fireEvent.mouseEnter(dockerTab)
     // Assert the menu is actually open before pressing Escape, so the test
     // verifies the open → close transition rather than passing vacuously.
     expect(screen.getByRole('menu')).not.toBeNull()
-    fireEvent.keyDown(dockerTab!, { key: 'Escape' })
+    fireEvent.keyDown(dockerTab, { key: 'Escape' })
     expect(screen.queryByRole('menu')).toBeNull()
   })
 
@@ -145,33 +167,27 @@ describe('Header', () => {
 
     it('closes the open menu when mouse leaves a menu tab', () => {
       render(<Header />, { wrapper: createWrapper() })
-      const tabs = screen.getAllByRole('tab')
-      const dockerTab = tabs.find((t) => t.textContent?.includes('Docker'))
-      expect(dockerTab).not.toBeNull()
-      fireEvent.mouseEnter(dockerTab!)
+      const dockerTab = findDockerTab()
+      fireEvent.mouseEnter(dockerTab)
       expect(screen.getByRole('menu')).not.toBeNull()
-      fireEvent.mouseLeave(dockerTab!)
+      fireEvent.mouseLeave(dockerTab)
       act(() => { flushTimers() })
       expect(screen.queryByRole('menu')).toBeNull()
     })
 
     it('opens the menu when a menu tab receives focus', () => {
       render(<Header />, { wrapper: createWrapper() })
-      const tabs = screen.getAllByRole('tab')
-      const dockerTab = tabs.find((t) => t.textContent?.includes('Docker'))
-      expect(dockerTab).not.toBeNull()
-      fireEvent.focus(dockerTab!)
+      const dockerTab = findDockerTab()
+      fireEvent.focus(dockerTab)
       expect(screen.getByRole('menu')).not.toBeNull()
     })
 
     it('closes the open menu when a menu tab loses focus', () => {
       render(<Header />, { wrapper: createWrapper() })
-      const tabs = screen.getAllByRole('tab')
-      const dockerTab = tabs.find((t) => t.textContent?.includes('Docker'))
-      expect(dockerTab).not.toBeNull()
-      fireEvent.focus(dockerTab!)
+      const dockerTab = findDockerTab()
+      fireEvent.focus(dockerTab)
       expect(screen.getByRole('menu')).not.toBeNull()
-      fireEvent.blur(dockerTab!)
+      fireEvent.blur(dockerTab)
       act(() => { flushTimers() })
       expect(screen.queryByRole('menu')).toBeNull()
     })

--- a/src/components/__tests__/header/Header.test.tsx
+++ b/src/components/__tests__/header/Header.test.tsx
@@ -55,8 +55,7 @@ mock.module('@/lib/constants/demo', () => ({ IS_DEMO_MODE: false }))
 
 const Header = (await import('@/components/header/Header')).default
 
-// Hosts seeded by default: a route with nothing to list gets no dropdown, so
-// without the seed no tab here would open a menu at all.
+// Hosts have to be seeded: a route with nothing to list renders no dropdown at all.
 function createWrapper(hosts: string[] = ['tank', 'nas']) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },

--- a/src/components/__tests__/header/MobileNav.test.tsx
+++ b/src/components/__tests__/header/MobileNav.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, mock } from 'bun:test'
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { MANAGED_HOST_NAMES_QUERY_KEY, STACKS_QUERY_KEY } from '@/lib/constants/stacks-keys'
 import type { StackSummary } from '@/types/stacks'
@@ -195,5 +195,32 @@ describe('MobileNav', () => {
     fireEvent.click(hostLink)
 
     await waitFor(() => expect(screen.queryByRole('menuitem', { name: /nas/i })).toBeNull())
+  })
+
+  it('closes the drawer from the header close button', async () => {
+    await openDrawer()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close navigation menu' }))
+
+    await waitFor(() => expect(screen.queryByRole('link', { name: /zfs/i })).toBeNull())
+  })
+
+  it('repeats the current route label in the drawer header', async () => {
+    await openDrawer()
+    const headerRow = screen.getByRole('button', { name: 'Close navigation menu' }).parentElement
+
+    expect(within(headerRow!).getByText('Docker').getAttribute('aria-hidden')).toBe('true')
+  })
+
+  it('names the drawer for assistive tech, not for the current route', async () => {
+    await openDrawer()
+    expect(screen.getByRole('dialog', { name: 'Main navigation' })).not.toBeNull()
+  })
+
+  it('gives the close button a 44px touch target', async () => {
+    await openDrawer()
+    expect(
+      screen.getByRole('button', { name: 'Close navigation menu' }).className,
+    ).toContain('size-11')
   })
 })

--- a/src/components/__tests__/header/MobileNav.test.tsx
+++ b/src/components/__tests__/header/MobileNav.test.tsx
@@ -1,6 +1,8 @@
 import { describe, it, expect, mock } from 'bun:test'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MANAGED_HOST_NAMES_QUERY_KEY, STACKS_QUERY_KEY } from '@/lib/constants/stacks-keys'
+import type { StackSummary } from '@/types/stacks'
 
 mock.module('@tanstack/react-router', () => ({
   Link: ({ children, to, hash, onClick, ...rest }: {
@@ -43,10 +45,29 @@ mock.module('@/lib/utils/icon-resolver', () => ({
 
 const MobileNav = (await import('@/components/header/MobileNav')).default
 
-function renderNav() {
+// Seeded, not fetched: disclosure buttons depend on the entry count, which has to
+// be settled before the drawer's first render.
+function stackSummary(name: string): StackSummary {
+  return {
+    name,
+    host: 'server1',
+    icon: null,
+    syncStatus: 'unknown',
+    deployMode: 'auto',
+    lastDeployAt: null,
+    lastDeployStatus: null,
+    containerCount: 0,
+  }
+}
+
+const TWO_STACKS = [stackSummary('plex'), stackSummary('authentik')]
+
+function renderNav(hosts: string[] = ['tank', 'nas'], stacks: StackSummary[] = TWO_STACKS) {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   })
+  qc.setQueryData(MANAGED_HOST_NAMES_QUERY_KEY, hosts)
+  qc.setQueryData(STACKS_QUERY_KEY, stacks)
   return render(
     <QueryClientProvider client={qc}>
       <MobileNav />
@@ -54,10 +75,10 @@ function renderNav() {
   )
 }
 
-async function openDrawer() {
-  renderNav()
+async function openDrawer(hosts?: string[], stacks?: StackSummary[]) {
+  renderNav(hosts, stacks)
   fireEvent.click(screen.getByRole('button', { name: 'Open navigation menu' }))
-  await screen.findByRole('link', { name: /docker/i })
+  await screen.findByRole('link', { name: /zfs/i })
 }
 
 describe('MobileNav', () => {
@@ -76,15 +97,18 @@ describe('MobileNav', () => {
   it('opens a drawer listing every nav destination', async () => {
     await openDrawer()
 
-    for (const label of ['Docker', 'Stacks', 'ZFS', 'Proxmox', 'Settings']) {
+    for (const label of ['ZFS', 'Proxmox']) {
       expect(screen.getByRole('link', { name: new RegExp(label, 'i') })).not.toBeNull()
+    }
+    for (const label of ['Docker', 'Stacks', 'Settings']) {
+      expect(screen.getByRole('button', { name: new RegExp(label, 'i') })).not.toBeNull()
     }
   })
 
   it('marks the active route', async () => {
     await openDrawer()
-    const dockerLink = screen.getByRole('link', { name: /docker/i })
-    expect(dockerLink.getAttribute('aria-current')).toBe('page')
+    const dockerRow = screen.getByRole('button', { name: /docker/i })
+    expect(dockerRow.getAttribute('aria-current')).toBe('page')
     expect(screen.getByRole('link', { name: /zfs/i }).getAttribute('aria-current')).toBeNull()
   })
 
@@ -98,21 +122,60 @@ describe('MobileNav', () => {
     expect(await screen.findByRole('menuitem', { name: /tank/i })).not.toBeNull()
   })
 
-  it('toggles a submenu from its disclosure button', async () => {
+  it('expands a submenu when its row is tapped', async () => {
     await openDrawer()
-    const toggle = screen.getByRole('button', { name: /expand stacks menu/i })
-    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    const settingsRow = screen.getByRole('button', { name: /settings/i })
+    expect(settingsRow.getAttribute('aria-expanded')).toBe('false')
 
-    fireEvent.click(toggle)
+    fireEvent.click(settingsRow)
 
-    expect(
-      screen.getByRole('button', { name: /collapse stacks menu/i }).getAttribute('aria-expanded'),
-    ).toBe('true')
+    expect(settingsRow.getAttribute('aria-expanded')).toBe('true')
+    expect(screen.getByRole('menuitem', { name: /developer/i })).not.toBeNull()
   })
 
-  it('offers no disclosure button for routes without a submenu', async () => {
+  it('does not navigate or close the drawer when a submenu row is tapped', async () => {
     await openDrawer()
-    expect(screen.queryByRole('button', { name: /zfs menu/i })).toBeNull()
+    const settingsRow = screen.getByRole('button', { name: /settings/i })
+    expect(settingsRow.tagName).toBe('BUTTON')
+
+    fireEvent.click(settingsRow)
+
+    expect(screen.getByRole('link', { name: /zfs/i })).not.toBeNull()
+  })
+
+  it('collapses an expanded submenu when its row is tapped again', async () => {
+    await openDrawer()
+    const dockerRow = screen.getByRole('button', { name: /docker/i })
+    expect(dockerRow.getAttribute('aria-expanded')).toBe('true')
+
+    fireEvent.click(dockerRow)
+
+    expect(dockerRow.getAttribute('aria-expanded')).toBe('false')
+  })
+
+  it('expands a route with a single destination', async () => {
+    await openDrawer(['tank'])
+    expect(await screen.findByRole('menuitem', { name: /tank/i })).not.toBeNull()
+  })
+
+  it('leaves a route with nothing to list a plain link', async () => {
+    await openDrawer([])
+    expect(screen.getByRole('link', { name: /docker/i })).not.toBeNull()
+  })
+
+  it('lists the stacks route itself alongside its stacks', async () => {
+    await openDrawer()
+
+    fireEvent.click(screen.getByRole('button', { name: /stacks/i }))
+
+    const allStacks = screen.getByRole('menuitem', { name: /all stacks/i })
+    expect(allStacks.getAttribute('href')).toBe('/stacks')
+  })
+
+  it('gives the docker menu no self entry, since every host lands on the route', async () => {
+    await openDrawer()
+    const items = screen.getAllByRole('menuitem').map((el) => el.getAttribute('href'))
+    expect(items).not.toContain('/docker')
   })
 
   it('closes the drawer and prefetches when a destination is tapped', async () => {

--- a/src/components/__tests__/header/MobileNav.test.tsx
+++ b/src/components/__tests__/header/MobileNav.test.tsx
@@ -45,8 +45,6 @@ mock.module('@/lib/utils/icon-resolver', () => ({
 
 const MobileNav = (await import('@/components/header/MobileNav')).default
 
-// Seeded, not fetched: disclosure buttons depend on the entry count, which has to
-// be settled before the drawer's first render.
 function stackSummary(name: string): StackSummary {
   return {
     name,

--- a/src/components/__tests__/header/menus.test.tsx
+++ b/src/components/__tests__/header/menus.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, mock, beforeEach } from 'bun:test'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, renderHook, screen, fireEvent } from '@testing-library/react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { MANAGED_HOST_NAMES_QUERY_KEY, STACKS_QUERY_KEY } from '@/lib/constants/stacks-keys'
 import type { StackSummary } from '@/types/stacks'
 import type { MenuRouteKey } from '@/components/header/nav-config'
 
@@ -63,6 +64,8 @@ const {
   StacksMenuContent,
   DockerHostsMenuContent,
   MenuContentFor,
+  shouldRenderMenu,
+  useMenuRoutes,
 } = await import('@/components/header/menus')
 
 function createWrapper() {
@@ -71,6 +74,19 @@ function createWrapper() {
   })
   return function Wrapper({ children }: { children: React.ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  }
+}
+
+function stackSummary(name: string, icon: string | null = null): StackSummary {
+  return {
+    name,
+    host: 'server1',
+    icon,
+    syncStatus: 'unknown',
+    deployMode: 'auto',
+    lastDeployAt: null,
+    lastDeployStatus: null,
+    containerCount: 0,
   }
 }
 
@@ -122,31 +138,9 @@ describe('SettingsMenuContent', () => {
 })
 
 describe('StacksMenuContent', () => {
-  it('shows loading state', () => {
-    mockListStacks.mockImplementation(() => new Promise(() => {}))
-    render(<StacksMenuContent />, { wrapper: createWrapper() })
-    expect(screen.getByText('Loading…')).not.toBeNull()
-  })
-
-  it('shows error state', async () => {
-    mockListStacks.mockImplementation(() => Promise.reject(new Error('fail')))
-    const { findByText } = render(<StacksMenuContent />, { wrapper: createWrapper() })
-    expect(await findByText('Failed to load stacks')).not.toBeNull()
-  })
-
-  it('shows empty state when no stacks', async () => {
-    mockListStacks.mockImplementation(() => Promise.resolve([]))
-    const { findByText } = render(<StacksMenuContent />, { wrapper: createWrapper() })
-    expect(await findByText('No stacks')).not.toBeNull()
-  })
-
   it('renders stacks sorted by name', async () => {
     mockListStacks.mockImplementation(() =>
-      Promise.resolve([
-        { name: 'zabbix', host: 'server1', icon: null, syncStatus: 'unknown', deployMode: 'auto', lastDeployAt: null, lastDeployStatus: null, containerCount: 0 },
-        { name: 'authentik', host: 'server1', icon: null, syncStatus: 'unknown', deployMode: 'auto', lastDeployAt: null, lastDeployStatus: null, containerCount: 0 },
-        { name: 'plex', host: 'server1', icon: null, syncStatus: 'unknown', deployMode: 'auto', lastDeployAt: null, lastDeployStatus: null, containerCount: 0 },
-      ]),
+      Promise.resolve([stackSummary('zabbix'), stackSummary('authentik'), stackSummary('plex')]),
     )
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const { findAllByRole } = render(
@@ -163,10 +157,7 @@ describe('StacksMenuContent', () => {
 
   it('renders <img> for stacks with icon and <span> placeholder for stacks with null icon', async () => {
     mockListStacks.mockImplementation(() =>
-      Promise.resolve([
-        { name: 'nginx', host: 'server1', icon: 'nginx', syncStatus: 'unknown', deployMode: 'auto', lastDeployAt: null, lastDeployStatus: null, containerCount: 0 },
-        { name: 'plex', host: 'server1', icon: null, syncStatus: 'unknown', deployMode: 'auto', lastDeployAt: null, lastDeployStatus: null, containerCount: 0 },
-      ]),
+      Promise.resolve([stackSummary('nginx', 'nginx'), stackSummary('plex')]),
     )
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const { findAllByRole } = render(
@@ -188,9 +179,7 @@ describe('StacksMenuContent', () => {
 
   it('calls close context when a stack link is clicked', async () => {
     const closeSpy = mock(() => {})
-    mockListStacks.mockImplementation(() =>
-      Promise.resolve([{ name: 'plex', host: 'server1', icon: null, syncStatus: 'unknown', deployMode: 'auto', lastDeployAt: null, lastDeployStatus: null, containerCount: 0 }]),
-    )
+    mockListStacks.mockImplementation(() => Promise.resolve([stackSummary('plex')]))
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const { findAllByRole } = render(
       <QueryClientProvider client={qc}>
@@ -205,11 +194,7 @@ describe('StacksMenuContent', () => {
   })
 
   it('renders links with the stack name resolved in the href', async () => {
-    mockListStacks.mockImplementation(() =>
-      Promise.resolve([
-        { name: 'plex', host: 'server1', icon: null, syncStatus: 'unknown', deployMode: 'auto', lastDeployAt: null, lastDeployStatus: null, containerCount: 0 },
-      ]),
-    )
+    mockListStacks.mockImplementation(() => Promise.resolve([stackSummary('plex')]))
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } })
     const { findAllByRole } = render(
       <QueryClientProvider client={qc}>
@@ -222,24 +207,6 @@ describe('StacksMenuContent', () => {
 })
 
 describe('DockerHostsMenuContent', () => {
-  it('shows loading state', () => {
-    mockListManagedHostNames.mockImplementation(() => new Promise(() => {}))
-    render(<DockerHostsMenuContent />, { wrapper: createWrapper() })
-    expect(screen.getByText('Loading…')).not.toBeNull()
-  })
-
-  it('shows error state', async () => {
-    mockListManagedHostNames.mockImplementation(() => Promise.reject(new Error('fail')))
-    const { findByText } = render(<DockerHostsMenuContent />, { wrapper: createWrapper() })
-    expect(await findByText('Failed to load hosts')).not.toBeNull()
-  })
-
-  it('shows empty state when no hosts', async () => {
-    mockListManagedHostNames.mockImplementation(() => Promise.resolve([]))
-    const { findByText } = render(<DockerHostsMenuContent />, { wrapper: createWrapper() })
-    expect(await findByText('No hosts')).not.toBeNull()
-  })
-
   it('renders host names', async () => {
     mockListManagedHostNames.mockImplementation(() =>
       Promise.resolve(['server1', 'server2']),
@@ -293,16 +260,16 @@ describe('MenuContentFor', () => {
     expect(screen.getByText('General')).not.toBeNull()
   })
 
-  it('renders StacksMenuContent for /stacks', () => {
-    mockListStacks.mockImplementation(() => new Promise(() => {}))
-    render(<MenuContentFor to="/stacks" />, { wrapper: createWrapper() })
-    expect(screen.getByText('Loading…')).not.toBeNull()
+  it('renders StacksMenuContent for /stacks', async () => {
+    mockListStacks.mockImplementation(() => Promise.resolve([stackSummary('plex')]))
+    const { findByText } = render(<MenuContentFor to="/stacks" />, { wrapper: createWrapper() })
+    expect(await findByText('plex')).not.toBeNull()
   })
 
-  it('renders DockerHostsMenuContent for /docker', () => {
-    mockListManagedHostNames.mockImplementation(() => new Promise(() => {}))
-    render(<MenuContentFor to="/docker" />, { wrapper: createWrapper() })
-    expect(screen.getByText('Loading…')).not.toBeNull()
+  it('renders DockerHostsMenuContent for /docker', async () => {
+    mockListManagedHostNames.mockImplementation(() => Promise.resolve(['server1']))
+    const { findByText } = render(<MenuContentFor to="/docker" />, { wrapper: createWrapper() })
+    expect(await findByText('server1')).not.toBeNull()
   })
 
   it('renders nothing for an unknown route key', () => {
@@ -312,5 +279,42 @@ describe('MenuContentFor', () => {
       { wrapper: createWrapper() },
     )
     expect(container.firstChild).toBeNull()
+  })
+})
+
+describe('shouldRenderMenu', () => {
+  it('withholds the menu only from a route with nothing to list', () => {
+    expect(shouldRenderMenu(0)).toBe(false)
+    expect(shouldRenderMenu(1)).toBe(true)
+  })
+})
+
+describe('useMenuRoutes', () => {
+  function renderMenuRoutes(stacks: StackSummary[], hosts: string[]) {
+    const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    queryClient.setQueryData(STACKS_QUERY_KEY, stacks)
+    queryClient.setQueryData(MANAGED_HOST_NAMES_QUERY_KEY, hosts)
+    return renderHook(() => useMenuRoutes(), {
+      wrapper: ({ children }: { children: React.ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      ),
+    })
+  }
+
+  it('always includes /settings, whose sections are fixed', () => {
+    const { result } = renderMenuRoutes([], [])
+    expect(result.current.has('/settings')).toBe(true)
+  })
+
+  it('excludes routes with nothing to list', () => {
+    const { result } = renderMenuRoutes([], [])
+    expect(result.current.has('/stacks')).toBe(false)
+    expect(result.current.has('/docker')).toBe(false)
+  })
+
+  it('includes routes down to a single entry', () => {
+    const { result } = renderMenuRoutes([stackSummary('plex')], ['server1'])
+    expect(result.current.has('/stacks')).toBe(true)
+    expect(result.current.has('/docker')).toBe(true)
   })
 })

--- a/src/components/__tests__/header/nav-config.test.ts
+++ b/src/components/__tests__/header/nav-config.test.ts
@@ -23,7 +23,7 @@ mock.module('@/lib/constants/preload-queries', () => ({
   preloadProxmoxStats: mock(() => Promise.resolve([])),
 }))
 
-const { NAV_ITEMS, SETTINGS_SECTIONS, PREFETCH_STALE_TIME, handlePrefetch } = await import('@/components/header/nav-config')
+const { NAV_ITEMS, SETTINGS_SECTIONS, PREFETCH_STALE_TIME, handlePrefetch, menuRouteFor } = await import('@/components/header/nav-config')
 
 beforeEach(() => {
   mockPrefetchQuery.mockClear()
@@ -64,6 +64,22 @@ describe('SETTINGS_SECTIONS', () => {
       'managed-hosts',
       'developer',
     ])
+  })
+})
+
+describe('menuRouteFor', () => {
+  const byRoute = Object.fromEntries(NAV_ITEMS.map((i) => [i.to, i]))
+
+  it('returns the route when the item has a menu that earned its entries', () => {
+    expect(menuRouteFor(byRoute['/docker'], new Set(['/docker']))).toBe('/docker')
+  })
+
+  it('returns null when the route has too few entries to warrant a menu', () => {
+    expect(menuRouteFor(byRoute['/docker'], new Set())).toBeNull()
+  })
+
+  it('returns null for an item that never has a menu', () => {
+    expect(menuRouteFor(byRoute['/zfs'], new Set(['/docker', '/stacks', '/settings']))).toBeNull()
   })
 })
 

--- a/src/components/docker/ContainerModal.tsx
+++ b/src/components/docker/ContainerModal.tsx
@@ -235,8 +235,6 @@ function ModalHeader({
     />
   );
 
-  // grid-template-columns below has no minmax(0, ...), so its tracks can't shrink
-  // below content width; below lg the header stacks into rows instead.
   if (isMobile) {
     return (
       <div className="flex flex-col gap-2 px-3 py-2 border-b border-(--border) shrink-0 bg-(--popover)">

--- a/src/components/docker/ContainerPortsMounts.tsx
+++ b/src/components/docker/ContainerPortsMounts.tsx
@@ -88,8 +88,6 @@ function MountRow({ mount }: { mount: ContainerMount }) {
 
   useEffect(() => {
     if (!isTouch || !expanded) return;
-    // Mirrors IconTooltip's dismiss pattern: pointerdown precedes this row's own
-    // toggle click, so an outside tap can collapse without racing a re-expand.
     function dismissIfOutside(e: PointerEvent) {
       if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) setExpanded(false);
     }

--- a/src/components/docker/IconGrid.tsx
+++ b/src/components/docker/IconGrid.tsx
@@ -78,13 +78,6 @@ const ICON_CELL_MIN_WIDTH = 64;
 const ICON_GRID_GAP = 8;
 const ICON_ROW_HEIGHT = 76;
 
-/**
- * Number of columns the grid can fit is derived from the measured container
- * width and clamped to [ICON_MIN_COLS, ICON_MAX_COLS]. The same value drives
- * both the CSS `gridTemplateColumns` and the `iconRows` chunking below, so the
- * two can never disagree the way a hardcoded `grid-cols-7` class paired with
- * a separate constant could.
- */
 function computeIconCols(containerWidth: number): number {
   if (containerWidth <= 0) return ICON_MAX_COLS;
   const cols = Math.floor((containerWidth + ICON_GRID_GAP) / (ICON_CELL_MIN_WIDTH + ICON_GRID_GAP));

--- a/src/components/docker/IconTooltip.tsx
+++ b/src/components/docker/IconTooltip.tsx
@@ -6,7 +6,6 @@ interface IconTooltipProps {
   children: ReactNode;
 }
 
-/** Single-line label for an icon-only button. */
 export default function IconTooltip({ label, children }: Readonly<IconTooltipProps>) {
   return (
     <TapTooltip

--- a/src/components/docker/IconTooltip.tsx
+++ b/src/components/docker/IconTooltip.tsx
@@ -1,82 +1,19 @@
-import { useState, useRef, useCallback, useEffect } from 'react';
-import { createPortal } from 'react-dom';
-import { useIsTouch } from '@/hooks/useMediaQuery';
+import type { ReactNode } from 'react';
+import TapTooltip from '@/components/ui/tap-tooltip';
 
 interface IconTooltipProps {
   label: string;
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
-/**
- * Tooltip for icon-only buttons that computes position via getBoundingClientRect on
- * mouseenter and portals into document.body. MUI Tooltip (Popper.js) misplaces tooltips
- * inside DataTable rows and Dialog headers due to nested scroll container / transform context.
- */
-export default function IconTooltip({ label, children }: IconTooltipProps) {
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
-  const ref = useRef<HTMLSpanElement>(null);
-  const isTouch = useIsTouch();
-
-  const show = useCallback(() => {
-    if (!ref.current) return;
-    const r = ref.current.getBoundingClientRect();
-    setPos({ x: r.left + r.width / 2, y: r.top });
-  }, []);
-
-  const hide = useCallback(() => setPos(null), []);
-
-  const toggle = useCallback(() => {
-    if (!isTouch) return;
-    setPos((current) => {
-      if (current !== null) return null;
-      if (!ref.current) return current;
-      const r = ref.current.getBoundingClientRect();
-      return { x: r.left + r.width / 2, y: r.top };
-    });
-  }, [isTouch]);
-
-  useEffect(() => {
-    if (!isTouch || pos === null) return;
-    // pointerdown fires before the tap's own click that reopens/toggles here, so an
-    // outside tap can dismiss without racing this element's own toggle.
-    function dismissIfOutside(e: PointerEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) hide();
-    }
-    document.addEventListener('pointerdown', dismissIfOutside);
-    return () => document.removeEventListener('pointerdown', dismissIfOutside);
-  }, [isTouch, pos, hide]);
-
+/** Single-line label for an icon-only button. */
+export default function IconTooltip({ label, children }: Readonly<IconTooltipProps>) {
   return (
-    <>
-      <span
-        ref={ref}
-        onMouseEnter={() => {
-          if (!isTouch) show();
-        }}
-        onMouseLeave={() => {
-          if (!isTouch) hide();
-        }}
-        onFocus={() => {
-          if (!isTouch) show();
-        }}
-        onBlur={() => {
-          if (!isTouch) hide();
-        }}
-        onClick={toggle}
-        className="inline-flex"
-      >
-        {children}
-      </span>
-      {pos !== null && createPortal(
-        <div
-          className="fixed z-[9999] pointer-events-none -translate-x-1/2 -translate-y-[calc(100%+6px)] rounded px-2 py-1 text-xs leading-[1.4] whitespace-nowrap text-white bg-(--tooltip)/90"
-          style={{ left: pos.x, top: pos.y }}
-          role="tooltip"
-        >
-          {label}
-        </div>,
-        document.body,
-      )}
-    </>
+    <TapTooltip
+      content={label}
+      contentClassName="rounded px-2 py-1 text-xs leading-[1.4] whitespace-nowrap text-white bg-(--tooltip)/90"
+    >
+      {children}
+    </TapTooltip>
   );
 }

--- a/src/components/docker/__tests__/ContainerModal.test.tsx
+++ b/src/components/docker/__tests__/ContainerModal.test.tsx
@@ -127,8 +127,6 @@ describe('ContainerModal', () => {
   });
 });
 
-// beforeEach rather than beforeAll: a sibling test file can replace matchMedia
-// mid-run, and reinstalling per test keeps these assertions independent of order.
 function installMatchMedia(matches: (query: string) => boolean) {
   const originalMatchMedia = window.matchMedia;
 

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -99,8 +99,6 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
                       if (isTouch) return
                       if (menuRoute) controller.requestClose()
                     }}
-                    // A touch device never fires the hover that opens these menus, so
-                    // the tap that navigates to the route opens the menu as well.
                     onClick={() => {
                       if (!isTouch) return
                       handlePrefetch(item.to)
@@ -137,8 +135,6 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
           <Popover.Root
             key={item.to}
             open={controller.openId === item.to && Boolean(anchor)}
-            // Without this the popup has no way to close on an outside press,
-            // which is the only dismissal gesture a touch device has here.
             onOpenChange={(next) => { if (!next) controller.closeNow() }}
             modal={false}
           >

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -7,7 +7,9 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { IS_DEMO_MODE } from '@/lib/constants/demo'
 import type { AuthUser } from '@/lib/auth/types'
 import {
+  HEADER_INSET_CLASSES,
   NAV_ITEMS,
+  NAV_ROW_CLASSES,
   type RouteKey,
   type MenuRouteKey,
   type MenuNavItem,
@@ -54,12 +56,12 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
   }, [])
 
   return (
-    <header className="sticky top-0 z-50 px-2 pt-[max(0.75rem,env(safe-area-inset-top))] pb-2 pointer-events-none sm:px-4">
+    <header className={`sticky top-0 z-50 pointer-events-none ${HEADER_INSET_CLASSES}`}>
       {/* Fixed height, not padding: a 44px touch target and a 36px tab trigger
           would otherwise give the bar a different height per breakpoint. */}
       <nav
         aria-label="Main navigation"
-        className="flex h-12 items-center min-w-0 rounded-2xl px-1.5 pointer-events-auto backdrop-blur-xl bg-card/75 border border-border/30 shadow-[0_8px_32px_rgba(0,0,0,0.1)] sm:px-3"
+        className={`${NAV_ROW_CLASSES} pointer-events-auto backdrop-blur-xl bg-card/75 border-border/30 shadow-[0_8px_32px_rgba(0,0,0,0.1)]`}
       >
         {isCompactNav ? (
           <MobileNav />
@@ -123,7 +125,7 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
           </Tabs>
         )}
 
-        <div className="ml-auto shrink-0 pl-2 border-l border-border/30 flex items-center gap-1 sm:pl-3">
+        <div className="ml-auto shrink-0 pl-3 border-l border-border/30 flex items-center gap-1">
           {!IS_DEMO_MODE && user && <AccountMenu />}
           <ModeToggle />
         </div>

--- a/src/components/header/Header.tsx
+++ b/src/components/header/Header.tsx
@@ -10,10 +10,12 @@ import {
   NAV_ITEMS,
   type RouteKey,
   type MenuRouteKey,
+  type MenuNavItem,
   handlePrefetch,
+  menuRouteFor,
 } from '@/components/header/nav-config'
 import { useCurrentTab, useMenuController } from '@/components/header/useMenuController'
-import { AccountMenu, MenuContentFor, NavMenuCloseContext } from '@/components/header/menus'
+import { AccountMenu, MenuContentFor, NavMenuCloseContext, useMenuRoutes } from '@/components/header/menus'
 import { DemoBanner } from '@/components/header/DemoBanner'
 import MobileNav from '@/components/header/MobileNav'
 import { useIsCompactNav, useIsTouch } from '@/hooks/useMediaQuery'
@@ -29,6 +31,7 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
   const controller = useMenuController()
   const isCompactNav = useIsCompactNav()
   const isTouch = useIsTouch()
+  const menuRoutes = useMenuRoutes()
   const [anchors, setAnchors] = useState<Partial<Record<MenuRouteKey, HTMLElement>>>({})
 
   // One stable setter per route, so React never re-runs a ref callback just
@@ -51,10 +54,12 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
   }, [])
 
   return (
-    <header className="sticky top-0 z-50 px-2 pt-[max(0.5rem,env(safe-area-inset-top))] pb-2 pointer-events-none sm:px-4 sm:pt-3">
+    <header className="sticky top-0 z-50 px-2 pt-[max(0.75rem,env(safe-area-inset-top))] pb-2 pointer-events-none sm:px-4">
+      {/* Fixed height, not padding: a 44px touch target and a 36px tab trigger
+          would otherwise give the bar a different height per breakpoint. */}
       <nav
         aria-label="Main navigation"
-        className="flex items-center min-w-0 rounded-2xl px-1.5 py-1 pointer-events-auto backdrop-blur-xl bg-card/75 border border-border/30 shadow-[0_8px_32px_rgba(0,0,0,0.1)] sm:px-3"
+        className="flex h-12 items-center min-w-0 rounded-2xl px-1.5 pointer-events-auto backdrop-blur-xl bg-card/75 border border-border/30 shadow-[0_8px_32px_rgba(0,0,0,0.1)] sm:px-3"
       >
         {isCompactNav ? (
           <MobileNav />
@@ -63,6 +68,7 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
             <TabsList aria-label="Main navigation">
               {NAV_ITEMS.map((item) => {
                 const { Icon } = item
+                const menuRoute = menuRouteFor(item, menuRoutes)
                 return (
                   <TabsTrigger
                     key={item.to}
@@ -70,36 +76,36 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
                     ref={refSetters[item.to as MenuRouteKey]}
                     nativeButton={false}
                     render={<Link to={item.to} />}
-                    aria-haspopup={item.hasMenu ? 'menu' : undefined}
-                    aria-expanded={item.hasMenu ? controller.openId === item.to : undefined}
-                    aria-controls={item.hasMenu ? `nav-menu-${item.to.slice(1)}` : undefined}
+                    aria-haspopup={menuRoute ? 'menu' : undefined}
+                    aria-expanded={menuRoute ? controller.openId === menuRoute : undefined}
+                    aria-controls={menuRoute ? `nav-menu-${menuRoute.slice(1)}` : undefined}
                     onMouseEnter={() => {
                       if (isTouch) return
                       handlePrefetch(item.to)
-                      if (item.hasMenu) controller.requestOpen(item.to)
+                      if (menuRoute) controller.requestOpen(menuRoute)
                     }}
                     onMouseLeave={() => {
                       if (isTouch) return
-                      if (item.hasMenu) controller.requestClose()
+                      if (menuRoute) controller.requestClose()
                     }}
                     onFocus={() => {
                       if (isTouch) return
                       handlePrefetch(item.to)
-                      if (item.hasMenu) controller.requestOpen(item.to)
+                      if (menuRoute) controller.requestOpen(menuRoute)
                     }}
                     onBlur={() => {
                       if (isTouch) return
-                      if (item.hasMenu) controller.requestClose()
+                      if (menuRoute) controller.requestClose()
                     }}
                     // A touch device never fires the hover that opens these menus, so
                     // the tap that navigates to the route opens the menu as well.
                     onClick={() => {
                       if (!isTouch) return
                       handlePrefetch(item.to)
-                      if (item.hasMenu) controller.requestOpen(item.to)
+                      if (menuRoute) controller.requestOpen(menuRoute)
                     }}
                     onKeyDown={(e: React.KeyboardEvent) => {
-                      if (e.key === 'Escape' && item.hasMenu) controller.closeNow()
+                      if (e.key === 'Escape' && menuRoute) controller.closeNow()
                     }}
                     className="py-2 uppercase"
                   >
@@ -108,7 +114,7 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
                       : <Icon size={18} />}
                     <span className="inline-flex items-center gap-1 ml-1.5">
                       {item.label}
-                      {item.hasMenu && <ChevronDown size={14} className="opacity-60" />}
+                      {menuRoute && <ChevronDown size={14} className="opacity-60" />}
                     </span>
                   </TabsTrigger>
                 )
@@ -123,7 +129,7 @@ export default function Header({ user }: Readonly<{ user?: AuthUser | null }>) {
         </div>
       </nav>
 
-      {!isCompactNav && NAV_ITEMS.filter((i) => i.hasMenu).map((item) => {
+      {!isCompactNav && NAV_ITEMS.filter((i): i is MenuNavItem => i.hasMenu && menuRoutes.has(i.to)).map((item) => {
         const anchor = anchors[item.to]
         return (
           <Popover.Root

--- a/src/components/header/MobileNav.tsx
+++ b/src/components/header/MobileNav.tsx
@@ -115,11 +115,7 @@ function MobileNavItem({
   )
 }
 
-/**
- * Header navigation below the `md` breakpoint. The desktop tab bar opens its
- * submenus on hover, which a touch device can never trigger, so the drawer
- * turns each one into a tap-expandable section instead.
- */
+/** Header navigation below the `md` breakpoint, not the `lg` one the rest of the mobile layout uses. */
 export default function MobileNav() {
   const [open, setOpen] = useState(false)
   const currentTab = useCurrentTab()

--- a/src/components/header/MobileNav.tsx
+++ b/src/components/header/MobileNav.tsx
@@ -10,10 +10,15 @@ import {
   SheetTitle,
 } from '@/components/ui/sheet'
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible'
-import { NAV_ITEMS, handlePrefetch } from '@/components/header/nav-config'
+import { NAV_ITEMS, handlePrefetch, menuRouteFor } from '@/components/header/nav-config'
 import type { MenuRouteKey, NavItem } from '@/components/header/nav-config'
 import { useCurrentTab } from '@/components/header/useMenuController'
-import { MenuContentFor, NavMenuCloseContext } from '@/components/header/menus'
+import {
+  MENU_ITEM_CLASSES,
+  MenuContentFor,
+  NavMenuCloseContext,
+  useMenuRoutes,
+} from '@/components/header/menus'
 
 const NAV_LINK_CLASSES =
   'flex flex-1 items-center gap-3 min-h-12 px-4 text-sm font-medium uppercase ' +
@@ -21,48 +26,76 @@ const NAV_LINK_CLASSES =
 
 function MobileNavItem({
   item,
+  menuRoute,
   isCurrent,
   onNavigate,
-}: Readonly<{ item: NavItem; isCurrent: boolean; onNavigate: () => void }>) {
-  const [expanded, setExpanded] = useState(isCurrent && item.hasMenu)
+  onExpand,
+}: Readonly<{
+  item: NavItem
+  menuRoute: MenuRouteKey | null
+  isCurrent: boolean
+  onNavigate: () => void
+  onExpand: () => void
+}>) {
+  const [expanded, setExpanded] = useState(isCurrent && menuRoute !== null)
   const { Icon } = item
+
+  const toggle = () => {
+    setExpanded((prev) => {
+      if (!prev) onExpand()
+      return !prev
+    })
+  }
 
   return (
     <div className="border-b border-border/30 last:border-b-0">
-      <div
-        className={`flex items-center ${isCurrent ? 'bg-accent text-primary' : ''}`}
-      >
-        <Link
-          to={item.to}
-          className={NAV_LINK_CLASSES}
-          onClick={onNavigate}
-          aria-current={isCurrent ? 'page' : undefined}
-        >
-          <Icon size={20} />
-          <span>{item.label}</span>
-        </Link>
-        {item.hasMenu && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="mr-2 size-11 text-foreground"
+      <div className={`flex items-center ${isCurrent ? 'bg-accent text-primary' : ''}`}>
+        {menuRoute ? (
+          <button
+            type="button"
+            className={`${NAV_LINK_CLASSES} justify-between pr-3 cursor-pointer`}
             aria-expanded={expanded}
-            aria-label={`${expanded ? 'Collapse' : 'Expand'} ${item.label} menu`}
-            onClick={() => setExpanded((prev) => !prev)}
+            aria-current={isCurrent ? 'page' : undefined}
+            onClick={toggle}
           >
+            <span className="flex items-center gap-3">
+              <Icon size={20} />
+              <span>{item.label}</span>
+            </span>
             <ChevronDown
               size={18}
               className={`transition-transform duration-150 ${expanded ? 'rotate-180' : ''}`}
             />
-          </Button>
+          </button>
+        ) : (
+          <Link
+            to={item.to}
+            className={NAV_LINK_CLASSES}
+            onClick={onNavigate}
+            aria-current={isCurrent ? 'page' : undefined}
+          >
+            <Icon size={20} />
+            <span>{item.label}</span>
+          </Link>
         )}
       </div>
-      {item.hasMenu && (
+      {menuRoute && (
         <Collapsible open={expanded}>
           <CollapsibleContent>
             <div className="bg-level1 pl-4" role="menu">
               <NavMenuCloseContext value={onNavigate}>
-                <MenuContentFor to={item.to as MenuRouteKey} />
+                {item.hasMenu && item.selfEntryLabel && (
+                  <Link
+                    to={item.to}
+                    className={MENU_ITEM_CLASSES}
+                    onClick={onNavigate}
+                    role="menuitem"
+                  >
+                    <Icon size={14} />
+                    <span>{item.selfEntryLabel}</span>
+                  </Link>
+                )}
+                <MenuContentFor to={menuRoute} />
               </NavMenuCloseContext>
             </div>
           </CollapsibleContent>
@@ -80,6 +113,7 @@ function MobileNavItem({
 export default function MobileNav() {
   const [open, setOpen] = useState(false)
   const currentTab = useCurrentTab()
+  const menuRoutes = useMenuRoutes()
   const pathname = useLocation({ select: (l) => l.pathname })
 
   useEffect(() => {
@@ -100,7 +134,11 @@ export default function MobileNav() {
       >
         <Menu size={22} />
       </Button>
-      <span className="ml-1 truncate text-sm font-semibold uppercase tracking-[0.02857em]">
+      <span
+        className={`ml-1 truncate text-sm font-medium uppercase tracking-[0.02857em] ${
+          currentLabel ? 'text-primary' : 'text-muted-foreground'
+        }`}
+      >
         {currentLabel ?? 'Homelab Manager'}
       </span>
 
@@ -115,11 +153,13 @@ export default function MobileNav() {
                 <MobileNavItem
                   key={item.to}
                   item={item}
+                  menuRoute={menuRouteFor(item, menuRoutes)}
                   isCurrent={currentTab === item.to}
                   onNavigate={() => {
                     handlePrefetch(item.to)
                     setOpen(false)
                   }}
+                  onExpand={() => handlePrefetch(item.to)}
                 />
               ))}
             </nav>

--- a/src/components/header/MobileNav.tsx
+++ b/src/components/header/MobileNav.tsx
@@ -5,12 +5,18 @@ import { Button } from '@/components/ui/button'
 import {
   Sheet,
   SheetBody,
+  SheetClose,
   SheetContent,
-  SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet'
 import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible'
-import { NAV_ITEMS, handlePrefetch, menuRouteFor } from '@/components/header/nav-config'
+import {
+  HEADER_INSET_CLASSES,
+  NAV_ITEMS,
+  NAV_ROW_CLASSES,
+  handlePrefetch,
+  menuRouteFor,
+} from '@/components/header/nav-config'
 import type { MenuRouteKey, NavItem } from '@/components/header/nav-config'
 import { useCurrentTab } from '@/components/header/useMenuController'
 import {
@@ -23,6 +29,10 @@ import {
 const NAV_LINK_CLASSES =
   'flex flex-1 items-center gap-3 min-h-12 px-4 text-sm font-medium uppercase ' +
   'tracking-[0.02857em] no-underline text-inherit'
+
+const routeLabelClasses = (hasRoute: boolean) =>
+  'ml-1 truncate text-sm font-medium uppercase tracking-[0.02857em] ' +
+  (hasRoute ? 'text-foreground' : 'text-muted-foreground')
 
 function MobileNavItem({
   item,
@@ -134,19 +144,32 @@ export default function MobileNav() {
       >
         <Menu size={22} />
       </Button>
-      <span
-        className={`ml-1 truncate text-sm font-medium uppercase tracking-[0.02857em] ${
-          currentLabel ? 'text-primary' : 'text-muted-foreground'
-        }`}
-      >
+      <span className={routeLabelClasses(Boolean(currentLabel))}>
         {currentLabel ?? 'Homelab Manager'}
       </span>
 
       <Sheet open={open} onOpenChange={setOpen}>
-        <SheetContent side="left" aria-label="Main navigation">
-          <SheetHeader>
-            <SheetTitle>Homelab Manager</SheetTitle>
-          </SheetHeader>
+        <SheetContent side="left" className="border-r-0 shadow-none">
+          <SheetTitle className="sr-only">Main navigation</SheetTitle>
+          <div className={HEADER_INSET_CLASSES}>
+            <div className={`${NAV_ROW_CLASSES} border-transparent`}>
+              <SheetClose
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-11 text-foreground"
+                    aria-label="Close navigation menu"
+                  />
+                }
+              >
+                <Menu size={22} />
+              </SheetClose>
+              <span aria-hidden className={routeLabelClasses(Boolean(currentLabel))}>
+                {currentLabel ?? 'Homelab Manager'}
+              </span>
+            </div>
+          </div>
           <SheetBody>
             <nav aria-label="Main navigation">
               {NAV_ITEMS.map((item) => (

--- a/src/components/header/menus.tsx
+++ b/src/components/header/menus.tsx
@@ -4,7 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 import { LogOut, Server, CircleUser } from 'lucide-react'
 import { Popover } from '@base-ui/react/popover'
 import { Button } from '@/components/ui/button'
-import { STACKS_QUERY_KEY } from '@/lib/constants/stacks-keys'
+import { MANAGED_HOST_NAMES_QUERY_KEY, STACKS_QUERY_KEY } from '@/lib/constants/stacks-keys'
 import { listManagedHostNames, listStacks } from '@/data/stacks/functions'
 import { getIconUrl } from '@/lib/utils/icon-resolver'
 import { SETTINGS_SECTIONS } from '@/components/header/nav-config'
@@ -12,9 +12,45 @@ import type { MenuRouteKey } from '@/components/header/nav-config'
 
 export const NavMenuCloseContext = createContext<() => void>(() => {})
 
-const MENU_ITEM_CLASSES =
+export const MENU_ITEM_CLASSES =
   'flex items-center gap-2 min-h-11 px-3 py-2 text-sm no-underline text-inherit ' +
   'hover:bg-accent transition-colors'
+
+function useStackSummaries() {
+  return useQuery({
+    queryKey: STACKS_QUERY_KEY,
+    queryFn: () => listStacks(),
+    staleTime: 30_000,
+  })
+}
+
+function useDockerHostNames() {
+  return useQuery({
+    queryKey: MANAGED_HOST_NAMES_QUERY_KEY,
+    queryFn: () => listManagedHostNames(),
+    staleTime: 60_000,
+  })
+}
+
+export function shouldRenderMenu(entryCount: number): boolean {
+  return entryCount > 0
+}
+
+/**
+ * Which nav routes get a dropdown. Menu content renders only for routes in this
+ * set, so the content components below never see an empty entry list, and a row
+ * with nothing to list stays a plain link instead of expanding into nothing.
+ */
+export function useMenuRoutes(): ReadonlySet<MenuRouteKey> {
+  const { data: stacks } = useStackSummaries()
+  const { data: hosts } = useDockerHostNames()
+
+  const routes = new Set<MenuRouteKey>()
+  if (shouldRenderMenu(hosts?.length ?? 0)) routes.add('/docker')
+  if (shouldRenderMenu(stacks?.length ?? 0)) routes.add('/stacks')
+  if (shouldRenderMenu(SETTINGS_SECTIONS.length)) routes.add('/settings')
+  return routes
+}
 
 export function SettingsMenuContent() {
   const close = useContext(NavMenuCloseContext)
@@ -42,23 +78,9 @@ export function SettingsMenuContent() {
 
 export function StacksMenuContent() {
   const close = useContext(NavMenuCloseContext)
-  const { data: stacks, isLoading, isError } = useQuery({
-    queryKey: STACKS_QUERY_KEY,
-    queryFn: () => listStacks(),
-    staleTime: 30_000,
-  })
+  const { data: stacks } = useStackSummaries()
 
-  if (isLoading) {
-    return <div className="px-3 py-2 text-sm opacity-60">Loading…</div>
-  }
-  if (isError) {
-    return <div className="px-3 py-2 text-sm text-destructive">Failed to load stacks</div>
-  }
-  if (!stacks?.length) {
-    return <div className="px-3 py-2 text-sm opacity-60">No stacks</div>
-  }
-
-  const sorted = [...stacks].sort((a, b) => a.name.localeCompare(b.name))
+  const sorted = [...(stacks ?? [])].sort((a, b) => a.name.localeCompare(b.name))
 
   return (
     <div className="max-h-[60vh] overflow-y-auto themed-scrollbar" role="none">
@@ -91,25 +113,11 @@ export function StacksMenuContent() {
 
 export function DockerHostsMenuContent() {
   const close = useContext(NavMenuCloseContext)
-  const { data: hosts, isLoading, isError } = useQuery({
-    queryKey: ['managed-host-names'],
-    queryFn: () => listManagedHostNames(),
-    staleTime: 60_000,
-  })
-
-  if (isLoading) {
-    return <div className="px-3 py-2 text-sm opacity-60">Loading…</div>
-  }
-  if (isError) {
-    return <div className="px-3 py-2 text-sm text-destructive">Failed to load hosts</div>
-  }
-  if (!hosts?.length) {
-    return <div className="px-3 py-2 text-sm opacity-60">No hosts</div>
-  }
+  const { data: hosts } = useDockerHostNames()
 
   return (
     <div role="none">
-      {hosts.map((host) => (
+      {(hosts ?? []).map((host) => (
         <Link
           key={host}
           to="/docker"

--- a/src/components/header/menus.tsx
+++ b/src/components/header/menus.tsx
@@ -36,11 +36,7 @@ export function shouldRenderMenu(entryCount: number): boolean {
   return entryCount > 0
 }
 
-/**
- * Which nav routes get a dropdown. Menu content renders only for routes in this
- * set, so the content components below never see an empty entry list, and a row
- * with nothing to list stays a plain link instead of expanding into nothing.
- */
+/** A route absent from this set stays a plain link, so menu content never renders an empty list. */
 export function useMenuRoutes(): ReadonlySet<MenuRouteKey> {
   const { data: stacks } = useStackSummaries()
   const { data: hosts } = useDockerHostNames()

--- a/src/components/header/nav-config.ts
+++ b/src/components/header/nav-config.ts
@@ -12,8 +12,7 @@ import type { SettingsSectionId } from '@/lib/constants/settings-sections'
 
 export type { SettingsSectionId }
 
-// The drawer header reproduces this box structure so its hamburger lands on the bar's
-// by construction; copying the resulting coordinates would desync on the next change.
+// Shared with the drawer header so its hamburger lands on the same spot as the bar's.
 export const HEADER_INSET_CLASSES =
   'px-4 pt-[max(0.75rem,env(safe-area-inset-top))] pb-2'
 
@@ -36,9 +35,8 @@ export type MenuNavItem = {
   Icon: React.ComponentType<IconProps>
   hasMenu: true
   /**
-   * Drawer-only row pointing at the route itself. Needed only where the menu
-   * entries navigate somewhere else; Docker and Settings entries are anchors on
-   * the parent page, so any of them already lands there.
+   * Drawer-only row pointing at the route itself. Set it only where the menu entries
+   * navigate elsewhere: Docker and Settings entries are anchors on the parent page.
    */
   selfEntryLabel?: string
 }

--- a/src/components/header/nav-config.ts
+++ b/src/components/header/nav-config.ts
@@ -12,6 +12,14 @@ import type { SettingsSectionId } from '@/lib/constants/settings-sections'
 
 export type { SettingsSectionId }
 
+// The drawer header reproduces this box structure so its hamburger lands on the bar's
+// by construction; copying the resulting coordinates would desync on the next change.
+export const HEADER_INSET_CLASSES =
+  'px-4 pt-[max(0.75rem,env(safe-area-inset-top))] pb-2'
+
+export const NAV_ROW_CLASSES =
+  'flex h-12 items-center min-w-0 rounded-2xl px-3 border'
+
 export type MenuRouteKey = '/docker' | '/stacks' | '/settings'
 export type RouteKey = MenuRouteKey | '/zfs' | '/proxmox'
 

--- a/src/components/header/nav-config.ts
+++ b/src/components/header/nav-config.ts
@@ -27,13 +27,26 @@ export type MenuNavItem = {
   label: string
   Icon: React.ComponentType<IconProps>
   hasMenu: true
+  /**
+   * Drawer-only row pointing at the route itself. Needed only where the menu
+   * entries navigate somewhere else; Docker and Settings entries are anchors on
+   * the parent page, so any of them already lands there.
+   */
+  selfEntryLabel?: string
 }
 
 export type NavItem = NoMenuNavItem | MenuNavItem
 
+export function menuRouteFor(
+  item: NavItem,
+  menuRoutes: ReadonlySet<MenuRouteKey>,
+): MenuRouteKey | null {
+  return item.hasMenu && menuRoutes.has(item.to) ? item.to : null
+}
+
 export const NAV_ITEMS: readonly NavItem[] = [
   { to: '/docker', label: 'Docker', Icon: DockerIcon, hasMenu: true },
-  { to: '/stacks', label: 'Stacks', Icon: Layers, hasMenu: true },
+  { to: '/stacks', label: 'Stacks', Icon: Layers, hasMenu: true, selfEntryLabel: 'All stacks' },
   { to: '/zfs', label: 'ZFS', Icon: HardDrive, hasMenu: false },
   { to: '/proxmox', label: 'Proxmox', Icon: ProxmoxIcon, hasMenu: false },
   { to: '/settings', label: 'Settings', Icon: SettingsIcon, hasMenu: true },

--- a/src/components/proxmox/GuestSection.tsx
+++ b/src/components/proxmox/GuestSection.tsx
@@ -37,6 +37,8 @@ function buildColumns(showSparklines: boolean, useAbbreviatedUnits: boolean): Co
       id: 'status',
       getValue: (row) => row.status,
       getColor: (row) => (row.status === 'running' ? 'success' : 'default'),
+      size: 100,
+      mobileFlex: 'minmax(60px, 0.7fr)',
     }),
     metricColumn<GuestRow>({
       id: 'cpu',

--- a/src/components/proxmox/ProxmoxHostView.tsx
+++ b/src/components/proxmox/ProxmoxHostView.tsx
@@ -90,20 +90,22 @@ export default function ProxmoxHostView({ overview }: Readonly<ProxmoxHostViewPr
               aria-controls={`proxmox-host-panel-${node.node}`}
               onClick={() => toggleProxmoxHostExpanded(node.node)}
               onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleProxmoxHostExpanded(node.node); } }}
-              className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer transition-colors duration-150 ${
+              className={`flex flex-wrap items-center gap-x-3 gap-y-1.5 px-4 py-2.5 cursor-pointer transition-colors duration-150 ${
                 nodeIdx > 0 ? 'border-t border-(--border)' : ''
               } ${hostExpanded ? 'bg-(--accent)' : 'bg-(--level2)'}`}
             >
-              <ChevronRight
-                size={18}
-                className={`transition-transform duration-200 shrink-0 ${hostExpanded ? 'rotate-90' : ''}`}
-              />
-              <Server size={18} className="shrink-0" />
-              <span className="font-bold">{node.node}</span>
-              <Badge variant={node.status === 'online' ? 'success' : 'destructive'}>
-                {node.status}
-              </Badge>
-              <div className="ml-auto flex items-center gap-4 text-sm tabular-nums">
+              <div className="flex items-center gap-3 min-w-0">
+                <ChevronRight
+                  size={18}
+                  className={`transition-transform duration-200 shrink-0 ${hostExpanded ? 'rotate-90' : ''}`}
+                />
+                <Server size={18} className="shrink-0" />
+                <span className="font-bold truncate">{node.node}</span>
+                <Badge variant={node.status === 'online' ? 'success' : 'destructive'}>
+                  {node.status}
+                </Badge>
+              </div>
+              <div className="ml-auto flex flex-wrap items-center gap-x-4 gap-y-1 text-sm tabular-nums">
                 <span>CPU: {cpuPercent}%</span>
                 <span>Mem: {memPercent}%</span>
                 <span>Disk: {diskPercent}%</span>

--- a/src/components/proxmox/ProxmoxIntervalToggle.tsx
+++ b/src/components/proxmox/ProxmoxIntervalToggle.tsx
@@ -1,8 +1,67 @@
+import { useEffect, useRef, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
 import { Zap, Waves } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useIsTouch } from '@/hooks/useMediaQuery'
 import type { ProxmoxUpdateInterval } from '@/hooks/useSettings'
+
+/**
+ * Base UI's Tooltip only opens for mouse/pen pointer types, so a tap on a touch
+ * device never reveals it. Controlling Root's `open` prop from a tap does not
+ * open the popup either: Root only shows content for the trigger it tracked
+ * through its own hover/focus/press interactions. So touch gets an entirely
+ * separate, manually positioned popup (mirroring ui/tap-tooltip's approach)
+ * instead of trying to drive Root's controlled `open`. It can't reuse
+ * ui/tap-tooltip directly: that wraps its trigger in a span, and
+ * ToggleGroupItem's rounded-corner classes are first/last-child selectors
+ * that depend on staying a direct DOM sibling of the other item.
+ */
+function useTapPopup() {
+  const isTouch = useIsTouch()
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    const el = triggerRef.current
+    if (!el || !isTouch) return
+    const handleClick = () => {
+      setPos((current) => {
+        if (current !== null) return null
+        const r = el.getBoundingClientRect()
+        return { x: r.left + r.width / 2, y: r.top }
+      })
+    }
+    el.addEventListener('click', handleClick)
+    return () => el.removeEventListener('click', handleClick)
+  }, [isTouch])
+
+  useEffect(() => {
+    if (!isTouch || pos === null) return
+    function dismissIfOutside(e: PointerEvent) {
+      if (triggerRef.current && !triggerRef.current.contains(e.target as Node)) setPos(null)
+    }
+    document.addEventListener('pointerdown', dismissIfOutside)
+    return () => document.removeEventListener('pointerdown', dismissIfOutside)
+  }, [isTouch, pos])
+
+  return { triggerRef, pos }
+}
+
+function TapPopup({ pos, children }: Readonly<{ pos: { x: number; y: number } | null; children: ReactNode }>) {
+  if (pos === null) return null
+  return createPortal(
+    <div
+      className="fixed z-[9999] -translate-x-1/2 -translate-y-[calc(100%+6px)] rounded-lg px-2 py-1 bg-tooltip/92 text-tooltip-foreground max-w-75 break-words"
+      style={{ left: pos.x, top: pos.y }}
+      role="tooltip"
+    >
+      {children}
+    </div>,
+    document.body,
+  )
+}
 
 export function IntervalToggle({
   interval,
@@ -11,41 +70,51 @@ export function IntervalToggle({
   interval: ProxmoxUpdateInterval
   onIntervalChange: (interval: ProxmoxUpdateInterval) => void
 }) {
+  const fastPopup = useTapPopup()
+  const relaxedPopup = useTapPopup()
+
+  const fastContent = (
+    <div className="flex flex-col gap-1">
+      <p className="text-sm">Fast updates (1 second)</p>
+      <Badge variant="warning">Increases API load on Proxmox</Badge>
+    </div>
+  )
+  const relaxedContent = (
+    <div className="flex flex-col gap-1">
+      <p className="text-sm">Relaxed updates (10 seconds)</p>
+      <Badge variant="success">Recommended for most users</Badge>
+    </div>
+  )
+
   return (
-    <ToggleGroup
-      value={[String(interval)]}
-      onValueChange={(groupValue) => {
-        const newValue = groupValue[0]
-        if (newValue !== undefined) onIntervalChange(Number(newValue) as ProxmoxUpdateInterval)
-      }}
-      aria-label="Update interval"
-    >
-      <Tooltip>
-        <TooltipTrigger
-          render={<ToggleGroupItem value="1000" aria-label="1 second (fast)" />}
-        >
-          <Zap size={16} />
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <div className="flex flex-col gap-1">
-            <p className="text-sm">Fast updates (1 second)</p>
-            <Badge variant="warning">Increases API load on Proxmox</Badge>
-          </div>
-        </TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger
-          render={<ToggleGroupItem value="10000" aria-label="10 seconds (relaxed)" />}
-        >
-          <Waves size={16} />
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <div className="flex flex-col gap-1">
-            <p className="text-sm">Relaxed updates (10 seconds)</p>
-            <Badge variant="success">Recommended for most users</Badge>
-          </div>
-        </TooltipContent>
-      </Tooltip>
-    </ToggleGroup>
+    <>
+      <ToggleGroup
+        value={[String(interval)]}
+        onValueChange={(groupValue) => {
+          const newValue = groupValue[0]
+          if (newValue !== undefined) onIntervalChange(Number(newValue) as ProxmoxUpdateInterval)
+        }}
+        aria-label="Update interval"
+      >
+        <Tooltip>
+          <TooltipTrigger
+            render={<ToggleGroupItem ref={fastPopup.triggerRef} value="1000" aria-label="1 second (fast)" />}
+          >
+            <Zap size={16} />
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{fastContent}</TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger
+            render={<ToggleGroupItem ref={relaxedPopup.triggerRef} value="10000" aria-label="10 seconds (relaxed)" />}
+          >
+            <Waves size={16} />
+          </TooltipTrigger>
+          <TooltipContent side="bottom">{relaxedContent}</TooltipContent>
+        </Tooltip>
+      </ToggleGroup>
+      <TapPopup pos={fastPopup.pos}>{fastContent}</TapPopup>
+      <TapPopup pos={relaxedPopup.pos}>{relaxedContent}</TapPopup>
+    </>
   )
 }

--- a/src/components/proxmox/ProxmoxIntervalToggle.tsx
+++ b/src/components/proxmox/ProxmoxIntervalToggle.tsx
@@ -8,15 +8,9 @@ import { useIsTouch } from '@/hooks/useMediaQuery'
 import type { ProxmoxUpdateInterval } from '@/hooks/useSettings'
 
 /**
- * Base UI's Tooltip only opens for mouse/pen pointer types, so a tap on a touch
- * device never reveals it. Controlling Root's `open` prop from a tap does not
- * open the popup either: Root only shows content for the trigger it tracked
- * through its own hover/focus/press interactions. So touch gets an entirely
- * separate, manually positioned popup (mirroring ui/tap-tooltip's approach)
- * instead of trying to drive Root's controlled `open`. It can't reuse
- * ui/tap-tooltip directly: that wraps its trigger in a span, and
- * ToggleGroupItem's rounded-corner classes are first/last-child selectors
- * that depend on staying a direct DOM sibling of the other item.
+ * Touch popup mirroring ui/tap-tooltip, which this cannot reuse directly: it wraps its
+ * trigger in a span, and ToggleGroupItem's rounded-corner classes are first/last-child
+ * selectors that need it to stay a direct sibling of the other item.
  */
 function useTapPopup() {
   const isTouch = useIsTouch()

--- a/src/components/proxmox/ProxmoxIntervalToggle.tsx
+++ b/src/components/proxmox/ProxmoxIntervalToggle.tsx
@@ -47,7 +47,7 @@ function TapPopup({ pos, children }: Readonly<{ pos: { x: number; y: number } | 
   if (pos === null) return null
   return createPortal(
     <div
-      className="fixed z-[9999] -translate-x-1/2 -translate-y-[calc(100%+6px)] rounded-lg px-2 py-1 bg-tooltip/92 text-tooltip-foreground max-w-75 break-words"
+      className="fixed z-[9999] pointer-events-none -translate-x-1/2 -translate-y-[calc(100%+6px)] rounded-lg px-2 py-1 bg-tooltip/92 text-tooltip-foreground max-w-75 break-words"
       style={{ left: pos.x, top: pos.y }}
       role="tooltip"
     >
@@ -60,10 +60,10 @@ function TapPopup({ pos, children }: Readonly<{ pos: { x: number; y: number } | 
 export function IntervalToggle({
   interval,
   onIntervalChange
-}: {
+}: Readonly<{
   interval: ProxmoxUpdateInterval
   onIntervalChange: (interval: ProxmoxUpdateInterval) => void
-}) {
+}>) {
   const fastPopup = useTapPopup()
   const relaxedPopup = useTapPopup()
 

--- a/src/components/proxmox/ProxmoxUpdateIndicator.tsx
+++ b/src/components/proxmox/ProxmoxUpdateIndicator.tsx
@@ -45,7 +45,7 @@ export function UpdateIndicator({ expectedInterval }: { expectedInterval: number
     : 'No data yet'
 
   return (
-    <TapTooltip content={tooltipTitle}>
+    <TapTooltip content={tooltipTitle} className="inline-flex tap-target">
       <div
         className="relative inline-flex items-center justify-center w-2 h-2"
         role="status"

--- a/src/components/proxmox/ProxmoxUpdateIndicator.tsx
+++ b/src/components/proxmox/ProxmoxUpdateIndicator.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react'
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import TapTooltip from '@/components/ui/tap-tooltip'
 import { useAtomValue } from 'jotai'
 import { proxmoxLastUpdateAtom } from '@/hooks/settingsAtom'
 
@@ -45,16 +45,12 @@ export function UpdateIndicator({ expectedInterval }: { expectedInterval: number
     : 'No data yet'
 
   return (
-    <Tooltip>
-      <TooltipTrigger
-        render={
-          <div
-            className="relative inline-flex items-center justify-center w-2 h-2"
-            role="status"
-            aria-label={tooltipTitle}
-            tabIndex={0}
-          />
-        }
+    <TapTooltip content={tooltipTitle}>
+      <div
+        className="relative inline-flex items-center justify-center w-2 h-2"
+        role="status"
+        aria-label={tooltipTitle}
+        tabIndex={0}
       >
         <div
           ref={dotRef}
@@ -64,8 +60,7 @@ export function UpdateIndicator({ expectedInterval }: { expectedInterval: number
           ref={pingRef}
           className="absolute w-2 h-2 bg-green-500 rounded-full opacity-0"
         />
-      </TooltipTrigger>
-      <TooltipContent side="bottom">{tooltipTitle}</TooltipContent>
-    </Tooltip>
+      </div>
+    </TapTooltip>
   )
 }

--- a/src/components/proxmox/StorageSection.tsx
+++ b/src/components/proxmox/StorageSection.tsx
@@ -36,6 +36,8 @@ function buildColumns(showSparklines: boolean, useAbbreviatedUnits: boolean): Co
       id: 'status',
       getValue: (row) => (row.active ? 'active' : 'inactive'),
       getColor: (row) => (row.active ? 'success' : 'default'),
+      size: 100,
+      mobileFlex: 'minmax(60px, 0.7fr)',
     }),
     metricColumn<ProxmoxStorage>({
       id: 'used',

--- a/src/components/proxmox/__tests__/GuestSection.test.tsx
+++ b/src/components/proxmox/__tests__/GuestSection.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { GuestSection } from '@/components/proxmox/GuestSection';
+import type { GuestRow } from '@/types/proxmox';
+
+function makeGuest(overrides: Partial<GuestRow> = {}): GuestRow {
+  return {
+    vmid: 100,
+    name: 'ubuntu-server',
+    status: 'running',
+    cpu: 0.2,
+    cpus: 2,
+    mem: 1_000_000_000,
+    maxmem: 4_000_000_000,
+    netin: 1000,
+    netout: 500,
+    ...overrides,
+  };
+}
+
+function mockNarrowResizeObserver(width: number) {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  let resizeCallback: ResizeObserverCallback | null = null;
+
+  globalThis.ResizeObserver = class MockResizeObserver {
+    constructor(cb: ResizeObserverCallback) {
+      resizeCallback = cb;
+    }
+    observe() {
+      if (resizeCallback) {
+        resizeCallback(
+          [{ contentRect: { width } } as unknown as ResizeObserverEntry],
+          this as unknown as ResizeObserver,
+        );
+      }
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+
+  return () => {
+    globalThis.ResizeObserver = originalResizeObserver;
+  };
+}
+
+describe('GuestSection', () => {
+  it('renders the section label with a guest count and expands to show a guest name', () => {
+    render(
+      <GuestSection
+        label="Virtual Machines"
+        guests={[makeGuest()]}
+        expanded
+        onToggle={() => {}}
+        showSparklines={false}
+        useAbbreviatedUnits={false}
+      />,
+    );
+
+    expect(screen.getByText('Virtual Machines (1)')).not.toBeNull();
+    expect(screen.getByText('ubuntu-server')).not.toBeNull();
+  });
+
+  it('gives the status column a tighter mobile track than the metric columns', () => {
+    const restore = mockNarrowResizeObserver(800);
+    try {
+      render(
+        <GuestSection
+          label="Virtual Machines"
+          guests={[makeGuest()]}
+          expanded
+          onToggle={() => {}}
+          showSparklines={false}
+          useAbbreviatedUnits={false}
+        />,
+      );
+
+      const header = document.querySelector('[data-slot="datatable-header"]') as HTMLElement;
+      expect(header.style.gridTemplateColumns).toContain('0.7fr');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/components/proxmox/__tests__/ProxmoxHostView.test.tsx
+++ b/src/components/proxmox/__tests__/ProxmoxHostView.test.tsx
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import ProxmoxHostView from '@/components/proxmox/ProxmoxHostView';
+import type { ProxmoxClusterOverview, ProxmoxNode } from '@/types/proxmox';
+
+function makeNode(overrides: Partial<ProxmoxNode> = {}): ProxmoxNode {
+  return {
+    node: 'pve1',
+    status: 'online',
+    cpu: 0.5,
+    maxcpu: 4,
+    mem: 4_000_000_000,
+    maxmem: 8_000_000_000,
+    disk: 0,
+    maxdisk: 0,
+    uptime: 3600,
+    type: 'node',
+    id: 'node/pve1',
+    ...overrides,
+  };
+}
+
+function makeOverview(overrides: Partial<ProxmoxClusterOverview> = {}): ProxmoxClusterOverview {
+  return {
+    clusterName: 'test-cluster',
+    quorate: true,
+    version: 1,
+    nodes: [],
+    vms: [],
+    containers: [],
+    storages: [],
+    totals: {
+      totalCpu: 0,
+      usedCpu: 0,
+      totalMemory: 0,
+      usedMemory: 0,
+      totalDisk: 0,
+      usedDisk: 0,
+      runningVMs: 0,
+      stoppedVMs: 0,
+      runningContainers: 0,
+      stoppedContainers: 0,
+    },
+    ...overrides,
+  };
+}
+
+describe('ProxmoxHostView', () => {
+  it('renders the node name and its CPU/Mem/Disk/uptime metrics', () => {
+    render(<ProxmoxHostView overview={makeOverview({ nodes: [makeNode()] })} />);
+
+    expect(screen.getByText('pve1')).not.toBeNull();
+    expect(screen.getByText('CPU: 50.0%')).not.toBeNull();
+    expect(screen.getByText('Mem: 50.0%')).not.toBeNull();
+  });
+
+  it('lets the accordion row wrap so the metric group can stack below the name on a narrow viewport', () => {
+    render(<ProxmoxHostView overview={makeOverview({ nodes: [makeNode()] })} />);
+
+    const row = screen.getByRole('button', { name: /pve1/ });
+    expect(row.className).toContain('flex-wrap');
+  });
+
+  it('groups the name and status badge so they can shrink independently of the metrics', () => {
+    render(<ProxmoxHostView overview={makeOverview({ nodes: [makeNode()] })} />);
+
+    const name = screen.getByText('pve1');
+    expect(name.className).toContain('truncate');
+    expect(name.parentElement?.className).toContain('min-w-0');
+  });
+
+  it('renders one row per node, sorted by name', () => {
+    render(
+      <ProxmoxHostView
+        overview={makeOverview({ nodes: [makeNode({ node: 'pve2', id: 'node/pve2' }), makeNode({ node: 'pve1' })] })}
+      />,
+    );
+
+    const rows = screen.getAllByRole('button', { name: /pve/ });
+    expect(rows.map((r) => r.textContent?.includes('pve1'))).toContain(true);
+    expect(rows.map((r) => r.textContent?.includes('pve2'))).toContain(true);
+  });
+});

--- a/src/components/proxmox/__tests__/ProxmoxIntervalToggle.test.tsx
+++ b/src/components/proxmox/__tests__/ProxmoxIntervalToggle.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { IntervalToggle } from '@/components/proxmox/ProxmoxIntervalToggle';
+
+const originalMatchMedia = window.matchMedia;
+
+function setTouch(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+describe('IntervalToggle on a mouse pointer', () => {
+  it('does not reveal the tooltip on click, leaving hover as the only way to open it', () => {
+    setTouch(false);
+    render(<IntervalToggle interval={1000} onIntervalChange={mock()} />);
+
+    const fastButton = screen.getByRole('button', { name: '1 second (fast)' });
+    fireEvent.click(fastButton);
+    expect(screen.queryByText('Fast updates (1 second)')).toBeNull();
+  });
+
+  it('still selects the interval on click', () => {
+    setTouch(false);
+    const onIntervalChange = mock();
+    render(<IntervalToggle interval={1000} onIntervalChange={onIntervalChange} />);
+
+    fireEvent.click(screen.getByRole('button', { name: '10 seconds (relaxed)' }));
+    expect(onIntervalChange).toHaveBeenCalledWith(10000);
+  });
+});
+
+describe('IntervalToggle on a touch pointer', () => {
+  it('reveals the tooltip content on tap and still selects the interval', () => {
+    setTouch(true);
+    const onIntervalChange = mock();
+    render(<IntervalToggle interval={1000} onIntervalChange={onIntervalChange} />);
+
+    expect(screen.queryByText('Relaxed updates (10 seconds)')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: '10 seconds (relaxed)' }));
+
+    expect(screen.getByText('Relaxed updates (10 seconds)')).not.toBeNull();
+    expect(screen.getByText('Recommended for most users')).not.toBeNull();
+    expect(onIntervalChange).toHaveBeenCalledWith(10000);
+  });
+
+  it('dismisses the tooltip on a second tap of the same trigger', () => {
+    setTouch(true);
+    render(<IntervalToggle interval={1000} onIntervalChange={mock()} />);
+
+    const fastButton = screen.getByRole('button', { name: '1 second (fast)' });
+    fireEvent.click(fastButton);
+    expect(screen.getByText('Fast updates (1 second)')).not.toBeNull();
+    fireEvent.click(fastButton);
+    expect(screen.queryByText('Fast updates (1 second)')).toBeNull();
+  });
+
+  it('dismisses the tooltip on a tap elsewhere', () => {
+    setTouch(true);
+    render(<IntervalToggle interval={1000} onIntervalChange={mock()} />);
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+
+    const fastButton = screen.getByRole('button', { name: '1 second (fast)' });
+    fireEvent.click(fastButton);
+    expect(screen.getByText('Fast updates (1 second)')).not.toBeNull();
+
+    fireEvent.pointerDown(outside);
+    expect(screen.queryByText('Fast updates (1 second)')).toBeNull();
+
+    outside.remove();
+  });
+
+  it('keeps the two triggers as direct siblings so rounded-corner classes still apply', () => {
+    setTouch(true);
+    render(<IntervalToggle interval={1000} onIntervalChange={mock()} />);
+
+    const fastButton = screen.getByRole('button', { name: '1 second (fast)' });
+    const relaxedButton = screen.getByRole('button', { name: '10 seconds (relaxed)' });
+    expect(fastButton.parentElement).toBe(relaxedButton.parentElement);
+  });
+});

--- a/src/components/proxmox/__tests__/ProxmoxUpdateIndicator.test.tsx
+++ b/src/components/proxmox/__tests__/ProxmoxUpdateIndicator.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
+import { UpdateIndicator } from '@/components/proxmox/ProxmoxUpdateIndicator';
+import { proxmoxLastUpdateAtom } from '@/hooks/settingsAtom';
+
+const originalMatchMedia = window.matchMedia;
+
+function setTouch(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+function renderIndicator(lastUpdate: number) {
+  const store = createStore();
+  store.set(proxmoxLastUpdateAtom, lastUpdate);
+  render(
+    <Provider store={store}>
+      <UpdateIndicator expectedInterval={1000} />
+    </Provider>,
+  );
+  return screen.getByRole('status');
+}
+
+describe('ProxmoxUpdateIndicator', () => {
+  it('exposes "No data yet" via aria-label before any update arrives', () => {
+    renderIndicator(0);
+    expect(screen.getByLabelText('No data yet')).not.toBeNull();
+  });
+
+  it('exposes the last-updated time via aria-label regardless of hover state', () => {
+    const now = Date.now();
+    const dot = renderIndicator(now);
+    const expected = `Last updated: ${new Date(now).toLocaleTimeString()}`;
+    expect(dot.getAttribute('aria-label')).toBe(expected);
+  });
+
+  it('reveals the tooltip on tap when the primary input is touch', () => {
+    setTouch(true);
+    const dot = renderIndicator(0);
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    fireEvent.click(dot);
+    expect(screen.getByRole('tooltip').textContent).toBe('No data yet');
+  });
+
+  it('reveals the tooltip on hover when the primary input is a mouse', () => {
+    setTouch(false);
+    const dot = renderIndicator(0);
+
+    fireEvent.mouseEnter(dot.parentElement as HTMLElement);
+    expect(screen.getByRole('tooltip').textContent).toBe('No data yet');
+  });
+});

--- a/src/components/proxmox/__tests__/StorageSection.test.tsx
+++ b/src/components/proxmox/__tests__/StorageSection.test.tsx
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'bun:test';
+import { render, screen } from '@testing-library/react';
+import { StorageSection } from '@/components/proxmox/StorageSection';
+import type { ProxmoxStorage } from '@/types/proxmox';
+
+function makeStorage(overrides: Partial<ProxmoxStorage> = {}): ProxmoxStorage {
+  return {
+    storage: 'local-zfs',
+    type: 'zfspool',
+    content: 'images',
+    active: 1,
+    enabled: 1,
+    shared: 0,
+    used: 100_000_000_000,
+    avail: 400_000_000_000,
+    total: 500_000_000_000,
+    used_fraction: 0.2,
+    ...overrides,
+  };
+}
+
+function mockNarrowResizeObserver(width: number) {
+  const originalResizeObserver = globalThis.ResizeObserver;
+  let resizeCallback: ResizeObserverCallback | null = null;
+
+  globalThis.ResizeObserver = class MockResizeObserver {
+    constructor(cb: ResizeObserverCallback) {
+      resizeCallback = cb;
+    }
+    observe() {
+      if (resizeCallback) {
+        resizeCallback(
+          [{ contentRect: { width } } as unknown as ResizeObserverEntry],
+          this as unknown as ResizeObserver,
+        );
+      }
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+
+  return () => {
+    globalThis.ResizeObserver = originalResizeObserver;
+  };
+}
+
+describe('StorageSection', () => {
+  it('renders the storage count and a storage name when expanded', () => {
+    render(
+      <StorageSection
+        storages={[makeStorage()]}
+        expanded
+        onToggle={() => {}}
+        showSparklines={false}
+        useAbbreviatedUnits={false}
+      />,
+    );
+
+    expect(screen.getByText('Storage (1)')).not.toBeNull();
+    expect(screen.getByText('local-zfs')).not.toBeNull();
+  });
+
+  it('gives the status column a tighter mobile track than the metric columns', () => {
+    const restore = mockNarrowResizeObserver(800);
+    try {
+      render(
+        <StorageSection
+          storages={[makeStorage()]}
+          expanded
+          onToggle={() => {}}
+          showSparklines={false}
+          useAbbreviatedUnits={false}
+        />,
+      );
+
+      const header = document.querySelector('[data-slot="datatable-header"]') as HTMLElement;
+      expect(header.style.gridTemplateColumns).toContain('0.7fr');
+    } finally {
+      restore();
+    }
+  });
+});

--- a/src/components/stacks/StackEditorForm.tsx
+++ b/src/components/stacks/StackEditorForm.tsx
@@ -29,7 +29,7 @@ import DeleteStackDialog from '@/components/stacks/DeleteStackDialog'
 import StackSettingsDialog from '@/components/stacks/StackSettingsDialog'
 import StackDriftWarning from '@/components/stacks/StackDriftWarning'
 import UnsavedChangesDialog from '@/components/stacks/UnsavedChangesDialog'
-import { STACKS_QUERY_KEY, DEPLOY_HISTORY_QUERY_KEY, STACK_DRIFT_QUERY_KEY } from '@/lib/constants/stacks-keys'
+import { STACKS_QUERY_KEY, DEPLOY_HISTORY_QUERY_KEY, STACK_DRIFT_QUERY_KEY, MANAGED_HOST_NAMES_QUERY_KEY } from '@/lib/constants/stacks-keys'
 import type { StackDetail } from '@/types/stacks'
 import type { StackFormValues } from '@/components/stacks/stack-form'
 
@@ -132,7 +132,7 @@ export default function StackEditorForm({ stackName, detail }: Readonly<StackEdi
   })
 
   const { data: availableHosts = [] } = useQuery({
-    queryKey: ['managed-host-names'],
+    queryKey: MANAGED_HOST_NAMES_QUERY_KEY,
     queryFn: () => listManagedHostNames(),
     enabled: settingsDialogOpen,
   })

--- a/src/components/ui/__tests__/tap-tooltip.test.tsx
+++ b/src/components/ui/__tests__/tap-tooltip.test.tsx
@@ -1,0 +1,125 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import TapTooltip from '@/components/ui/tap-tooltip';
+
+const originalMatchMedia = window.matchMedia;
+
+function setTouch(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+function renderTapTooltip() {
+  render(
+    <TapTooltip content="Disk name: nvme0n1">
+      <button type="button">chip</button>
+    </TapTooltip>,
+  );
+  const trigger = screen.getByRole('button', { name: 'chip' }).parentElement as HTMLElement;
+  return { trigger };
+}
+
+describe('TapTooltip on a mouse pointer', () => {
+  it('shows on mouse enter and hides on mouse leave', () => {
+    setTouch(false);
+    const { trigger } = renderTapTooltip();
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    fireEvent.mouseEnter(trigger);
+    expect(screen.getByRole('tooltip').textContent).toBe('Disk name: nvme0n1');
+    fireEvent.mouseLeave(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('shows on focus and hides on blur', () => {
+    setTouch(false);
+    const { trigger } = renderTapTooltip();
+
+    fireEvent.focus(trigger);
+    expect(screen.getByRole('tooltip')).not.toBeNull();
+    fireEvent.blur(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('ignores a click, leaving hover as the only way to reveal it', () => {
+    setTouch(false);
+    const { trigger } = renderTapTooltip();
+
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+});
+
+describe('TapTooltip on a touch pointer', () => {
+  it('reveals the content on tap', () => {
+    setTouch(true);
+    const { trigger } = renderTapTooltip();
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip').textContent).toBe('Disk name: nvme0n1');
+  });
+
+  it('dismisses on a second tap of the same trigger', () => {
+    setTouch(true);
+    const { trigger } = renderTapTooltip();
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip')).not.toBeNull();
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('dismisses on a tap elsewhere', () => {
+    setTouch(true);
+    const { trigger } = renderTapTooltip();
+    const outside = document.createElement('div');
+    document.body.appendChild(outside);
+
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip')).not.toBeNull();
+    fireEvent.pointerDown(outside);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+
+    outside.remove();
+  });
+
+  it('ignores hover and focus, which a touch device can never satisfy', () => {
+    setTouch(true);
+    const { trigger } = renderTapTooltip();
+
+    fireEvent.mouseEnter(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    fireEvent.focus(trigger);
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('supports rich ReactNode content, not just strings', () => {
+    setTouch(true);
+    render(
+      <TapTooltip content={<span data-testid="rich">rich content</span>}>
+        <button type="button">chip</button>
+      </TapTooltip>,
+    );
+    const trigger = screen.getByRole('button', { name: 'chip' }).parentElement as HTMLElement;
+
+    fireEvent.click(trigger);
+    expect(screen.getByTestId('rich')).not.toBeNull();
+  });
+});

--- a/src/components/ui/datatable/DataTable.tsx
+++ b/src/components/ui/datatable/DataTable.tsx
@@ -27,11 +27,7 @@ export interface MetricGroup {
   icon?: ReactNode;
 }
 
-/**
- * Lets a nested DataTable follow its parent's metric-group selection. A detail-panel
- * subtable shares the parent's columns but owns no toolbar, so without this its
- * columns stay all-visible on mobile and stop lining up with the parent header.
- */
+/** Lets a nested DataTable follow its parent's selection: a subtable shares the parent's columns but owns no toolbar. */
 const MetricGroupContext = createContext<{ metricGroups: MetricGroup[]; activeIndex: number } | null>(null);
 
 type ExpansionControl =
@@ -473,9 +469,8 @@ function DataTableRow<TRow>({ row, gridTemplate, rowClassName, rowAttributes, ha
       {...extraAttributes}
     >
       {row.getVisibleCells().map((cell) => (
-        // min-w-0 + overflow-hidden: without them a grid item's automatic minimum
-        // size is its content's min-content width, so a long name widens the track
-        // instead of letting the `truncate` inside the cell take effect.
+        // min-w-0 is load-bearing: without it a long name widens the grid track instead
+        // of letting the `truncate` inside the cell take effect.
         <div key={cell.id} className={`min-w-0 overflow-hidden py-2 ${isMobile ? 'px-2' : 'px-3'}`}>
           {flexRender(cell.column.columnDef.cell, cell.getContext())}
         </div>

--- a/src/components/ui/datatable/__tests__/columns.test.tsx
+++ b/src/components/ui/datatable/__tests__/columns.test.tsx
@@ -189,6 +189,27 @@ describe('statusColumn', () => {
     expect(badge).toBeTruthy();
   });
 
+  it('has no meta when mobileFlex is not provided, matching the pre-existing default', () => {
+    const col = statusColumn<TestRow>({
+      id: 'status',
+      getValue: (r) => r.status,
+      getColor: () => 'default',
+    });
+
+    expect(col.meta).toBeUndefined();
+  });
+
+  it('exposes mobileFlex in meta for a tighter mobile grid track', () => {
+    const col = statusColumn<TestRow>({
+      id: 'status',
+      getValue: (r) => r.status,
+      getColor: () => 'default',
+      mobileFlex: 'minmax(60px, 0.7fr)',
+    });
+
+    expect((col.meta as { mobileFlex: string }).mobileFlex).toBe('minmax(60px, 0.7fr)');
+  });
+
 });
 
 describe('progressColumn', () => {
@@ -299,5 +320,26 @@ describe('progressColumn', () => {
     const { container } = render(<CellRenderer column={col} row={sampleRow} />);
     const bar = container.querySelector('[data-slot="progress-indicator"]');
     expect(bar?.className).toContain('bg-destructive');
+  });
+
+  it('exposes mobileFlex in meta when provided', () => {
+    const col = progressColumn<TestRow>({
+      id: 'usage',
+      getValue: (r) => r.pct,
+      getLabel: (r) => `${r.pct}%`,
+      mobileFlex: 'minmax(80px, 1.2fr)',
+    });
+
+    expect((col.meta as { mobileFlex: string }).mobileFlex).toBe('minmax(80px, 1.2fr)');
+  });
+
+  it('has no meta when mobileFlex is not provided, matching the pre-existing default', () => {
+    const col = progressColumn<TestRow>({
+      id: 'usage',
+      getValue: (r) => r.pct,
+      getLabel: (r) => `${r.pct}%`,
+    });
+
+    expect(col.meta).toBeUndefined();
   });
 });

--- a/src/components/ui/datatable/columns.tsx
+++ b/src/components/ui/datatable/columns.tsx
@@ -119,6 +119,8 @@ export function statusColumn<TRow>(opts: {
   getValue: (row: TRow) => string;
   getColor: (row: TRow) => 'success' | 'default' | 'warning' | 'error';
   size?: number;
+  /** Grid track for the mobile proportional layout (default: equal weight with metric columns) */
+  mobileFlex?: string;
 }): ColumnDef<TRow, unknown> {
   return {
     id: opts.id,
@@ -129,6 +131,7 @@ export function statusColumn<TRow>(opts: {
       </Badge>
     ),
     size: opts.size,
+    meta: opts.mobileFlex ? { mobileFlex: opts.mobileFlex } : undefined,
   };
 }
 
@@ -142,6 +145,8 @@ export function progressColumn<TRow>(opts: {
   getValue: (row: TRow) => number;
   getLabel: (row: TRow) => string;
   size?: number;
+  /** Grid track for the mobile proportional layout (default: equal weight with metric columns) */
+  mobileFlex?: string;
 }): ColumnDef<TRow, unknown> {
   return {
     id: opts.id,
@@ -172,5 +177,6 @@ export function progressColumn<TRow>(opts: {
       );
     },
     size: opts.size,
+    meta: opts.mobileFlex ? { mobileFlex: opts.mobileFlex } : undefined,
   };
 }

--- a/src/components/ui/datatable/columns.tsx
+++ b/src/components/ui/datatable/columns.tsx
@@ -119,7 +119,6 @@ export function statusColumn<TRow>(opts: {
   getValue: (row: TRow) => string;
   getColor: (row: TRow) => 'success' | 'default' | 'warning' | 'error';
   size?: number;
-  /** Grid track for the mobile proportional layout (default: equal weight with metric columns) */
   mobileFlex?: string;
 }): ColumnDef<TRow, unknown> {
   return {
@@ -145,7 +144,6 @@ export function progressColumn<TRow>(opts: {
   getValue: (row: TRow) => number;
   getLabel: (row: TRow) => string;
   size?: number;
-  /** Grid track for the mobile proportional layout (default: equal weight with metric columns) */
   mobileFlex?: string;
 }): ColumnDef<TRow, unknown> {
   return {

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -34,12 +34,6 @@ const sheetVariants = cva(
 type SheetContentProps = ComponentProps<typeof DialogPrimitive.Popup> &
   VariantProps<typeof sheetVariants>;
 
-/**
- * Slide-in panel. `bottom` is the phone-friendly default for pickers and
- * actions; `left`/`right` suit navigation. Height uses `dvh` so the panel does
- * not sit under a mobile browser's retracting URL bar, and the safe-area pad
- * keeps the last row clear of the iOS home indicator.
- */
 function SheetContent({ className, children, side, ...props }: SheetContentProps) {
   return (
     <DialogPrimitive.Portal>

--- a/src/components/ui/tap-tooltip.tsx
+++ b/src/components/ui/tap-tooltip.tsx
@@ -1,0 +1,90 @@
+import { useState, useRef, useCallback, useEffect, type ReactNode } from 'react';
+import { createPortal } from 'react-dom';
+import { useIsTouch } from '@/hooks/useMediaQuery';
+
+interface TapTooltipProps {
+  content: ReactNode;
+  children: ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
+
+const DEFAULT_CONTENT_CLASSES =
+  'rounded-lg px-2 py-1 text-[0.6875rem] font-medium text-tooltip-foreground bg-tooltip/92 max-w-75 break-words';
+
+/**
+ * Tooltip that also reveals on tap. Base UI's Tooltip only opens for mouse/pen
+ * pointer types (`useHoverReferenceInteraction`'s `mouseOnly: true`), so content
+ * that lives only in a tooltip is unreachable on touch without this. Positions
+ * via getBoundingClientRect into a body portal, because a Popper-style tooltip
+ * is misplaced inside DataTable rows and Dialog headers by their nested scroll
+ * container and transform contexts.
+ */
+export default function TapTooltip({ content, children, className, contentClassName }: Readonly<TapTooltipProps>) {
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const ref = useRef<HTMLSpanElement>(null);
+  const isTouch = useIsTouch();
+
+  const show = useCallback(() => {
+    if (!ref.current) return;
+    const r = ref.current.getBoundingClientRect();
+    setPos({ x: r.left + r.width / 2, y: r.top });
+  }, []);
+
+  const hide = useCallback(() => setPos(null), []);
+
+  const toggle = useCallback(() => {
+    if (!isTouch) return;
+    setPos((current) => {
+      if (current !== null) return null;
+      if (!ref.current) return current;
+      const r = ref.current.getBoundingClientRect();
+      return { x: r.left + r.width / 2, y: r.top };
+    });
+  }, [isTouch]);
+
+  useEffect(() => {
+    if (!isTouch || pos === null) return;
+    // pointerdown fires before the tap's own click that reopens/toggles here, so an
+    // outside tap can dismiss without racing this element's own toggle.
+    function dismissIfOutside(e: PointerEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) hide();
+    }
+    document.addEventListener('pointerdown', dismissIfOutside);
+    return () => document.removeEventListener('pointerdown', dismissIfOutside);
+  }, [isTouch, pos, hide]);
+
+  return (
+    <>
+      <span
+        ref={ref}
+        onMouseEnter={() => {
+          if (!isTouch) show();
+        }}
+        onMouseLeave={() => {
+          if (!isTouch) hide();
+        }}
+        onFocus={() => {
+          if (!isTouch) show();
+        }}
+        onBlur={() => {
+          if (!isTouch) hide();
+        }}
+        onClick={toggle}
+        className={className ?? 'inline-flex'}
+      >
+        {children}
+      </span>
+      {pos !== null && createPortal(
+        <div
+          className={`fixed z-[9999] pointer-events-none -translate-x-1/2 -translate-y-[calc(100%+6px)] ${contentClassName ?? DEFAULT_CONTENT_CLASSES}`}
+          style={{ left: pos.x, top: pos.y }}
+          role="tooltip"
+        >
+          {content}
+        </div>,
+        document.body,
+      )}
+    </>
+  );
+}

--- a/src/components/ui/tap-tooltip.tsx
+++ b/src/components/ui/tap-tooltip.tsx
@@ -13,12 +13,10 @@ const DEFAULT_CONTENT_CLASSES =
   'rounded-lg px-2 py-1 text-[0.6875rem] font-medium text-tooltip-foreground bg-tooltip/92 max-w-75 break-words';
 
 /**
- * Tooltip that also reveals on tap. Base UI's Tooltip only opens for mouse/pen
- * pointer types (`useHoverReferenceInteraction`'s `mouseOnly: true`), so content
- * that lives only in a tooltip is unreachable on touch without this. Positions
- * via getBoundingClientRect into a body portal, because a Popper-style tooltip
- * is misplaced inside DataTable rows and Dialog headers by their nested scroll
- * container and transform contexts.
+ * Base UI's Tooltip only opens for mouse/pen pointer types, so tooltip-only content is
+ * unreachable on touch. Positions itself into a body portal instead of using a Popper,
+ * which lands wrong inside the nested scroll and transform contexts of DataTable rows
+ * and Dialog headers.
  */
 export default function TapTooltip({ content, children, className, contentClassName }: Readonly<TapTooltipProps>) {
   const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
@@ -45,8 +43,8 @@ export default function TapTooltip({ content, children, className, contentClassN
 
   useEffect(() => {
     if (!isTouch || pos === null) return;
-    // pointerdown fires before the tap's own click that reopens/toggles here, so an
-    // outside tap can dismiss without racing this element's own toggle.
+    // pointerdown, not click: it fires before the tap's own click, so dismissing does
+    // not race this element's toggle.
     function dismissIfOutside(e: PointerEvent) {
       if (ref.current && !ref.current.contains(e.target as Node)) hide();
     }

--- a/src/components/zfs/ZFSEntityCell.tsx
+++ b/src/components/zfs/ZFSEntityCell.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { Badge } from '@/components/ui/badge';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import TapTooltip from '@/components/ui/tap-tooltip';
 import { ChevronRight, Server } from 'lucide-react';
 
 interface ZFSEntityCellProps {
@@ -27,7 +27,12 @@ const ZFSEntityCell = memo(function ZFSEntityCell({
   const isBold = entityType === 'host' || entityType === 'pool';
 
   const chipEl = badge ? (
-    <Badge variant="secondary">{badge.label}</Badge>
+    <Badge
+      variant="secondary"
+      aria-label={badge.tooltip ? `${badge.label}: ${badge.tooltip}` : undefined}
+    >
+      {badge.label}
+    </Badge>
   ) : null;
 
   return (
@@ -44,10 +49,9 @@ const ZFSEntityCell = memo(function ZFSEntityCell({
       {entityType === 'host' && <Server size={18} />}
       <span className={`truncate ${isBold ? 'font-bold' : 'text-sm'}`}>{name}</span>
       {badge?.tooltip ? (
-        <Tooltip>
-          <TooltipTrigger render={chipEl!} />
-          <TooltipContent side="bottom">{badge.tooltip}</TooltipContent>
-        </Tooltip>
+        <TapTooltip content={badge.tooltip} className="inline-flex tap-target">
+          {chipEl}
+        </TapTooltip>
       ) : (
         chipEl
       )}

--- a/src/components/zfs/ZFSEntityCell.tsx
+++ b/src/components/zfs/ZFSEntityCell.tsx
@@ -26,12 +26,12 @@ const ZFSEntityCell = memo(function ZFSEntityCell({
 }: Readonly<ZFSEntityCellProps>) {
   const isBold = entityType === 'host' || entityType === 'pool';
 
+  // Badge renders a bare span, where browsers drop aria-label: naming a generic
+  // role is prohibited. The tooltip text has to reach assistive tech as content.
   const chipEl = badge ? (
-    <Badge
-      variant="secondary"
-      aria-label={badge.tooltip ? `${badge.label}: ${badge.tooltip}` : undefined}
-    >
+    <Badge variant="secondary">
       {badge.label}
+      {badge.tooltip && <span className="sr-only">: {badge.tooltip}</span>}
     </Badge>
   ) : null;
 

--- a/src/components/zfs/ZFSPoolSpeedChart.tsx
+++ b/src/components/zfs/ZFSPoolSpeedChart.tsx
@@ -4,6 +4,7 @@ import type { EChartsOption } from 'echarts';
 import { formatBytes } from '@/formatters/metrics';
 import { useGeneralSettings } from '@/hooks/useSettings';
 import { useEChartTimeScroll } from '@/hooks/useEChartTimeScroll';
+import { useIsMobile } from '@/hooks/useMediaQuery';
 import { resolveChartColors, resolveChartChromeColors } from '@/lib/charts/css-vars';
 import { calculateCleanYAxis } from '@/lib/charts/y-axis';
 
@@ -20,7 +21,7 @@ interface ZFSPoolSpeedChartProps {
 
 const WINDOW_MS = 60_000;
 
-function getChartOption(dataPoints: TimeSeriesDataPoint[], use12HourTime: boolean): EChartsOption {
+function getChartOption(dataPoints: TimeSeriesDataPoint[], use12HourTime: boolean, isMobile: boolean): EChartsOption {
   const now = Date.now();
   const readPairs = dataPoints.map((d) => [d.timestamp, d.readBytesPerSec] as [number, number]);
   const writePairs = dataPoints.map((d) => [d.timestamp, d.writeBytesPerSec] as [number, number]);
@@ -45,12 +46,9 @@ function getChartOption(dataPoints: TimeSeriesDataPoint[], use12HourTime: boolea
 
   return {
     animation: false,
-    grid: {
-      top: 10,
-      right: 15,
-      bottom: 45,
-      left: 55,
-    },
+    grid: isMobile
+      ? { top: 8, right: 8, bottom: 38, left: 40 }
+      : { top: 10, right: 15, bottom: 45, left: 55 },
     tooltip: {
       trigger: 'axis',
       backgroundColor: chrome.tooltipBg,
@@ -172,7 +170,8 @@ export default function ZFSPoolSpeedChart({
   dataPoints,
 }: ZFSPoolSpeedChartProps) {
   const { general } = useGeneralSettings();
-  const option = getChartOption(dataPoints, general.use12HourTime);
+  const isMobile = useIsMobile();
+  const option = getChartOption(dataPoints, general.use12HourTime, isMobile);
   const chartRef = useRef<ReactECharts>(null);
   const wrapperRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/zfs/ZFSPoolsTable.tsx
+++ b/src/components/zfs/ZFSPoolsTable.tsx
@@ -38,7 +38,8 @@ export interface ZFSTableRow {
   children?: ZFSTableRow[];
 }
 
-/** Leaves room for the stacked speed charts below without the table collapsing. */
+/** Caps the table so the stacked speed charts below get room; a flex share instead
+ *  still paints rows at full size and overlaps them. */
 const MOBILE_TABLE_MAX_HEIGHT = 480;
 
 const METRIC_GROUPS: MetricGroup[] = [
@@ -275,8 +276,6 @@ export default function ZFSPoolsTable({
         metricGroups={METRIC_GROUPS}
         rowClassName={rowClassName}
         enableSorting={false}
-        // Mobile stacks the speed charts one per row, and a squeezed flex share
-        // here still paints its rows at full size, overlapping them.
         maxHeight={isMobile ? MOBILE_TABLE_MAX_HEIGHT : undefined}
       />
     </div>

--- a/src/components/zfs/ZFSPoolsTable.tsx
+++ b/src/components/zfs/ZFSPoolsTable.tsx
@@ -8,6 +8,7 @@ import type { ZFSStatsRow, ZFSHostHierarchy } from '@/types/zfs';
 import { buildZFSHostHierarchy } from '@/lib/utils/zfs-hierarchy-builder';
 import { formatBytesParts, formatAsPercentParts } from '@/formatters/metrics';
 import { useGeneralSettings, useZfsSettings } from '@/hooks/useSettings';
+import { useIsMobile } from '@/hooks/useMediaQuery';
 import ZFSEntityCell from '@/components/zfs/ZFSEntityCell';
 import PoolSubTable from '@/components/zfs/subtables/PoolSubTable';
 import { buildHostRow } from '@/components/zfs/utils/zfs-row-builders';
@@ -36,6 +37,9 @@ export interface ZFSTableRow {
   /** Tree children */
   children?: ZFSTableRow[];
 }
+
+/** Leaves room for the stacked speed charts below without the table collapsing. */
+const MOBILE_TABLE_MAX_HEIGHT = 480;
 
 const METRIC_GROUPS: MetricGroup[] = [
   { label: 'Capacity', columnIds: ['capacity'] },
@@ -83,6 +87,7 @@ export default function ZFSPoolsTable({
     zfs,
   } = useZfsSettings();
   const { general } = useGeneralSettings();
+  const isMobile = useIsMobile();
 
   const hostHierarchy = useMemo<ZFSHostHierarchy>(() => {
     const rows = Array.from(latestByEntity.values());
@@ -258,7 +263,7 @@ export default function ZFSPoolsTable({
   }
 
   return (
-    <div className="flex flex-col flex-1 min-h-0 w-full">
+    <div className={isMobile ? 'w-full' : 'flex flex-col flex-1 min-h-0 w-full'}>
       <StaleDataAlert isStale={isStale} />
       <DataTable
         data={tableData}
@@ -270,6 +275,9 @@ export default function ZFSPoolsTable({
         metricGroups={METRIC_GROUPS}
         rowClassName={rowClassName}
         enableSorting={false}
+        // Mobile stacks the speed charts one per row, and a squeezed flex share
+        // here still paints its rows at full size, overlapping them.
+        maxHeight={isMobile ? MOBILE_TABLE_MAX_HEIGHT : undefined}
       />
     </div>
   );

--- a/src/components/zfs/__tests__/ZFSEntityCell.test.tsx
+++ b/src/components/zfs/__tests__/ZFSEntityCell.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import ZFSEntityCell from '@/components/zfs/ZFSEntityCell';
+
+const originalMatchMedia = window.matchMedia;
+
+function setTouch(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+afterEach(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+});
+
+describe('ZFSEntityCell', () => {
+  it('renders the name and no badge when none is provided', () => {
+    render(<ZFSEntityCell name="rust" entityType="pool" indent={0} />);
+    expect(screen.getByText('rust')).not.toBeNull();
+    expect(screen.queryByText(/single disk/)).toBeNull();
+  });
+
+  it('renders a badge without a tooltip trigger when the badge has no tooltip', () => {
+    render(
+      <ZFSEntityCell
+        name="rust"
+        entityType="pool"
+        indent={0}
+        badge={{ label: 'raidz2-0' }}
+      />,
+    );
+    expect(screen.getByText('raidz2-0')).not.toBeNull();
+    expect(screen.queryByRole('tooltip')).toBeNull();
+  });
+
+  it('exposes the tooltip text to screen readers via aria-label regardless of hover state', () => {
+    setTouch(false);
+    render(
+      <ZFSEntityCell
+        name="system"
+        entityType="pool"
+        indent={0}
+        badge={{ label: 'single disk', tooltip: 'sda' }}
+      />,
+    );
+    expect(screen.getByLabelText('single disk: sda')).not.toBeNull();
+  });
+
+  it('reveals the disk name on tap when the primary input is touch', () => {
+    setTouch(true);
+    render(
+      <ZFSEntityCell
+        name="system"
+        entityType="pool"
+        indent={0}
+        badge={{ label: 'single disk', tooltip: 'sda' }}
+      />,
+    );
+
+    expect(screen.queryByRole('tooltip')).toBeNull();
+    fireEvent.click(screen.getByText('single disk'));
+    expect(screen.getByRole('tooltip').textContent).toBe('sda');
+  });
+
+  it('reveals the disk name on hover when the primary input is a mouse', () => {
+    setTouch(false);
+    render(
+      <ZFSEntityCell
+        name="system"
+        entityType="pool"
+        indent={0}
+        badge={{ label: 'single disk', tooltip: 'sda' }}
+      />,
+    );
+
+    const trigger = screen.getByText('single disk').parentElement as HTMLElement;
+    fireEvent.mouseEnter(trigger);
+    expect(screen.getByRole('tooltip').textContent).toBe('sda');
+  });
+
+  it('renders an expand chevron and the host server icon', () => {
+    render(
+      <ZFSEntityCell name="nas01" entityType="host" indent={0} canExpand isExpanded />,
+    );
+    expect(screen.getByText('nas01')).not.toBeNull();
+  });
+});

--- a/src/components/zfs/__tests__/ZFSEntityCell.test.tsx
+++ b/src/components/zfs/__tests__/ZFSEntityCell.test.tsx
@@ -45,7 +45,7 @@ describe('ZFSEntityCell', () => {
     expect(screen.queryByRole('tooltip')).toBeNull();
   });
 
-  it('exposes the tooltip text to screen readers via aria-label regardless of hover state', () => {
+  it('exposes the tooltip text to screen readers regardless of hover state', () => {
     setTouch(false);
     render(
       <ZFSEntityCell
@@ -55,7 +55,7 @@ describe('ZFSEntityCell', () => {
         badge={{ label: 'single disk', tooltip: 'sda' }}
       />,
     );
-    expect(screen.getByLabelText('single disk: sda')).not.toBeNull();
+    expect(screen.getByText('single disk').textContent).toContain('sda');
   });
 
   it('reveals the disk name on tap when the primary input is touch', () => {

--- a/src/components/zfs/__tests__/ZFSPoolSpeedChart.test.tsx
+++ b/src/components/zfs/__tests__/ZFSPoolSpeedChart.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, mock, beforeEach, afterEach } from 'bun:test';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { EChartsOption } from 'echarts';
+
+const capturedOptions: EChartsOption[] = [];
+
+mock.module('echarts-for-react', () => ({
+  __esModule: true,
+  default: (props: { option: EChartsOption }) => {
+    capturedOptions.push(props.option);
+    return <div data-testid="react-echarts" />;
+  },
+}));
+
+mock.module('@/hooks/useSettings', () => ({
+  useGeneralSettings: () => ({
+    general: { use12HourTime: false },
+    retention: {},
+    developer: {},
+  }),
+}));
+
+const isMobile = { value: false };
+
+mock.module('@/hooks/useMediaQuery', () => ({
+  useIsMobile: () => isMobile.value,
+}));
+
+const { default: ZFSPoolSpeedChart } = await import('@/components/zfs/ZFSPoolSpeedChart');
+
+const dataPoints = [
+  { timestamp: Date.now() - 30_000, readBytesPerSec: 1_000_000, writeBytesPerSec: 500_000 },
+  { timestamp: Date.now(), readBytesPerSec: 2_000_000, writeBytesPerSec: 750_000 },
+];
+
+function lastOption(): Record<string, unknown> {
+  return capturedOptions[capturedOptions.length - 1] as Record<string, unknown>;
+}
+
+describe('ZFSPoolSpeedChart', () => {
+  beforeEach(() => {
+    capturedOptions.length = 0;
+    isMobile.value = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders the pool name and an echarts canvas', () => {
+    render(<ZFSPoolSpeedChart poolName="rust" dataPoints={dataPoints} />);
+    expect(screen.getByText('rust')).not.toBeNull();
+    expect(screen.getByTestId('react-echarts')).not.toBeNull();
+  });
+
+  it('uses the desktop grid margins when the container is not mobile-width', () => {
+    isMobile.value = false;
+    render(<ZFSPoolSpeedChart poolName="rust" dataPoints={dataPoints} />);
+    const grid = lastOption().grid as { top: number; right: number; bottom: number; left: number };
+    expect(grid).toEqual({ top: 10, right: 15, bottom: 45, left: 55 });
+  });
+
+  it('tightens the grid margins on mobile so more of a 375px viewport is plot area', () => {
+    isMobile.value = true;
+    render(<ZFSPoolSpeedChart poolName="rust" dataPoints={dataPoints} />);
+    const grid = lastOption().grid as { top: number; right: number; bottom: number; left: number };
+    expect(grid.left).toBeLessThan(55);
+    expect(grid.right).toBeLessThan(15);
+    expect(grid.bottom).toBeLessThan(45);
+  });
+});

--- a/src/components/zfs/__tests__/ZFSPoolsTable.test.tsx
+++ b/src/components/zfs/__tests__/ZFSPoolsTable.test.tsx
@@ -1,0 +1,209 @@
+import { describe, it, expect, mock, afterEach } from 'bun:test';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { createStore, Provider } from 'jotai';
+import ZFSPoolsTable from '@/components/zfs/ZFSPoolsTable';
+import type { ZFSStatsRow } from '@/types/zfs';
+
+// Expanding a vdev persists the change via updateSetting, a createServerFn that
+// requires the TanStack Start server runtime. Stub it so the expand click under
+// test doesn't hit that unrelated failure path.
+mock.module('@/data/settings/functions', () => ({
+  updateSetting: mock(() => Promise.resolve()),
+}));
+
+/**
+ * Regression coverage for the ZFS subtable nesting: PoolSubTable, VdevDiskSubTable,
+ * and DiskSubTable (src/components/zfs/subtables/) each render a further-nested
+ * DataTable without declaring their own `metricGroups`, relying entirely on the
+ * MetricGroupContext the top-level ZFSPoolsTable DataTable provides. This locks in
+ * that the inherited mobile column filter reaches all the way down to the disk
+ * level, three DataTable layers below the one that owns the metric groups.
+ */
+function makeRow(overrides: Partial<ZFSStatsRow>): ZFSStatsRow {
+  return {
+    time: Date.now(),
+    host: 'nas01',
+    pool: 'tank',
+    entity: 'tank',
+    entity_type: 'pool',
+    indent: 0,
+    capacity_alloc: 1000,
+    capacity_free: 2000,
+    read_ops_per_sec: 10,
+    write_ops_per_sec: 5,
+    read_bytes_per_sec: 1024,
+    write_bytes_per_sec: 512,
+    utilization_percent: 25,
+    ...overrides,
+  };
+}
+
+const rows: ZFSStatsRow[] = [
+  makeRow({ entity: 'tank', entity_type: 'pool', indent: 0 }),
+  makeRow({ entity: 'tank/mirror-0', entity_type: 'vdev', indent: 2 }),
+  makeRow({ entity: 'tank/mirror-0/sda', entity_type: 'disk', indent: 4 }),
+  makeRow({ entity: 'tank/mirror-0/sdb', entity_type: 'disk', indent: 4 }),
+  makeRow({ entity: 'tank/mirror-1', entity_type: 'vdev', indent: 2 }),
+  makeRow({ entity: 'tank/mirror-1/sdc', entity_type: 'disk', indent: 4 }),
+];
+
+function latestByEntity(): Map<string, ZFSStatsRow> {
+  const map = new Map<string, ZFSStatsRow>();
+  for (const row of rows) map.set(row.entity, row);
+  return map;
+}
+
+const originalMatchMedia = window.matchMedia;
+
+function setMobileViewport(matches: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: (query: string) => ({
+      matches,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }),
+  });
+}
+
+function restoreMatchMedia() {
+  Object.defineProperty(window, 'matchMedia', {
+    configurable: true,
+    writable: true,
+    value: originalMatchMedia,
+  });
+}
+
+function mockNarrowResizeObserver() {
+  const original = globalThis.ResizeObserver;
+  let cb: ResizeObserverCallback | null = null;
+  globalThis.ResizeObserver = class MockResizeObserver {
+    constructor(callback: ResizeObserverCallback) {
+      cb = callback;
+    }
+    observe() {
+      cb?.(
+        [{ contentRect: { width: 375 } } as unknown as ResizeObserverEntry],
+        this as unknown as ResizeObserver,
+      );
+    }
+    unobserve() {}
+    disconnect() {}
+  } as unknown as typeof ResizeObserver;
+  return () => {
+    globalThis.ResizeObserver = original;
+  };
+}
+
+describe('ZFSPoolsTable nested metric group inheritance on mobile', () => {
+  it('limits a disk row three DataTable levels deep to the active metric group', () => {
+    const restore = mockNarrowResizeObserver();
+    try {
+      render(
+        <Provider store={createStore()}>
+          <ZFSPoolsTable
+            latestByEntity={latestByEntity()}
+            hasData
+            isConnected
+            error={null}
+            isStale={false}
+          />
+        </Provider>,
+      );
+
+      // Host ("nas01") and its single pool ("tank") auto-expand (isZfsHostExpanded /
+      // isPoolExpanded both default to expanded when there is only one of them).
+      expect(screen.getByText('nas01')).not.toBeNull();
+      expect(screen.getByText('tank')).not.toBeNull();
+      expect(screen.getByText('mirror-0')).not.toBeNull();
+
+      // Vdevs default to collapsed; expand mirror-0 to mount its DiskSubTable.
+      fireEvent.click(screen.getByText('mirror-0').closest('[role="button"]')!);
+      expect(screen.getByText('sda')).not.toBeNull();
+
+      // Capacity is the default active metric group -> only "name" + "capacity"
+      // should be visible columns on a disk row, out of the 7 the full column set defines.
+      const diskRow = screen.getByText('sda').closest('.group') as HTMLElement;
+      expect(diskRow.children.length).toBe(2);
+    } finally {
+      restore();
+    }
+  });
+
+  it('follows the parent toggle when the active metric group changes, all the way to the disk level', () => {
+    const restore = mockNarrowResizeObserver();
+    try {
+      render(
+        <Provider store={createStore()}>
+          <ZFSPoolsTable
+            latestByEntity={latestByEntity()}
+            hasData
+            isConnected
+            error={null}
+            isStale={false}
+          />
+        </Provider>,
+      );
+
+      fireEvent.click(screen.getByText('mirror-0').closest('[role="button"]')!);
+      expect(screen.getByText('sda')).not.toBeNull();
+
+      // Switch the parent's active group to "Throughput" (3 columns: readBytes,
+      // writeBytes, utilization) via its toolbar toggle.
+      fireEvent.click(screen.getByRole('button', { name: 'Throughput' }));
+
+      const diskRow = screen.getByText('sda').closest('.group') as HTMLElement;
+      // name + 3 throughput columns
+      expect(diskRow.children.length).toBe(4);
+    } finally {
+      restore();
+    }
+  });
+});
+
+describe('ZFSPoolsTable mobile layout (viewport-width based, not container-width)', () => {
+  afterEach(() => {
+    restoreMatchMedia();
+  });
+
+  it('caps the table height on mobile instead of letting it compete with the speed charts below for flex space', () => {
+    setMobileViewport(true);
+    render(
+      <Provider store={createStore()}>
+        <ZFSPoolsTable
+          latestByEntity={latestByEntity()}
+          hasData
+          isConnected
+          error={null}
+          isStale={false}
+        />
+      </Provider>,
+    );
+
+    const scrollContainer = document.querySelector('[data-slot="datatable-header"]')!
+      .parentElement as HTMLElement;
+    expect(scrollContainer.style.maxHeight).toBe('480px');
+  });
+
+  it('leaves the table filling the viewport on non-mobile widths (unbounded height, flex-1 wrapper)', () => {
+    setMobileViewport(false);
+    const { container } = render(
+      <Provider store={createStore()}>
+        <ZFSPoolsTable
+          latestByEntity={latestByEntity()}
+          hasData
+          isConnected
+          error={null}
+          isStale={false}
+        />
+      </Provider>,
+    );
+
+    const scrollContainer = document.querySelector('[data-slot="datatable-header"]')!
+      .parentElement as HTMLElement;
+    expect(scrollContainer.style.maxHeight).toBe('');
+    expect((container.firstChild as HTMLElement).className).toContain('flex-1');
+  });
+});

--- a/src/components/zfs/__tests__/ZFSPoolsTable.test.tsx
+++ b/src/components/zfs/__tests__/ZFSPoolsTable.test.tsx
@@ -4,21 +4,12 @@ import { createStore, Provider } from 'jotai';
 import ZFSPoolsTable from '@/components/zfs/ZFSPoolsTable';
 import type { ZFSStatsRow } from '@/types/zfs';
 
-// Expanding a vdev persists the change via updateSetting, a createServerFn that
-// requires the TanStack Start server runtime. Stub it so the expand click under
-// test doesn't hit that unrelated failure path.
+// Expanding a vdev persists through updateSetting, a createServerFn that needs the
+// TanStack Start server runtime.
 mock.module('@/data/settings/functions', () => ({
   updateSetting: mock(() => Promise.resolve()),
 }));
 
-/**
- * Regression coverage for the ZFS subtable nesting: PoolSubTable, VdevDiskSubTable,
- * and DiskSubTable (src/components/zfs/subtables/) each render a further-nested
- * DataTable without declaring their own `metricGroups`, relying entirely on the
- * MetricGroupContext the top-level ZFSPoolsTable DataTable provides. This locks in
- * that the inherited mobile column filter reaches all the way down to the disk
- * level, three DataTable layers below the one that owns the metric groups.
- */
 function makeRow(overrides: Partial<ZFSStatsRow>): ZFSStatsRow {
   return {
     time: Date.now(),
@@ -113,18 +104,15 @@ describe('ZFSPoolsTable nested metric group inheritance on mobile', () => {
         </Provider>,
       );
 
-      // Host ("nas01") and its single pool ("tank") auto-expand (isZfsHostExpanded /
-      // isPoolExpanded both default to expanded when there is only one of them).
+      // A lone host and a lone pool default to expanded; vdevs do not.
       expect(screen.getByText('nas01')).not.toBeNull();
       expect(screen.getByText('tank')).not.toBeNull();
       expect(screen.getByText('mirror-0')).not.toBeNull();
 
-      // Vdevs default to collapsed; expand mirror-0 to mount its DiskSubTable.
       fireEvent.click(screen.getByText('mirror-0').closest('[role="button"]')!);
       expect(screen.getByText('sda')).not.toBeNull();
 
-      // Capacity is the default active metric group -> only "name" + "capacity"
-      // should be visible columns on a disk row, out of the 7 the full column set defines.
+      // Capacity is the default group: name + capacity, out of the 7 defined columns.
       const diskRow = screen.getByText('sda').closest('.group') as HTMLElement;
       expect(diskRow.children.length).toBe(2);
     } finally {
@@ -150,8 +138,6 @@ describe('ZFSPoolsTable nested metric group inheritance on mobile', () => {
       fireEvent.click(screen.getByText('mirror-0').closest('[role="button"]')!);
       expect(screen.getByText('sda')).not.toBeNull();
 
-      // Switch the parent's active group to "Throughput" (3 columns: readBytes,
-      // writeBytes, utilization) via its toolbar toggle.
       fireEvent.click(screen.getByRole('button', { name: 'Throughput' }));
 
       const diskRow = screen.getByText('sda').closest('.group') as HTMLElement;

--- a/src/hooks/useMediaQuery.ts
+++ b/src/hooks/useMediaQuery.ts
@@ -4,11 +4,9 @@ import { MOBILE_BREAKPOINT, NAV_BREAKPOINT } from '@/lib/constants/breakpoints';
 const NOOP_UNSUBSCRIBE = () => {};
 
 /**
- * Subscribe to a CSS media query.
- *
- * Window-scoped, unlike DataTable's container-scoped ResizeObserver: use this
- * for chrome that reacts to the device (nav, dialogs, page layout) and the
- * ResizeObserver for anything that must also react to a narrow container.
+ * Window-scoped, unlike DataTable's container-scoped ResizeObserver: use this for
+ * chrome that reacts to the device, the ResizeObserver for anything that must also
+ * react to a narrow container.
  */
 export function useMediaQuery(query: string): boolean {
   const subscribe = useCallback(
@@ -33,20 +31,14 @@ export function useMediaQuery(query: string): boolean {
   return useSyncExternalStore(subscribe, getSnapshot, () => false);
 }
 
-/** True below the `lg` breakpoint: the viewport gets the single-column touch layout. */
 export function useIsMobile(): boolean {
   return useMediaQuery(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
 }
 
-/** True below the `md` breakpoint: the header tab bar is collapsed into the drawer. */
 export function useIsCompactNav(): boolean {
   return useMediaQuery(`(max-width: ${NAV_BREAKPOINT - 1}px)`);
 }
 
-/**
- * True when the primary input is touch. Drives tap-to-open on menus that
- * otherwise open on hover, which a touch device can never satisfy.
- */
 export function useIsTouch(): boolean {
   return useMediaQuery('(hover: none), (pointer: coarse)');
 }

--- a/src/lib/constants/breakpoints.ts
+++ b/src/lib/constants/breakpoints.ts
@@ -1,9 +1,4 @@
-/**
- * Viewport widths shared between CSS (Tailwind's default `sm`/`md`/`lg` screens)
- * and the JS that has to make the same decision. Keep these in sync with the
- * Tailwind prefix used alongside them: a hook reporting `lg` while the markup
- * switches at `md` produces a band where the two disagree.
- */
+/** Tailwind's default screen widths, duplicated for the JS that makes the same decision. */
 export const BREAKPOINTS = {
   sm: 640,
   md: 768,
@@ -13,10 +8,10 @@ export const BREAKPOINTS = {
 
 export type BreakpointName = keyof typeof BREAKPOINTS;
 
-/** Below this, layouts switch to their single-column touch variants (Tailwind `lg:`). */
+/** Pairs with the `lg:` Tailwind prefix in the markup it switches alongside. */
 export const MOBILE_BREAKPOINT = BREAKPOINTS.lg;
 
-/** Below this, the header collapses its tab bar into the drawer (Tailwind `md:`). */
+/** Pairs with the `md:` Tailwind prefix in the markup it switches alongside. */
 export const NAV_BREAKPOINT = BREAKPOINTS.md;
 
 /** Minimum comfortable touch target, per WCAG 2.2 target-size (minimum). */

--- a/src/lib/constants/stacks-keys.ts
+++ b/src/lib/constants/stacks-keys.ts
@@ -1,6 +1,9 @@
 /** Query key for the stacks list. Defined here to avoid circular imports between route and components. */
 export const STACKS_QUERY_KEY = ['stacks-list'] as const;
 
+/** Query key for the names of every managed host. */
+export const MANAGED_HOST_NAMES_QUERY_KEY = ['managed-host-names'] as const;
+
 /** Query key for live stack container status (SSE-backed). */
 export const STACK_STATUS_QUERY_KEY = ['stack-status'] as const;
 

--- a/src/lib/constants/stacks-keys.ts
+++ b/src/lib/constants/stacks-keys.ts
@@ -1,7 +1,6 @@
 /** Query key for the stacks list. Defined here to avoid circular imports between route and components. */
 export const STACKS_QUERY_KEY = ['stacks-list'] as const;
 
-/** Query key for the names of every managed host. */
 export const MANAGED_HOST_NAMES_QUERY_KEY = ['managed-host-names'] as const;
 
 /** Query key for live stack container status (SSE-backed). */

--- a/src/routes/stacks.tsx
+++ b/src/routes/stacks.tsx
@@ -4,15 +4,13 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { listStacks, listManagedHostNames } from '@/data/stacks/functions'
 import { useStackStatus } from '@/hooks/useStackStatus'
 import { StackListContext, StackStatusContext } from '@/components/stacks/stacks-context'
-import { STACKS_QUERY_KEY } from '@/lib/constants/stacks-keys'
+import { STACKS_QUERY_KEY, MANAGED_HOST_NAMES_QUERY_KEY } from '@/lib/constants/stacks-keys'
 import { Spinner } from '@/components/ui/spinner';
 
 export const Route = createFileRoute('/stacks')({
   ssr: false,
   component: StacksLayout,
 })
-
-const HOST_NAMES_QUERY_KEY = ['managed-host-names']
 
 function StacksLayout() {
   const queryClient = useQueryClient()
@@ -23,7 +21,7 @@ function StacksLayout() {
   })
 
   const { data: hosts, isLoading: hostsLoading, error: hostsError } = useQuery({
-    queryKey: HOST_NAMES_QUERY_KEY,
+    queryKey: MANAGED_HOST_NAMES_QUERY_KEY,
     queryFn: () => listManagedHostNames(),
   })
 

--- a/src/routes/zfs.tsx
+++ b/src/routes/zfs.tsx
@@ -7,6 +7,7 @@ import PageStatusBar from '@/components/PageStatusBar'
 import ZFSStatusSummary from '@/components/zfs/ZFSStatusSummary'
 import { useTimeSeriesStream } from '@/hooks/useTimeSeriesStream'
 import { useGeneralSettings } from '@/hooks/useSettings'
+import { useIsMobile } from '@/hooks/useMediaQuery'
 import { ZFS_PRELOAD_KEY, PRELOAD_STALE_TIME, preloadZFSStats } from '@/lib/constants/preload-queries'
 import { zfsStatsChannel } from '@/lib/sse/channels/zfs-stats'
 
@@ -17,6 +18,7 @@ export const Route = createFileRoute('/zfs')({
 
 function ZFSPageContent() {
   const { general } = useGeneralSettings()
+  const isMobile = useIsMobile()
 
   const preloadFn = useCallback(preloadZFSStats, [])
 
@@ -38,7 +40,7 @@ function ZFSPageContent() {
   })
 
   return (
-    <div className="flex flex-col flex-1 min-h-0">
+    <div className={`flex flex-col flex-1 min-h-0 ${isMobile ? 'overflow-y-auto' : ''}`}>
       <PageStatusBar left={<ZFSStatusSummary latestByEntity={stream.latestByEntity} />} />
       <ZFSPoolsTable
         latestByEntity={stream.latestByEntity}


### PR DESCRIPTION
Stacked on #400 (which is itself on #399). Base is `claude/mobile-routes-responsive-v1nd2r-docker`, not `main` -- these routes share the DataTable, so this needs #400's fluid grid underneath it.

## What and why

Both routes inherit the proportional mobile grid and the `min-w-0` cells from #400. This covers what that did not reach.

- **Status/usage column widths.** `statusColumn` and `progressColumn` were given no `size` at their call sites, so they fell back to TanStack's 150px default. Under the new proportional layout that meant a short badge sitting at equal weight with the metric columns. Both factories now accept a `mobileFlex`, and the Proxmox guest and storage tables give status a narrower track.
- **ZFS subtable inheritance turned out to already be fixed** by #400's `MetricGroupContext`: `PoolSubTable` / `VdevDiskSubTable` / `DiskSubTable` declare no `metricGroups` of their own, so they inherit rather than reset. Rather than assume that, there is now a regression test that expands all three real nesting levels (host -> pool -> vdev -> disk) and asserts a disk row exposes only the active group, and that switching at the top toolbar cascades down.
- **Three places kept text nowhere but a hover tooltip**, unreachable on touch: the ZFS single-disk badge (whose tooltip held the *only* copy of the disk name), the Proxmox update dot, and the interval toggle's explanation of what each interval costs in API load. Docker's `IconTooltip` already solved this shape, so rather than land a second copy of the same 60 lines it is now a thin wrapper over a shared `TapTooltip`; `IconTooltip`'s own tests pass unchanged against the shared implementation.
- The interval toggle needed a separate path, for two reasons worth flagging: wrapping `ToggleGroupItem` in a span breaks the `first:`/`last:`/`not-first:` rules that depend on direct DOM sibling order, and driving Base UI's `Tooltip.Root` via `open`/`onOpenChange` from a native click does **not** open the popup -- `Root` only renders content for a trigger it tracked through its own interaction hooks. The agent verified that with instrumented builds rather than inferring it.
- The Proxmox node row wraps instead of forcing a horizontal drag on a row that is simultaneously the tap target for expanding it, and `PageStatusBar` wraps between its two slots.
- ECharts grid margins tighten on mobile, where the plot area was down to ~240px.

## A bug outside the audit

On mobile the ZFS speed charts stack one per row, so their natural height can exceed the viewport. `ZFSPoolsTable`'s wrapper has `flex-1 min-h-0` and the charts section does not, so flexbox squeezed the table's *allocated* box toward zero while nothing clipped its *painted* rows -- they overlapped the chart canvas below and left the last pool row's badge physically untappable. Confirmed with `elementFromPoint`, so it is not a test-environment artifact. Fixed by capping the table's height on mobile through DataTable's existing `maxHeight` prop rather than fighting the flex chain, and letting the route scroll on mobile only. Desktop is untouched.

## Flow

```
statusColumn/progressColumn -> meta.mobileFlex -> buildGridTemplate (from #400)
TapTooltip -> tap opens + pointerdown dismisses   (IconTooltip now wraps it)
ZFSPoolsTable -> maxHeight on mobile -> route scrolls instead of rows overlapping
```

## What else this touches

- `columns.tsx`: `mobileFlex` is additive and optional; no existing caller changes behavior.
- `IconTooltip` (Docker, from #400) is reimplemented as a wrapper. Its rendered classes are preserved via `contentClassName`, so the Docker modal's tooltips look identical. Its 7 tests and ContainerModal's 14 pass unchanged.
- `PageStatusBar` is shared by the Docker, ZFS, and Proxmox routes; adding `flex-wrap` cannot narrow anything.
- No route loader, SSE channel, settings key, migration, or env var.

## Verification

- `bun run typecheck` -- clean.
- `bunx playwright test` -- 34 passed, 1 failed on the first run: `docker.e2e.ts > streams live stats that change over time`, a pre-existing polling assertion that waits for streamed text to change. Re-ran it with `--repeat-each=3`: 3/3 green. It is flaky, not a regression from this branch.
- Per-file unit tests green standalone: tap-tooltip 8, IconTooltip 7, ContainerModal 14, ZFSPoolsTable 4, ZFSEntityCell 6, ZFSPoolSpeedChart, ProxmoxIntervalToggle 6, ProxmoxHostView 4, ProxmoxUpdateIndicator, GuestSection, StorageSection, columns 24, PageStatusBar 9.
- The full `bun test --isolate` run is not a usable signal in this container (~530 failures on unmodified `main` too; Bun 1.3.11 vs the pinned 1.3.14 leaks module mocks across files). CI on the pinned Bun is the authority for the coverage gate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y2DmUg6NUpd51qSsKyiG5R)_